### PR TITLE
Add test for empty message in Validation Messages component

### DIFF
--- a/components/validation_messages/validation_messages.test.js
+++ b/components/validation_messages/validation_messages.test.js
@@ -166,6 +166,30 @@ describe('Validation Messages Tests', function () {
         itBehavesLikeHasNoVisibleValidationMessages();
       });
 
+      describe('When there is also a correct success validation message', function () {
+        // Test Environment
+        const successValidationMessage = 'Success';
+
+        // Test Setup
+        beforeEach(function () {
+          validationMessages = addFormattedValidationMessage(
+            validationMessages,
+            VALIDATION_MESSAGE_TYPES.SUCCESS,
+            successValidationMessage,
+          );
+        });
+
+        describe('When the validation message renders', function () {
+          // Test Setup
+          beforeEach(function () {
+            propsData = { ...basePropsData, validationMessages };
+            _setWrappers();
+          });
+
+          itBehavesLikeHasNoVisibleValidationMessages();
+        });
+      });
+
       describe('When there is also a correct warning validation message', function () {
         // Test Environment
         const warningValidationMessage = 'Warning';


### PR DESCRIPTION
# Add test for empty message in Validation Messages component

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added test case for the empty message fix in the validation message component introduced in this PR https://github.com/dialpad/dialtone-vue/pull/158

## :bulb: Context

## :pencil: Checklist

- [ ] I have updated library exports
- [x] I have reviewed my changes
- [x] I have added tests
- [ ] I have added all relevant documentation
- [x] All tests are passing
- [x] All linters are passing
- [ ] No accessibility issues reported
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation

## :crystal_ball: Next Steps

## :camera: Screenshots / GIFs

## :link: Sources