### PR TITLE
feat: allow footer slot to list section

### DIFF
--- a/components/list_section/list_section.vue
+++ b/components/list_section/list_section.vue
@@ -26,16 +26,20 @@
     >
       <vnodes :vnodes="displayedItems" />
     </ol>
-
-    <dt-button
-      v-if="isCollapsible"
-      :id="`${id}-list-section-show-more-less`"
-      link
-      class="d-ml16 d-py6"
-      @click="showMoreLessClicked"
+    <div
+      class="d-d-flex"
     >
-      {{ showMoreLessText }}
-    </dt-button>
+      <dt-button
+        v-if="isCollapsible"
+        :id="`${id}-list-section-show-more-less`"
+        link
+        class="d-ml16 d-py6"
+        @click="showMoreLessClicked"
+      >
+        {{ showMoreLessText }}
+      </dt-button>
+      <slot name="footer" />
+    </div>
   </div>
 </template>
 
@@ -47,6 +51,7 @@
    - Can add border lines to visually separate the section
    - Allows a list to have a max number of visible items, and any items
      above the max you'd press "show more" to display.
+  -  Allows to add additional content to list footer.
 */
 import utils from '../utils';
 import { DtButton } from '../button';


### PR DESCRIPTION
# DP 40979 Add Dynamic caller link with list section

https://switchcomm.atlassian.net/browse/DP-40979
Added second link along side of "show more"/"show less"

## :hammer_and_wrench: Type Of Change
- [ ]  Fix
- [x]  Feature
- [ ]  Refactoring
- [ ]  Documentation

## :book: Description
Allows to add additional content to footer as named slot of list section new link along with Show More/Show Less of List Section. 

## :bulb: Context
list section feature of left or right clickable text

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [X] I have reviewed my changes
- [ ] I have added tests
- [x] I have added all relevant documentation
- [ ] All tests are passing
- [x] All linters are passing
- [ ] No accessibility issues reported
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation

## :camera: Screenshots / GIFs

https://drive.google.com/drive/folders/1F_lljI3_FDyN0aLFEKYk9CVDipoW3gqy?usp=sharing

## :link: Sources

https://www.figma.com/file/GmIahNx2kDyEaY7VCqjFYV/Toggle-Local-Presence?node-id=107%3A17361
