### PR TITLE
fix: fix input length validation tests in dialpad

### DIFF
--- a/components/input/input.vue
+++ b/components/input/input.vue
@@ -388,14 +388,17 @@ export default {
       this.$emit('update:invalid', val);
     },
 
-    value () {
-      if (this.shouldValidateLength) {
-        this.validateLength(this.inputLength);
-      }
+    value: {
+      immediate: true,
+      handler (newValue) {
+        if (this.shouldValidateLength) {
+          this.validateLength(this.inputLength);
+        }
 
-      if (this.currentLength == null) {
-        this.$emit('update:length', this.calculateLength(this.value));
-      }
+        if (this.currentLength == null) {
+          this.$emit('update:length', this.calculateLength(newValue));
+        }
+      },
     },
   },
 


### PR DESCRIPTION
# fix input length validation tests in dialpad

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

There is a `select_menu` component in Dialpad that was passing a null value in the input during some test ([default value](https://github.com/dialpad/firespotter/blob/d83a07deeaa3c4e0a9ab282cd66d569506fda410/ubervoice/static/js/components/select_menu.vue#L119)) so added validation for this case.
Also fixed a bug in the input state and input classes associated with the length validation.

## :bulb: Context

These changes are deployed in `@dialpad/dialtone-vue@2.1.0-beta.4` for testing in Dialpad.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [ ] I have updated library exports
- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [x] All tests are passing
- [ ] All linters are passing
- [ ] No accessibility issues reported
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
