### PR TITLE
Bumping DT version to beta.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1149,9 +1149,9 @@
       }
     },
     "@dialpad/dialtone": {
-      "version": "6.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-6.0.0-beta.13.tgz",
-      "integrity": "sha512-3NDS4RC19vXAxDKq/mjhrZDSeyJpg9+VFvPuIYTj7wl6yxnezyomxA2I4A51iPfKuSvUMmPktiviyQL8p+mi9Q==",
+      "version": "6.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-6.0.0-beta.14.tgz",
+      "integrity": "sha512-NDnsBnnnkR0+9QNPEPKqYGqUUwdhAc7RaAF2cddd61ihCmRO7IDbgLI1AoOanmHS8hxXa0rrYCR+kKND3mz3JQ==",
       "dev": true,
       "requires": {
         "eleventy-plugin-nesting-toc": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "v-click-outside": "^3.1.2"
   },
   "devDependencies": {
-    "@dialpad/dialtone": "6.0.0-beta.13",
+    "@dialpad/dialtone": "6.0.0-beta.14",
     "@dialpad/generator-dp": "^1.0.0",
     "@vue/cli-plugin-babel": "~4.4.6",
     "@vue/cli-plugin-eslint": "~4.4.6",
@@ -64,7 +64,7 @@
     "yo": "^3.1.1"
   },
   "peerDependencies": {
-    "@dialpad/dialtone": "6.0.0-beta.13",
+    "@dialpad/dialtone": "6.0.0-beta.14",
     "vue": "^2.6.11"
   },
   "gitHooks": {


### PR DESCRIPTION
# PR Title
Bumps Dialtone version to `6.0.0-beta.14`

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [ ] I have updated library exports
- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [x] All tests are passing
- [x] All linters are passing
- [ ] No accessibility issues reported
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
