### PR TITLE
remove fixDefaultSlot from story.vue files, not needed anymore

### DIFF
--- a/components/radio/radio_default.story.vue
+++ b/components/radio/radio_default.story.vue
@@ -29,11 +29,9 @@
 
 <script>
 import DtRadio from './radio';
-import fixDefaultSlot from '../plugins/fixDefaultSlot';
 
 export default {
   name: 'RadioDefault',
   components: { DtRadio },
-  mixins: [fixDefaultSlot],
 };
 </script>

--- a/components/radio/radio_variants.story.vue
+++ b/components/radio/radio_variants.story.vue
@@ -187,13 +187,11 @@
 
 <script>
 import DtRadio from './radio';
-import fixDefaultSlot from '../plugins/fixDefaultSlot';
 import { VALIDATION_MESSAGE_TYPES } from '../constants';
 
 export default {
   name: 'RadioVariants',
   components: { DtRadio },
-  mixins: [fixDefaultSlot],
   created () {
     this.VALIDATION_MESSAGE_TYPES = VALIDATION_MESSAGE_TYPES;
   },


### PR DESCRIPTION
Just removing fixDefaultSlot where it was still existing as it was added as a default mixin
