### PR TITLE
fix: error with number value in calculateLength

### DIFF
--- a/components/input/input.vue
+++ b/components/input/input.vue
@@ -432,7 +432,7 @@ export default {
     },
 
     calculateLength (value) {
-      if (value === null || typeof value !== 'string') {
+      if (typeof value !== 'string') {
         return 0;
       }
 


### PR DESCRIPTION
It is possible to have a number in an input rather than a string if you have the input set to type="number" in this case we were getting a "value is not iterable" error when the value was a number. Added an additional check to make sure the value is a string.