### PR TITLE
fix: bad exports on skeleton

### DIFF
--- a/components/skeleton/index.js
+++ b/components/skeleton/index.js
@@ -2,7 +2,7 @@ export { default as DtSkeleton } from './skeleton.vue';
 export { default as DtSkeletonListItem } from './skeleton-list-item.vue';
 export { default as DtSkeletonText } from './skeleton-text.vue';
 export { default as DtSkeletonShape } from './skeleton-shape.vue';
-export { default as DtSkeletonParagraph } from './skeleton-shape.vue';
+export { default as DtSkeletonParagraph } from './skeleton-paragraph.vue';
 export {
   SKELETON_RIPPLE_DURATION,
   SKELETON_SHAPES,

--- a/components/skeleton/skeleton.vue
+++ b/components/skeleton/skeleton.vue
@@ -122,3 +122,36 @@ export default {
   },
 };
 </script>
+
+<style lang="less">
+// The --placeholder-from-color and --placeholder-to-color
+// custom properties can be set on the parent class of the
+// placeholder to control the animation colors.
+.skeleton-placeholder {
+  display: flex;
+  stroke: none;
+  fill: var(--placeholder-from-color, var(--black-075));
+  background: var(--placeholder-from-color, var(--black-075));
+
+  &--animate {
+    animation-name: placeholder-throb;
+    animation-iteration-count: infinite;
+  }
+}
+
+// the animation is used by the skeleton component
+@keyframes placeholder-throb {
+  10% {
+    fill: var(--placeholder-from-color, var(--black-075));
+    background: var(--placeholder-from-color, var(--black-075));
+  }
+  50% {
+    fill: var(--placeholder-to-color, var(--black-025));
+    background: var(--placeholder-to-color, var(--black-025));
+  }
+  90% {
+    fill: var(--placeholder-from-color, var(--black-075));
+    background: var(--placeholder-from-color, var(--black-075));
+  }
+}
+</style>

--- a/css/dialtone-globals.less
+++ b/css/dialtone-globals.less
@@ -141,34 +141,3 @@
   white-space: nowrap;
   width: 1px;
 }
-
-// The --placeholder-from-color and --placeholder-to-color
-// custom properties can be set on the parent class of the
-// placeholder to control the animation colors.
-.skeleton-placeholder {
-  display: flex;
-  stroke: none;
-  fill: var(--placeholder-from-color, @black-075);
-  background: var(--placeholder-from-color, @black-075);
-
-  &--animate {
-    animation-name: placeholder-throb;
-    animation-iteration-count: infinite;
-  }
-}
-
-// the animation is used by the skeleton component
-@keyframes placeholder-throb {
-  10% {
-    fill: var(--placeholder-from-color, @black-075);
-    background: var(--placeholder-from-color, @black-075);
-  }
-  50% {
-    fill: var(--placeholder-to-color, @black-025);
-    background: var(--placeholder-to-color, @black-025);
-  }
-  90% {
-    fill: var(--placeholder-from-color, @black-075);
-    background: var(--placeholder-from-color, @black-075);
-  }
-}


### PR DESCRIPTION
Dialtone-globals do not get exported in dialtone-vue so the skeleton-placeholder classes were not available in the product.

Also fixed a bad export with skeleton paragraph.