### PR TITLE
fix(vue3): anchor disabled in popover

### DIFF
--- a/.esplint.rec.json
+++ b/.esplint.rec.json
@@ -11,6 +11,9 @@
     "components/input/input.vue": {
       "max-lines": 1
     },
+    "components/popover/popover.vue": {
+      "complexity": 1
+    },
     "components/skeleton/skeleton-paragraph.vue": {
       "complexity": 1
     },

--- a/components/popover/popover.test.js
+++ b/components/popover/popover.test.js
@@ -217,6 +217,22 @@ describe('Dialtone Vue Popover tests', function () {
           assert.isFalse(popoverWindow.isVisible());
         });
       });
+
+      describe('When anchor is clicked but it\'s disabled', function () {
+        beforeEach(async function () {
+          button.element.disabled = 'disabled';
+          await button.trigger('click');
+          _setChildWrappers();
+        });
+
+        afterEach(function () {
+          button.element.disabled = undefined;
+        });
+
+        it('should not open the popover', function () {
+          assert.isFalse(popoverWindow.isVisible());
+        });
+      });
     });
 
     describe('When open prop is unset (default behaviour)', function () {

--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -537,7 +537,10 @@ export default {
       // Only use default toggle behaviour if the user has not set the open prop.
       // Check that the anchor element specifically was clicked.
       if (this.open === null || this.open === undefined) {
-        if (!this.anchorEl.contains(e.target) && !this.anchorEl.isEqualNode(e.target)) return;
+        if ((!this.anchorEl.contains(e.target) && !this.anchorEl.isEqualNode(e.target)) || this.anchorEl?.disabled) {
+          return;
+        }
+
         this.toggleOpen();
       }
     },


### PR DESCRIPTION
# fix: anchor disabled in popover

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Add validation to not open popover if the anchor is disabled when using the default toggle open.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [ ] I have updated library exports
- [x] I have reviewed my changes
- [x] I have added tests
- [ ] I have added all relevant documentation
- [x] All tests are passing
- [x] All linters are passing
- [ ] No accessibility issues reported
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
