### PR TITLE
chore: add install:all script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ These requirements are enforced via peerdependencies of Dialtone Vue when possib
 If you would like to contribute to Dialtone Vue the first step is to get the project running locally. Follow the below quickstart to do so.
 
 1. Clone the repo `git clone https://github.com/dialpad/dialtone-vue.git`
-2. Install storybook dependencies `npm run storybook:install`
-3. Install dialtone-vue dependencies `npm install`
-4. Run local dev server `npm start`
-5. Visit local dev server at http://localhost:9011/
+2. Install dependencies `npm run install:all`
+3. Run local dev server `npm start`
+4. Visit local dev server at http://localhost:9011/
 
 Next read the more detailed contributor documentation in [CONTRIBUTING.md](.github/CONTRIBUTING.md).

--- a/docs/component_driven_development/yeoman_generator.stories.mdx
+++ b/docs/component_driven_development/yeoman_generator.stories.mdx
@@ -11,6 +11,7 @@ project.
 
 ```bash
 # From Dialtone Vue root directory
+npm run install:all
 npx yo dialtone-vue
 ```
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "storybook": "npm run --prefix storybook storybook",
     "storybook:install": "npm install --prefix storybook",
     "storybook:build": "npm run --prefix storybook build",
-    "storybook:a11y-test": "npm run --prefix storybook storybook-a11y-test"
+    "storybook:a11y-test": "npm run --prefix storybook storybook-a11y-test",
+    "install:all": "npm install && npm install --prefix storybook && npm install --prefix generator-dialtone-vue"
   },
   "dependencies": {
     "@linusborg/vue-simple-portal": "^0.1.5",


### PR DESCRIPTION
Added a new script to install all dependencies since there are actually 3:

- main project
- storybook
- dialtone-vue yeoman generator

This should prevent confusion about what needs to be installed.