### PR TITLE
fix: disable hide when append to is parent

### DIFF
--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -557,6 +557,10 @@ export default {
               fallbackPlacements: this.fallbackPlacements,
             },
           },
+          {
+            name: 'hide',
+            enabled: this.appendTo !== 'parent',
+          },
           getArrowDetected(({ state }) => {
             this.verticalAlignment = state.placement.includes('top') ? 'top' : 'bottom';
             if (state.placement === 'top' || state.placement === 'bottom') {


### PR DESCRIPTION
Related to issue https://switchcomm.atlassian.net/browse/DP-43698

On popovers within scroll lists such as this we'll have to append to parent or else you get the janky behavior you see in the video in the ticket.

The selection list was also being hidden once you have scrolled and the anchor is no longer showing. Seems to be a default option of popper.js https://popper.js.org/docs/v2/modifiers/hide/. This was making it impossible to select an item further down the list.

I figure in the special cases where we need to render popovers at parent such as this we probably never want to hide the dialog when the anchor is no longer visible.
