### PR TITLE
fix: list-item story prefix

### DIFF
--- a/components/list_item/list_item.mdx
+++ b/components/list_item/list_item.mdx
@@ -29,7 +29,7 @@ text size and lighter color than default slot.
 The **bottom** slot can be used to display content below the subtitle slot.
 
 <Canvas>
-  <Story id="elements-list-item--default" />
+  <Story id="components-list-item--default" />
 </Canvas>
 
 ### Usage
@@ -87,7 +87,7 @@ When `type` is set to "custom" the list item will not render any styles or slots
 used when the list item has to support content that does not work with the default structure.
 
 <Canvas>
-  <Story id="elements-list-item--custom" />
+  <Story id="components-list-item--custom" />
 </Canvas>
 
 ### Usage

--- a/components/list_item/list_item.stories.js
+++ b/components/list_item/list_item.stories.js
@@ -157,7 +157,7 @@ const decorator = () => ({
 
 // Story Collection
 export default {
-  title: 'Elements/List Item',
+  title: 'Components/List Item',
   component: DtListItem,
   args: argsData,
   argTypes: argTypesData,


### PR DESCRIPTION
# Fix dt-list-item story prefix

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

I missed this change from yesterday in my recent PR, so fixing now the story prefix to the new naming convention. Naming change was done in https://github.com/dialpad/dialtone-vue/pull/195

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes

