### PR TITLE
add support for icon based shortcuts

### DIFF
--- a/components/keyboard_shortcut/keyboard_shortcut.vue
+++ b/components/keyboard_shortcut/keyboard_shortcut.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/no-v-html -->
 <template>
   <div
     :class="[
@@ -12,20 +13,40 @@
       inverted ? 'd-bc-black-400' : 'd-bc-black-100',
     ]"
   >
-    <span
-      :class="[
-        inverted ? 'd-fc-black-075' : 'd-fc-black-500',
-      ]"
-      v-html="formattedShortcut"
-    />
+    <template
+      v-for="item in formattedShortcutSplit"
+    >
+      <component
+        :is="SHORTCUTS_ICON_ALIASES[item]"
+        v-if="SHORTCUTS_ICON_ALIASES[item]"
+        :key="item"
+        :class="[
+          inverted ? 'd-fc-black-075' : 'd-fc-black-500',
+          'd-mx1',
+        ]"
+      />
+      <span
+        v-else
+        :key="item"
+        :class="[
+          inverted ? 'd-fc-black-075' : 'd-fc-black-500',
+        ]"
+        v-html="item"
+      />
+    </template>
   </div>
 </template>
 
 <script>
-import { SHORTCUTS_ALIASES } from './keyboard_shortcut_constants';
+import IconGrid from '@dialpad/dialtone/lib/dist/vue/icons/IconGrid';
+import { SHORTCUTS_ALIASES, SHORTCUTS_ICON_ALIASES } from './keyboard_shortcut_constants';
 
 export default {
   name: 'DtKeyboardShortcut',
+
+  components: {
+    IconGrid,
+  },
 
   props: {
     inverted: {
@@ -39,11 +60,32 @@ export default {
     },
   },
 
+  data () {
+    return {
+      SHORTCUTS_ICON_ALIASES,
+    };
+  },
+
   computed: {
     formattedShortcut () {
       return Object.keys(SHORTCUTS_ALIASES).reduce((result, key) => {
         return result.replace(new RegExp('{' + key + '}', 'gi'), SHORTCUTS_ALIASES[key]);
       }, this.shortcut);
+    },
+
+    // Splits any icon based aliases into their own array items.
+    formattedShortcutSplit () {
+      const iconAliasString = Object.keys(SHORTCUTS_ICON_ALIASES).join('|');
+
+      /* any SHORTCUTS_ICON_ALIASES will go into the lookaround separated by or's
+         example: split(/(?={icon1|icon2})|(?<={icon1|icon2})/g);
+
+         splits a string while retaining the delimiters in their own array item:
+
+         if {win} is our delimiter AKA shortcut icon alias
+         '{win} + D + {win}' would split like [{win}, ' + D + ', {win}] */
+      const regex = new RegExp(`(?=${iconAliasString})|(?<=${iconAliasString})`, 'gi');
+      return this.formattedShortcut.split(regex);
     },
   },
 };

--- a/components/keyboard_shortcut/keyboard_shortcut_constants.js
+++ b/components/keyboard_shortcut/keyboard_shortcut_constants.js
@@ -12,4 +12,8 @@ export const SHORTCUTS_ALIASES = {
   pageDown: '&#8671;', // ⇟ Page down
 };
 
+export const SHORTCUTS_ICON_ALIASES = {
+  '{win}': 'IconGrid',
+};
+
 export const SHORTCUTS_ALIASES_LIST = Object.keys(SHORTCUTS_ALIASES).map(key => `{${key}}`);


### PR DESCRIPTION
Was messing around to see if we could get a "dialtone icon based shortcut" working in this component for the windows key situtation. Think this should work pretty well. Will still need to add the actual windows icon into dialtone, just uses "grid" for a placeholder right now.

Uses a regex to split the string into icon based aliases, and non-icon based aliases and then renders it as a component or a v-html based on what it is.