### PR TITLE
chore: handle showing of the bottom panel per story

### DIFF
--- a/components/avatar/avatar.stories.js
+++ b/components/avatar/avatar.stories.js
@@ -84,6 +84,9 @@ export default {
     docs: {
       page: DtAvatarMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 

--- a/components/badge/badge.stories.js
+++ b/components/badge/badge.stories.js
@@ -39,6 +39,9 @@ export default {
     docs: {
       page: DtBadgeMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -53,5 +56,5 @@ Default.args = {
 };
 
 export const Variants = VariantsTemplate.bind({});
-Variants.parameters = { controls: { disable: true }, actions: { disable: true } };
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };
 Variants.args = {};

--- a/components/banner/banner.stories.js
+++ b/components/banner/banner.stories.js
@@ -34,6 +34,9 @@ export default {
     docs: {
       page: BaseBannerMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
   args: argsData,
   argTypes: argTypesData,

--- a/components/breadcrumbs/breadcrumbs.stories.js
+++ b/components/breadcrumbs/breadcrumbs.stories.js
@@ -65,6 +65,9 @@ export default {
     docs: {
       page: DtBreadcrumbsMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -80,3 +83,4 @@ Default.args = {};
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/button/button.stories.js
+++ b/components/button/button.stories.js
@@ -167,6 +167,9 @@ export default {
     docs: {
       page: BaseButtonMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
   args: argsData,
   argTypes: argTypesData,
@@ -183,5 +186,5 @@ Default.args = {
 const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(args, argTypes, ButtonVariants);
 
 export const Variants = VariantsTemplate.bind({});
-Variants.parameters = { controls: { disable: true }, actions: { disable: true } };
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };
 Variants.args = {};

--- a/components/button_group/button_group.stories.js
+++ b/components/button_group/button_group.stories.js
@@ -35,6 +35,9 @@ export default {
     docs: {
       page: DtButtonGroupMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 

--- a/components/checkbox/checkbox.stories.js
+++ b/components/checkbox/checkbox.stories.js
@@ -141,6 +141,9 @@ export default {
     docs: {
       page: BaseCheckboxMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -154,3 +157,4 @@ Default.args = {};
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/checkbox_group/checkbox_group.stories.js
+++ b/components/checkbox_group/checkbox_group.stories.js
@@ -135,6 +135,9 @@ export default {
     docs: {
       page: CheckboxGroupMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -152,3 +155,4 @@ Default.args = {};
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/combobox/combobox.stories.js
+++ b/components/combobox/combobox.stories.js
@@ -129,6 +129,9 @@ export default {
     docs: {
       page: DtComboboxMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 

--- a/components/dropdown/dropdown.stories.js
+++ b/components/dropdown/dropdown.stories.js
@@ -160,6 +160,9 @@ export default {
     docs: {
       page: DtDropdownMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -184,6 +187,7 @@ Default.decorators = [() => ({
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };
 Variants.decorators = [() => ({
   template: `<div class="d-d-flex d-jc-center d-ai-center d-h164"><story /></div>`,
 })];

--- a/components/input/input.stories.js
+++ b/components/input/input.stories.js
@@ -186,6 +186,9 @@ export default {
     docs: {
       page: InputMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
   decorators: [decorator],
   excludeStories: /.*Data$/,

--- a/components/input_group/input_group.stories.js
+++ b/components/input_group/input_group.stories.js
@@ -110,6 +110,9 @@ export default {
     docs: {
       page: InputGroupMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -123,3 +126,4 @@ Default.args = {};
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/keyboard_shortcut/keyboard_shortcut.stories.js
+++ b/components/keyboard_shortcut/keyboard_shortcut.stories.js
@@ -33,6 +33,9 @@ export default {
     docs: {
       page: DtKeyboardShortcutMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -54,3 +57,4 @@ Default.args = {};
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/lazy_show/lazy_show.stories.js
+++ b/components/lazy_show/lazy_show.stories.js
@@ -35,6 +35,9 @@ export default {
     docs: {
       page: LazyShowMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
   excludeStories: /.Data$/,
 };

--- a/components/link/link.stories.js
+++ b/components/link/link.stories.js
@@ -112,6 +112,9 @@ export default {
     docs: {
       page: DtLinkMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -125,3 +128,4 @@ Default.args = {};
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/list_item/list_item.stories.js
+++ b/components/list_item/list_item.stories.js
@@ -149,6 +149,9 @@ export default {
     docs: {
       page: DtListItemMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 

--- a/components/modal/modal.stories.js
+++ b/components/modal/modal.stories.js
@@ -102,6 +102,9 @@ export default {
     docs: {
       page: ModalMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
   args: argsData,
   argTypes: argTypesData,

--- a/components/notice/notice.stories.js
+++ b/components/notice/notice.stories.js
@@ -95,6 +95,9 @@ export default {
     docs: {
       page: DtNoticeMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 

--- a/components/popover/popover.stories.js
+++ b/components/popover/popover.stories.js
@@ -150,6 +150,9 @@ export default {
     docs: {
       page: PopoverMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
   excludeStories: /.Data$/,
 };
@@ -185,3 +188,5 @@ Default.parameters = {
 };
 
 export const Variants = TemplateVariants.bind({});
+Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/radio/radio.stories.js
+++ b/components/radio/radio.stories.js
@@ -142,6 +142,9 @@ export default {
     docs: {
       page: RadioMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -155,3 +158,4 @@ Default.args = {};
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/radio_group/radio_group.stories.js
+++ b/components/radio_group/radio_group.stories.js
@@ -127,6 +127,9 @@ export default {
     docs: {
       page: RadioGroupMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -140,3 +143,4 @@ Default.args = {};
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/select_menu/select_menu.stories.js
+++ b/components/select_menu/select_menu.stories.js
@@ -235,6 +235,9 @@ export default {
     docs: {
       page: DtSelectMenuMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -256,3 +259,4 @@ Default.args = {};
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/skeleton/skeleton.stories.js
+++ b/components/skeleton/skeleton.stories.js
@@ -104,6 +104,9 @@ export default {
     docs: {
       page: DtSkeletonMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -128,3 +131,4 @@ Default.args = {};
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/tabs/tabs.stories.js
+++ b/components/tabs/tabs.stories.js
@@ -68,6 +68,9 @@ export default {
     docs: {
       page: DtTabsMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -89,3 +92,4 @@ Default.args = {};
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/toast/toast.stories.js
+++ b/components/toast/toast.stories.js
@@ -103,6 +103,9 @@ export default {
     docs: {
       page: DtToastMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 

--- a/components/toggle/toggle.stories.js
+++ b/components/toggle/toggle.stories.js
@@ -90,6 +90,9 @@ export default {
     docs: {
       page: ToggleMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -103,3 +106,4 @@ Default.args = {};
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/tooltip/tooltip.stories.js
+++ b/components/tooltip/tooltip.stories.js
@@ -103,6 +103,9 @@ export default {
     docs: {
       page: DtTooltipMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
 };
 
@@ -119,6 +122,8 @@ Default.args = {};
 
 export const Variants = TooltipVariantsTemplate.bind({});
 Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };
 
 export const Flip = TooltipFlipTemplate.bind({});
 Flip.args = {};
+Flip.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/validation_messages/validation_messages.stories.js
+++ b/components/validation_messages/validation_messages.stories.js
@@ -36,6 +36,9 @@ export default {
     docs: {
       page: BaseValidationMessagesMdx,
     },
+    options: {
+      showPanel: true,
+    },
   },
   args: argsData,
   argTypes: argTypesData,
@@ -79,5 +82,7 @@ const VariantsTemplate = () => {
 };
 export const Variants = VariantsTemplate.bind({});
 Variants.parameters = {
-  controls: { hideNoControlsWarning: true },
+  controls: { hideNoControlsWarning: true, disable: true },
+  actions: { disable: true },
+  options: { showPanel: false },
 };


### PR DESCRIPTION
Friday Afternoon Fixup

We have many pages with multiple variants on them where it makes no sense to show the controls at the bottom of the screen because they don't even work. Probably just confuses the hell out of everyone. I've disabled the bottom panel and the controls in these cases. Also had to add `showPanel: true` by default or else the panel will not show up when you switch to a story that actually does need it.

Example:
![Screen Shot 2022-02-18 at 4 04 17 PM](https://user-images.githubusercontent.com/64808812/154776654-0a06f970-8cb3-4863-8afe-397a6cfa351e.png)
