### PR TITLE
fix(avatar): default slot content

### DIFF
--- a/components/avatar/avatar.vue
+++ b/components/avatar/avatar.vue
@@ -93,9 +93,9 @@ export default {
     },
 
     setKind (element) {
-      if (this.isSvgType(element)) this.kind = 'icon';
-      if (this.isImageType(element)) this.kind = 'image';
-      if (this.isInitialsType(element)) this.kind = 'initials';
+      if (this.isSvgType(element)) { this.kind = 'icon'; return; }
+      if (this.isImageType(element)) { this.kind = 'image'; return; }
+      this.kind = 'initials';
     },
 
     isSvgType (element) {
@@ -104,10 +104,6 @@ export default {
 
     isImageType (element) {
       return element?.tagName?.toUpperCase() === 'IMG';
-    },
-
-    isInitialsType (element) {
-      return element?.nodeType === Node.TEXT_NODE;
     },
 
     validateImageAttrsPresence () {


### PR DESCRIPTION
# Remove validation for default slot

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

The default slot could only accept img, svg, or raw text. Validation is removed and now any html can be provided, only `<img />` and `<svg />` elements at the root level will make the avatar `icon` or `image` type. Anything else will be considered `initials` type.

## :pencil: Checklist

- [x] I have reviewed my changes

## :camera: Screenshots / GIFs

<img width="573" alt="image" src="https://user-images.githubusercontent.com/33143001/178061746-4b40b6b8-6a76-4642-a810-40da476b35ae.png">
