### PR TITLE
refactor: make combobox enter key event exact

### DIFF
--- a/components/combobox/combobox.test.js
+++ b/components/combobox/combobox.test.js
@@ -141,6 +141,16 @@ describe('Dialtone Vue Combobox tests', function () {
       it('should emit select event', function () { assert.equal(wrapper.emitted().select.length, 1); });
     });
 
+    describe('When "Enter" key is pressed with another key and item is highlighted', function () {
+      beforeEach(async function () {
+        await wrapper.setData({ highlightIndex: 1 });
+        await wrapper.trigger('keydown.shift.enter');
+      });
+
+      it('should not call listener', function () { assert.isFalse(selectStub.called); });
+      it('should not emit select event', function () { assert.isUndefined(wrapper.emitted().select); });
+    });
+
     describe('When "Esc" key is pressed', function () {
       beforeEach(async function () {
         await wrapper.trigger('keydown.esc');

--- a/components/combobox/combobox.vue
+++ b/components/combobox/combobox.vue
@@ -6,7 +6,7 @@
     :aria-owns="listId"
     aria-haspopup="listbox"
     @keydown.esc.stop="onEscapeKey"
-    @keydown.enter="onEnterKey"
+    @keydown.enter.exact="onEnterKey"
     @keydown.up.stop.prevent="onUpKey"
     @keydown.down.stop.prevent="onDownKey"
     @keydown.home.stop.prevent="onHomeKey"


### PR DESCRIPTION
# PR Title

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [ ] Feature
- [x] Refactoring
- [ ] Documentation

## :book: Description

I need to be able to do custom hooks for shift+enter combination while using the combobox, so I need it to not hijack enter key combinations.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] All tests are passing
- [x] All linters are passing
- [x ] No accessibility issues reported
- [x] I have validated components keyboard navigation

