### PR TITLE
fix: storybook addon-docs custom alias

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,6 +2,7 @@ const path = require('path');
 const less = require('less');
 const package = require('../package.json');
 const generate = require('generate-file-webpack-plugin');
+const vueConf = require('../vue.config');
 
 const cssLoaders = [
   'style-loader',
@@ -85,7 +86,16 @@ module.exports = {
     '../docs/**/*.stories.@(js|mdx)',
   ],
   addons: [
-    '@storybook/addon-docs',
+    {
+      name: '@storybook/addon-docs',
+      options: {
+        vueDocgenOptions: {
+          alias: {
+            '@': path.resolve(__dirname, '../')
+          },
+        },
+      }
+    },
     '@storybook/addon-controls',
     '@storybook/addon-actions',
     '@storybook/addon-links',


### PR DESCRIPTION
# Storybook addon-docs custom alias

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added configuration in `addon-docs` storybook addon to add custom alias `@`.

## :bulb: Context

Some warnings appeared with props defined in mixin (in input and select_menu stories), and I figured out that vue-docgen plugin in Storybook wasn't resolving the `@` alias defined in the `.storybook/main.js` file.

<img width="1265" alt="Screen Shot 2022-02-18 at 14 23 31" src="https://user-images.githubusercontent.com/83774467/154731955-d6b25d94-9c43-464d-9a90-74d749e3220e.png">

Configuration added: https://github.com/storybookjs/storybook/tree/70bc53d5bd43ef87e965af9ad97c86fe21567320/addons/docs/vue#preset-options

Issue in Storybook repo: https://github.com/storybookjs/storybook/issues/9615#issuecomment-745738523

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [ ] I have updated library exports
- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] All tests are passing
- [ ] All linters are passing
- [ ] No accessibility issues reported
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
