### PR TITLE
fix(dropdown): dt-570 initial focus

### DIFF
--- a/components/dropdown/dropdown.vue
+++ b/components/dropdown/dropdown.vue
@@ -4,7 +4,7 @@
     :content-width="contentWidth"
     :open="open"
     :placement="placement"
-    initial-focus-element="first"
+    :initial-focus-element="openedWithKeyboard ? 'first' : 'dialog'"
     :fallback-placements="fallbackPlacements"
     padding="none"
     role="menu"

--- a/dialtone-vue.code-workspace
+++ b/dialtone-vue.code-workspace
@@ -55,14 +55,14 @@
     "version": "0.2.0",
     "configurations": [
       {
-        "type": "pwa-chrome",
+        "type": "chrome",
         "request": "launch",
         "name": "Debug Local JS (storybook)",
-        "url": "http://localhost:9011",
+        "url": "http://localhost:9010",
         "webRoot": "${workspaceFolder}",
         "smartStep": true,
         "sourceMapPathOverrides": {
-          "webpack:///../*": "${webRoot}/*"
+          "webpack://*": "${webRoot}/*"
         }
       },
       {


### PR DESCRIPTION
https://dialpad.atlassian.net/browse/DT-570

Fixes the issue where initial focus is on the first item when opening via mouse when navigationType = 'tab'. This should only happen when opening via keyboard