### PR TITLE
fix: dt-417 handle anchor with no children

### DIFF
--- a/components/popover/tippy_utils.js
+++ b/components/popover/tippy_utils.js
@@ -55,7 +55,7 @@ const createAnchor = (anchorWrapper, tabIndex) => {
 };
 
 export const getAnchor = (anchorWrapper, tabIndex = '0') => {
-  const anchor = anchorWrapper.children[0];
+  const anchor = anchorWrapper?.children[0];
   if (!anchor) return createAnchor(anchorWrapper);
   if (!findFirstFocusableNode(anchor)) {
     anchor.setAttribute('tabindex', tabIndex);


### PR DESCRIPTION
Fix for reported error in production https://dialpad.atlassian.net/browse/DT-417

We aren't sure exactly why this specific component (call_attestation.vue) is rendering without an anchor at some point. It appears that the anchor slot is correctly populated in the component, however this should fix the error.