### PR TITLE
fix: add main back to package.json, clean before test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Vue component library for Dialtone components",
   "scripts": {
     "build": "vue-cli-service build --target lib --name dialtone-vue index.js",
+    "clean": "rm -rf ./dist",
+    "pretest": "npm run clean",
     "lint": "run-s lint:code lint:docs",
     "build:wc": "vue-cli-service build --target wc-async --name dialtone-vue 'components/**/*[!.story]*.vue'",
     "lint-staged:code": "eslint --fix",
@@ -24,6 +26,7 @@
   "files": [
     "dist/*.js"
   ],
+  "main": "./dist/dialtone-vue.common.js",
   "dependencies": {
     "@linusborg/vue-simple-portal": "^0.1.5",
     "tippy.js": "^6.3.7"


### PR DESCRIPTION
- Add main property back in
- Clean before testing as it seems to always use the output dist file if it exists. This is problematic if the dist is stale.