### PR TITLE
add hideclose prop to modal

### DIFF
--- a/components/modal/modal.test.js
+++ b/components/modal/modal.test.js
@@ -51,6 +51,15 @@ describe('Dialtone Vue Modal Tests', function () {
     assert.equal(title.text(), newTitle);
   });
 
+  it('Close button is visible by default', async function () {
+    assert.isTrue(closeBtn.exists());
+  });
+
+  it('Close button is hidden if hideClose prop is true', async function () {
+    await wrapper.setProps({ hideClose: true });
+    assert.isFalse(closeBtn.exists());
+  });
+
   it('Should display slotted header and content instead of title and copy', function () {
     const contentText = 'test content';
     const headerText = 'test header';

--- a/components/modal/modal.vue
+++ b/components/modal/modal.vue
@@ -38,6 +38,7 @@
         {{ title }}
       </h2>
       <dt-button
+        v-if="!hideClose"
         class="d-modal__close"
         circle
         size="lg"
@@ -181,6 +182,14 @@ export default {
     modalClass: {
       type: [String, Object, Array],
       default: '',
+    },
+
+    /**
+     * Hides the close button on the modal
+     */
+    hideClose: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/components/modal/modal_default.story.vue
+++ b/components/modal/modal_default.story.vue
@@ -7,26 +7,37 @@
       :kind="kind"
       :size="size"
       :copy="copy"
+      :hide-close="hideClose"
       @update:show="close"
     >
       <template
         v-if="header"
         #header
       >
-        <span v-html="header"></span>
+        <span v-html="header" />
       </template>
       <template
         v-if="defaultSlot"
         #default
       >
-        <span v-html="defaultSlot"></span>
+        <span v-html="defaultSlot" />
       </template>
       <template
         v-if="showFooter"
         #footer
       >
-        <dt-button :kind="kind" importance="primary">Confirm</dt-button>
-        <dt-button :kind="kind" importance="clear">Cancel</dt-button>
+        <dt-button
+          :kind="kind"
+          importance="primary"
+        >
+          Confirm
+        </dt-button>
+        <dt-button
+          :kind="kind"
+          importance="clear"
+        >
+          Cancel
+        </dt-button>
       </template>
     </dt-modal>
     <dt-button


### PR DESCRIPTION


# Add hideclose prop to modal

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added hideclose prop to modal so the close button can be hidden if needed.

## :bulb: Context

Was requested and change was already made in handset

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [x] All tests are passing
- [x] All linters are passing
- [x] No accessibility issues reported
