### PR TITLE
feat(combobox multi-select): expose closeComboboxList - vue3 

### DIFF
--- a/recipes/comboboxes/combobox_multi_select/combobox_multi_select.mdx
+++ b/recipes/comboboxes/combobox_multi_select/combobox_multi_select.mdx
@@ -71,6 +71,17 @@ import { DtRecipeComboboxMultiSelect } from '@dialpad/dialtone-vue';
 </dt-recipe-combobox-multi-select>
 ```
 
+When not passing `showList` and `hasSuggestionList` is `true`,
+to close the list with the `select` event,
+use the `closeComboboxList` method:
+
+```jsx
+methods: {
+  onSelect (i) {
+    this.$refs.comboboxMultiSelect.closeComboboxList();
+  },
+}
+
 ### With Max Selected Validation
 
 Adds validation for max selection. Make sure to provide the following props:

--- a/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -280,11 +280,20 @@ export default {
       return {
         input: event => {
           this.$emit('input', event);
+          if (this.hasSuggestionList) {
+            this.showComboboxList();
+          }
         },
 
         keyup: event => {
           this.onInputKeyup(event);
           this.$emit('keyup', event);
+        },
+
+        click: event => {
+          if (this.hasSuggestionList) {
+            this.showComboboxList();
+          }
         },
       };
     },
@@ -337,6 +346,16 @@ export default {
     onComboboxSelect (i) {
       this.value = '';
       this.$emit('select', i);
+    },
+
+    showComboboxList () {
+      if (this.showList != null) { return; }
+      this.$refs.comboboxWithPopover.showComboboxList();
+    },
+
+    closeComboboxList () {
+      if (this.showList != null) { return; }
+      this.$refs.comboboxWithPopover.closeComboboxList();
     },
 
     getChipButtons () {
@@ -393,13 +412,13 @@ export default {
     moveFromInputToChip () {
       this.getLastChipButton().focus();
       this.$refs.input.blur();
-      this.$refs.comboboxWithPopover.closeComboboxList();
+      this.closeComboboxList();
     },
 
     moveFromChipToInput () {
       this.getLastChipButton().blur();
       this.$refs.input.focus();
-      this.$refs.comboboxWithPopover.showComboboxList();
+      this.showComboboxList();
     },
 
     navigateBetweenChips (target, toLeft) {
@@ -410,7 +429,7 @@ export default {
       }
       this.getChipButtons()[from].blur();
       this.getChipButtons()[to].focus();
-      this.$refs.comboboxWithPopover.closeComboboxList();
+      this.closeComboboxList();
     },
 
     setChipsTopPosition () {


### PR DESCRIPTION
# JIRA: https://dialpad.atlassian.net/browse/DT-578

 Multi-select disposition project needs the list to be closed when a selection is made. We need to expose `closeComboboxList` function. The list should be opened again with a click or any input. 

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

