### PR TITLE
fix peerDependencies version for dialtone beta 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "yo": "^3.1.1"
   },
   "peerDependencies": {
-    "@dialpad/dialtone": "6.0.0-beta.6",
+    "@dialpad/dialtone": "6.0.0-beta.8",
     "vue": "^2.6.11"
   },
   "gitHooks": {


### PR DESCRIPTION
Make the same `devDependency` `peerDependency` for `dialtone-beta.8`