### PR TITLE
fix(popover): transparent overlay render at the root

### DIFF
--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
-    <dt-lazy-show
-      :show="modal && isOpen"
-      transition="d-zoom"
-      class="d-modal--transparent"
-      :aria-hidden="modal && isOpen ? 'false' : 'true'"
-    />
+    <portal v-if="modal && isOpen">
+      <div
+        class="d-modal--transparent"
+        :aria-hidden="modal && isOpen ? 'false' : 'true'"
+      />
+    </portal>
     <component
       :is="elementType"
       ref="popover"
@@ -118,6 +118,7 @@ import {
 } from './popover_constants';
 import { getUniqueString } from '@/common/utils';
 import DtLazyShow from '../lazy_show/lazy_show';
+import { Portal } from '@linusborg/vue-simple-portal';
 import ModalMixin from '@/common/mixins/modal.js';
 import {
   createTippy,
@@ -135,6 +136,7 @@ export default {
   components: {
     DtLazyShow,
     PopoverHeaderFooter,
+    Portal,
   },
 
   mixins: [ModalMixin],
@@ -594,7 +596,7 @@ export default {
     onClickOutside () {
       if (!this.hideOnClick) return;
       // If a modal popover is opened inside of this one, do not hide on click out
-      const innerModals = this.popoverContentEl.querySelector('.d-modal--transparent[aria-hidden="false"]');
+      const innerModals = this.popoverContentEl.querySelector('.d-popover__anchor--modal-opened');
       if (!innerModals) {
         this.closePopover();
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@dialpad/dialtone-vue",
       "version": "2.1.1",
       "dependencies": {
+        "@linusborg/vue-simple-portal": "^0.1.5",
         "tippy.js": "^6.3.1"
       },
       "devDependencies": {
@@ -2240,6 +2241,17 @@
       "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
       "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
       "dev": true
+    },
+    "node_modules/@linusborg/vue-simple-portal": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@linusborg/vue-simple-portal/-/vue-simple-portal-0.1.5.tgz",
+      "integrity": "sha512-dq+oubEVW4UabBoQxmH97GiDa+F6sTomw4KcXFHnXEpw69rdkXFCxo1WzwuvWjoLiUVYJTyN1dtlUvTa50VcXg==",
+      "dependencies": {
+        "nanoid": "^3.1.20"
+      },
+      "peerDependencies": {
+        "vue": "^2.6.6"
+      }
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -17992,7 +18004,6 @@
     },
     "node_modules/nanoid": {
       "version": "3.1.31",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -29651,7 +29662,6 @@
     },
     "node_modules/vue": {
       "version": "2.6.12",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vue-eslint-parser": {
@@ -33581,6 +33591,14 @@
       "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
       "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
       "dev": true
+    },
+    "@linusborg/vue-simple-portal": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@linusborg/vue-simple-portal/-/vue-simple-portal-0.1.5.tgz",
+      "integrity": "sha512-dq+oubEVW4UabBoQxmH97GiDa+F6sTomw4KcXFHnXEpw69rdkXFCxo1WzwuvWjoLiUVYJTyN1dtlUvTa50VcXg==",
+      "requires": {
+        "nanoid": "^3.1.20"
+      }
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -44414,8 +44432,7 @@
       "optional": true
     },
     "nanoid": {
-      "version": "3.1.31",
-      "dev": true
+      "version": "3.1.31"
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -52519,8 +52536,7 @@
       "dev": true
     },
     "vue": {
-      "version": "2.6.12",
-      "dev": true
+      "version": "2.6.12"
     },
     "vue-eslint-parser": {
       "version": "7.6.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "storybook:build": "npm run --prefix storybook build"
   },
   "dependencies": {
+    "@linusborg/vue-simple-portal": "^0.1.5",
     "tippy.js": "^6.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
# popover: transparent overlay render at the root

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

We were rendering the transparent overlay within the anchor prior to this change, which worked in most cases due to the absolute positioning css. However if the anchor was set to display: none after opening a popover, the overlay would disappear as well. This change renders the modal overlay at root using the portal-vue library.

This will need a separate vue3 implementation as vue3 has a native implementation of portal and you are not supposed to use portal-vue.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] All tests are passing
- [x] All linters are passing
- [x] No accessibility issues reported

## :crystal_ball: Next Steps

probably want to do this on our actual modal component also, but I'll do that in a separate PR to limit breakage potential

## :link: Sources

(https://github.com/LinusBorg/portal-vue)
