### PR TITLE
fix: removed css loader rule from storybook webpack config

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -35,11 +35,6 @@ module.exports = {
     });
 
     config.module.rules.push({
-      test: /\.css$/,
-      use: cssLoaders,
-    });
-
-    config.module.rules.push({
       test: /\.(stories|story)\.[tj]sx?$/,
       loader: require.resolve('@storybook/source-loader'),
       exclude: [/node_modules/],


### PR DESCRIPTION
Issue originally found in https://github.com/dialpad/dialtone/pull/498

`IconPlayStoreBadge.vue Unknown word`

this is happening when building dialtone svg vue components with style tags in storybook. Removed the rule for .css in storybook webpack config as I read this error generally happens when a file is processed twice. It seems the css loader was already included in the "less-loaders" array. Seems to have fixed the issue. Found the idea in this thread.
https://github.com/webpack-contrib/css-loader/issues/295

Jose can you test as well and see if the issue is resolved?