### PR TITLE
add default slot handling to notice stories

### DIFF
--- a/components/banner/banner_default.story.vue
+++ b/components/banner/banner_default.story.vue
@@ -16,7 +16,11 @@
       :close-button-props="buttonCloseProps"
       @close="displayBanner = false; onClose($event)"
     >
-      <span>
+      <span
+        v-if="defaultSlot"
+        v-html="defaultSlot"
+      />
+      <span v-else>
         Message body with
         <a
           href="#"

--- a/components/notice/notice_default.story.vue
+++ b/components/notice/notice_default.story.vue
@@ -9,7 +9,11 @@
     :close-button-props="computedCloseButtonProps"
     @close="onClose($event)"
   >
-    <span>
+    <span
+      v-if="defaultSlot"
+      v-html="defaultSlot"
+    />
+    <span v-else>
       Message body with
       <a
         href="#"
@@ -17,7 +21,6 @@
         :class="linkClass"
       >a link</a>.
     </span>
-
     <template #action>
       <dt-button
         size="sm"

--- a/components/toast/toast_default.story.vue
+++ b/components/toast/toast_default.story.vue
@@ -17,7 +17,11 @@
       :close-button-props="buttonCloseProps"
       @close="closeToast(); onClose($event)"
     >
-      <span>
+      <span
+        v-if="defaultSlot"
+        v-html="defaultSlot"
+      />
+      <span v-else>
         Message body with
         <a
           href="#"


### PR DESCRIPTION
# PR Title
Fix default slot not working in storybook for notice, banner, toast
<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Make default slot input override the initial elements

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] All tests are passing
- [x] All linters are passing
