### PR TITLE
fix: popover within popover stuck when ESC

### DIFF
--- a/components/popover/tippy_utils.js
+++ b/components/popover/tippy_utils.js
@@ -1,5 +1,5 @@
 import tippy from 'tippy.js';
-import { getArrowDetected, hideOnEsc } from '../tooltip/modifiers';
+import { getArrowDetected } from '../tooltip/modifiers';
 import { findFirstFocusableNode } from '@/common/utils';
 
 export const BASE_TIPPY_DIRECTIONS = [
@@ -15,7 +15,6 @@ export const createTippy = (anchorElement, options) => {
   return tippy(anchorElement, {
     ...options,
     render: () => getContentWrapper(contentElement),
-    plugins: [hideOnEsc],
   });
 };
 

--- a/components/tooltip/modifiers.js
+++ b/components/tooltip/modifiers.js
@@ -1,24 +1,3 @@
-export const hideOnEsc = {
-  name: 'hideOnEsc',
-  defaultValue: true,
-  fn ({ hide }) {
-    function onKeyDown (event) {
-      if (event.key === 'Escape') {
-        hide();
-      }
-    }
-
-    return {
-      onShow () {
-        document.addEventListener('keydown', onKeyDown);
-      },
-      onHide () {
-        document.removeEventListener('keydown', onKeyDown);
-      },
-    };
-  },
-};
-
 export const getArrowDetected = fn => ({
   name: 'arrowDetected',
   enabled: true,


### PR DESCRIPTION
Removing this hideOnEsc plugin. It is no longer necessary with the new version of popover / tooltip, and was causing a bug where it would completely lock up the UI and prevent any interaction when you opened a popover within a popover, and then closed it by pressing ESC.