### PR TITLE
fix: rename args -> $attrs and fix createTemplateFromVueFile function

### DIFF
--- a/common/storybook_utils.js
+++ b/common/storybook_utils.js
@@ -9,12 +9,13 @@
  *                                      but rather the usage of that component.
  * @returns {component} the template component with props and args added.
  */
-export const createTemplateFromVueFile = (args, templateComponent) => {
-  templateComponent.setup = () => {
+export const createTemplateFromVueFile = (args, templateComponent) => ({
+  components: { templateComponent },
+  setup () {
     return { args };
-  };
-  return templateComponent;
-};
+  },
+  template: '<template-component v-bind="args"></template-component>',
+});
 
 /**
  * Gets the full list of icon component names from the dialtone package

--- a/components/avatar/avatar_default.story.vue
+++ b/components/avatar/avatar_default.story.vue
@@ -1,22 +1,22 @@
 <template>
   <dt-avatar
-    :id="args.id"
-    :kind="args.kind"
-    :size="args.size"
-    :color="args.color"
-    :src="args.src"
-    :alt="args.alt"
+    :id="$attrs.id"
+    :kind="$attrs.kind"
+    :size="$attrs.size"
+    :color="$attrs.color"
+    :src="$attrs.src"
+    :alt="$attrs.alt"
   >
     <template
-      v-if="args.default"
+      v-if="defaultSlot"
     >
       <component
-        :is="args.default"
-        v-if="args.kind === 'icon'"
+        :is="defaultSlot"
+        v-if="$attrs.kind === 'icon'"
       />
       <html-fragment
         v-else
-        :html="args.default"
+        :html="defaultSlot"
       />
     </template>
   </dt-avatar>

--- a/components/badge/badge_default.story.vue
+++ b/components/badge/badge_default.story.vue
@@ -1,10 +1,10 @@
 <template>
   <dt-badge
-    :text="args.text"
-    :color="args.color"
+    :text="$attrs.text"
+    :color="$attrs.color"
   >
-    <template v-if="args.default">
-      {{ args.default }}
+    <template v-if="defaultSlot">
+      {{ defaultSlot }}
     </template>
   </dt-badge>
 </template>

--- a/components/banner/banner_default.story.vue
+++ b/components/banner/banner_default.story.vue
@@ -6,19 +6,19 @@
 
     <dt-banner
       v-if="displayBanner"
-      :kind="args.kind"
-      :title="args.title"
-      :title-id="args.titleId"
-      :content-id="args.contentId"
-      :important="args.important"
-      :pinned="args.pinned"
-      :hide-close="args.hideClose"
+      :kind="$attrs.kind"
+      :title="$attrs.title"
+      :title-id="$attrs.titleId"
+      :content-id="$attrs.contentId"
+      :important="$attrs.important"
+      :pinned="$attrs.pinned"
+      :hide-close="$attrs.hideClose"
       :close-button-props="buttonCloseProps"
-      @close="displayBanner = false; args.onClose($event)"
+      @close="displayBanner = false; $attrs.onClose($event)"
     >
       <span
-        v-if="args.default"
-        v-html="args.default"
+        v-if="defaultSlot"
+        v-html="defaultSlot"
       />
       <span v-else>
         Message body with
@@ -30,28 +30,28 @@
       </span>
 
       <template
-        v-if="args.action"
+        v-if="$attrs.action"
         #action
       >
         <dt-button
           :kind="buttonKind"
           importance="outlined"
-          @click="args.onClick"
+          @click="$attrs.onClick"
         >
-          {{ args.action }}
+          {{ $attrs.action }}
         </dt-button>
       </template>
       <template
-        v-if="args.icon"
+        v-if="$attrs.icon"
         #icon
       >
-        <component :is="args.icon" />
+        <component :is="$attrs.icon" />
       </template>
       <template
-        v-if="args.titleOverride"
+        v-if="$attrs.titleOverride"
         #titleOverride
       >
-        <span v-html="args.titleOverride" />
+        <span v-html="$attrs.titleOverride" />
       </template>
     </dt-banner>
   </div>
@@ -79,11 +79,11 @@ export default {
 
   computed: {
     shouldInvertButton () {
-      return this.args.kind === 'base' || this.args.kind === 'error' || this.args.kind === 'info';
+      return this.$attrs.kind === 'base' || this.$attrs.kind === 'error' || this.$attrs.kind === 'info';
     },
 
     isInverted () {
-      return this.args.important && this.shouldInvertButton;
+      return this.$attrs.important && this.shouldInvertButton;
     },
 
     buttonKind () {
@@ -96,7 +96,7 @@ export default {
 
     buttonCloseProps () {
       return {
-        ...this.args.closeButtonProps,
+        ...this.$attrs.closeButtonProps,
         kind: this.buttonKind,
         ariaLabel: 'Close',
       };

--- a/components/button/button_default.story.vue
+++ b/components/button/button_default.story.vue
@@ -1,31 +1,31 @@
 <template>
   <dt-button
-    :importance="args.importance"
-    :type="args.type"
-    :size="args.size"
-    :kind="args.kind"
-    :circle="args.circle"
-    :loading="args.loading"
-    :label-class="args.labelClass"
-    :assertive-on-focus="args.assertiveOnFocus"
-    :link="args.link"
-    :link-kind="args.linkKind"
-    :icon-position="args.iconPosition"
-    :disabled="args.disabled"
-    :style="{ width: args.width }"
-    @click="args.onClick"
-    @focusin="args.onFocusIn"
-    @focusout="args.onFocusOut"
+    :importance="$attrs.importance"
+    :type="$attrs.type"
+    :size="$attrs.size"
+    :kind="$attrs.kind"
+    :circle="$attrs.circle"
+    :loading="$attrs.loading"
+    :label-class="$attrs.labelClass"
+    :assertive-on-focus="$attrs.assertiveOnFocus"
+    :link="$attrs.link"
+    :link-kind="$attrs.linkKind"
+    :icon-position="$attrs.iconPosition"
+    :disabled="$attrs.disabled"
+    :style="{ width: $attrs.width }"
+    @click="$attrs.onClick"
+    @focusin="$attrs.onFocusIn"
+    @focusout="$attrs.onFocusOut"
   >
     <span
-      v-if="args.default"
-      v-html="args.default"
+      v-if="defaultSlot"
+      v-html="defaultSlot"
     />
     <template
-      v-if="args.icon"
+      v-if="$attrs.icon"
       #icon
     >
-      <component :is="args.icon" />
+      <component :is="$attrs.icon" />
     </template>
   </dt-button>
 </template>

--- a/components/notice/notice_default.story.vue
+++ b/components/notice/notice_default.story.vue
@@ -1,17 +1,17 @@
 <template>
   <dt-notice
-    :kind="args.kind"
-    :title="args.title"
-    :title-id="args.titleId"
-    :content-id="args.contentId"
-    :important="args.important"
-    :hide-close="args.hideClose"
-    :close-button-props="args.computedCloseButtonProps"
-    @close="args.onClose($event)"
+    :kind="$attrs.kind"
+    :title="$attrs.title"
+    :title-id="$attrs.titleId"
+    :content-id="$attrs.contentId"
+    :important="$attrs.important"
+    :hide-close="$attrs.hideClose"
+    :close-button-props="$attrs.computedCloseButtonProps"
+    @close="$attrs.onClose($event)"
   >
     <span
-      v-if="args.default"
-      v-html="args.default"
+      v-if="defaultSlot"
+      v-html="defaultSlot"
     />
     <span v-else>
       Message body with
@@ -23,30 +23,30 @@
     </span>
     <template #action>
       <span
-        v-if="args.action"
-        v-html="args.action"
+        v-if="$attrs.action"
+        v-html="$attrs.action"
       />
       <dt-button
         v-else
         size="sm"
         importance="outlined"
         :kind="buttonKind"
-        @click="args.onClick"
+        @click="$attrs.onClick"
       >
         Action
       </dt-button>
     </template>
     <template
-      v-if="args.icon"
+      v-if="$attrs.icon"
       #icon
     >
-      <component :is="args.icon" />
+      <component :is="$attrs.icon" />
     </template>
     <template
-      v-if="args.titleOverride"
+      v-if="$attrs.titleOverride"
       #titleOverride
     >
-      <span v-html="args.titleOverride" />
+      <span v-html="$attrs.titleOverride" />
     </template>
   </dt-notice>
 </template>


### PR DESCRIPTION
# Rename args -> $attrs and fix createTemplateFromVueFile function

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Replaced `args` with `$attrs` and the createTemplateFromVueFile function

## :bulb: Context

Found a bug that a recent PR introduced, in the Docs section the variants didn't worked, all variants looked the same.

## :pencil: Checklist

- [ ] I have updated library exports
- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] All tests are passing
- [ ] All linters are passing
- [ ] No accessibility issues reported
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation