### PR TITLE
fix(vue3): contact info avatar display blank image

### DIFF
--- a/recipes/list_items/contact_info/contact_info.vue
+++ b/recipes/list_items/contact_info/contact_info.vue
@@ -14,16 +14,19 @@
           v-if="avatarSrc"
           kind="default"
           size="lg"
-          :src="avatarSrc"
-          :alt="avatarInitials"
           avatar-class="d-bar2"
-        />
+        >
+          <img
+            data-qa="dt-contact-avatar"
+            :src="avatarSrc"
+            :alt="avatarInitials"
+          >
+        </dt-avatar>
         <dt-avatar
           v-else-if="avatarInitials"
           kind="initials"
           size="lg"
           :color="avatarColor"
-          :alt="avatarInitials"
         >
           {{ avatarInitials }}
         </dt-avatar>


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

This pull request fixes a issue that contact info avatar display blank image:
![Screen Shot 2022-05-04 at 2 33 45 PM](https://user-images.githubusercontent.com/61763780/166829553-103f9872-36a3-46b2-a7a4-f92a6193214d.png)


## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [ ] I have updated library exports
- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [x] All tests are passing
- [x] All linters are passing
- [x] No accessibility issues reported
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation

