### PR TITLE
fix: loading, empty state order and remove emptyStateMessage value-vue3

### DIFF
--- a/components/combobox/combobox.stories.js
+++ b/components/combobox/combobox.stories.js
@@ -11,6 +11,7 @@ export const argsData = {
   onHighlight: action('highlight'),
   onSelect: action('select'),
   onOpened: action('opened'),
+  emptyStateMessage: 'No matches found.',
 };
 
 export const argTypesData = {

--- a/components/combobox/combobox.vue
+++ b/components/combobox/combobox.vue
@@ -140,7 +140,7 @@ export default {
      */
     emptyStateMessage: {
       type: String,
-      default: 'No matches found.',
+      default: '',
     },
   },
 

--- a/recipes/comboboxes/combobox_with_popover/combobox_with_popover.stories.js
+++ b/recipes/comboboxes/combobox_with_popover/combobox_with_popover.stories.js
@@ -12,6 +12,7 @@ export const argsData = {
   onHighlight: action('highlight'),
   onSelect: action('select'),
   onOpened: action('opened'),
+  emptyStateMessage: 'No matches found.',
 };
 
 export const argTypesData = {

--- a/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue
+++ b/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue
@@ -259,7 +259,7 @@ export default {
      */
     emptyStateMessage: {
       type: String,
-      default: 'No matches found.',
+      default: '',
     },
   },
 


### PR DESCRIPTION
# Vue 3 version of: https://github.com/dialpad/dialtone-vue/pull/428

This contains only the emptyStateMessage change as the loading and empty state order where OK in Vue 3 version.