### PR TITLE
fix: update list-item y-padding 2 -> 4

### DIFF
--- a/components/list_item/default_list_item.vue
+++ b/components/list_item/default_list_item.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="dt-default-list-item d-fs14 d-lh4 d-py2 d-px12 d-d-flex d-ai-center">
+  <div class="dt-default-list-item d-fs14 d-lh4 d-py4 d-px12 d-d-flex d-ai-center">
     <section
       v-if="$slots.left"
       class="dt-default-list-item--left d-d-inline-flex d-as-flex-start d-d-flex d-ai-center d-pr8"


### PR DESCRIPTION
# fix: update list-item y-padding 2 -> 4

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Natayi reached out to me as she noticed on the storybook that the y-padding of list items is 2 when it should be 4. Visually doesn't really change much - just makes the rows ever slightly taller (maybe, depending on the content).

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] All tests are passing
- [x] All linters are passing
- [x] No accessibility issues reported

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

![image](https://user-images.githubusercontent.com/50376477/160009575-2a0b54ee-a32e-4854-a1a1-3c4f34f0dba7.png)
