### PR TITLE
feat(dropdown): add support to headings and separator

### DIFF
--- a/components/dropdown/dropdown.vue
+++ b/components/dropdown/dropdown.vue
@@ -253,7 +253,7 @@ export default {
     onMouseHighlight (e) {
       const liElement = e.target.closest('li');
 
-      if (liElement && this.highlightId !== liElement.id) {
+      if (liElement && liElement.role && this.highlightId !== liElement.id) {
         this.setHighlightId(liElement.id);
         liElement.focus();
       }

--- a/components/dropdown/dropdown_list.vue
+++ b/components/dropdown/dropdown_list.vue
@@ -1,0 +1,47 @@
+<template>
+  <li>
+    <div
+      v-if="heading"
+      class="dt-dropdown-list--header d-fs12 d-fc-black-400 d-fw-bold d-lh4 d-py4 d-px12 d-d-flex d-ai-center"
+    >
+      <span>{{ heading }}</span>
+    </div>
+    <!-- eslint-disable-next-line vuejs-accessibility/mouse-events-have-key-events -->
+    <ul
+      :class="['d-ps-relative', 'd-px0', listClass]"
+      data-qa="dt-dropdown-list-wrapper"
+    >
+      <!-- @slot Slot for the list component -->
+      <slot
+        :close="close"
+      />
+    </ul>
+  </li>
+</template>
+
+<script>
+export default {
+  name: 'DtDropdownList',
+
+  props: {
+    /**
+     * List's heading.
+     */
+    heading: {
+      type: String,
+      default: '',
+    },
+
+    /**
+     * Additional class for the wrapper list element.
+     */
+    listClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/components/dropdown/dropdown_separator.vue
+++ b/components/dropdown/dropdown_separator.vue
@@ -1,0 +1,19 @@
+<template>
+  <li
+    aria-hidden="true"
+    class="dt-list-separator d-bgc-black-075 d-my8"
+  />
+</template>
+
+<script>
+export default {
+  name: 'DtDropdownSeparator',
+};
+</script>
+
+<style lang="less">
+.dt-list-separator {
+  height: 1px;
+  list-style: none;
+}
+</style>

--- a/components/dropdown/dropdown_variants.story.vue
+++ b/components/dropdown/dropdown_variants.story.vue
@@ -31,11 +31,143 @@
         </dt-list-item>
       </template>
     </dt-dropdown>
+
+    <dt-dropdown
+      :open="open"
+      class="d-mr8"
+      :placement="placement"
+      :fallback-placements="fallbackPlacements"
+      :content-width="contentWidth"
+      :padding="padding"
+      :modal="modal"
+      :max-height="maxHeight"
+      :max-width="maxWidth"
+      :navigation-type="navigationType"
+      @highlight="onHighlight"
+      @opened="onOpened"
+    >
+      <template
+        slot="anchor"
+        slot-scope="{ attrs }"
+      >
+        <div
+          v-if="anchor"
+          v-html="anchor"
+        />
+        <dt-button
+          v-else
+          v-bind="attrs"
+        >
+          with sections
+        </dt-button>
+      </template>
+      <template
+        slot="list"
+        slot-scope="{ close }"
+      >
+        <dt-dropdown-list
+          :list-class="listClass"
+        >
+          <dt-list-item
+            role="menuitem"
+            :navigation-type="navigationType"
+            @click="close"
+          >
+            Menu item 1
+          </dt-list-item>
+          <dt-list-item
+            role="menuitem"
+            :navigation-type="navigationType"
+            @click="close"
+          >
+            Menu Item 2
+          </dt-list-item>
+        </dt-dropdown-list>
+        <dt-dropdown-separator />
+        <dt-list-item
+          role="menuitem"
+          :navigation-type="navigationType"
+          @click="close"
+        >
+          Menu Item 3
+        </dt-list-item>
+      </template>
+    </dt-dropdown>
+
+    <dt-dropdown
+      :open="open"
+      :placement="placement"
+      :fallback-placements="fallbackPlacements"
+      :content-width="contentWidth"
+      :padding="padding"
+      :modal="modal"
+      :max-height="maxHeight"
+      :max-width="maxWidth"
+      :navigation-type="navigationType"
+      @highlight="onHighlight"
+      @opened="onOpened"
+    >
+      <template
+        slot="anchor"
+        slot-scope="{ attrs }"
+      >
+        <div
+          v-if="anchor"
+          v-html="anchor"
+        />
+        <dt-button
+          v-else
+          v-bind="attrs"
+        >
+          with sections and headings
+        </dt-button>
+      </template>
+      <template
+        slot="list"
+        slot-scope="{ close }"
+      >
+        <dt-dropdown-list
+          :list-class="listClass"
+          heading="Menu Heading A"
+        >
+          <dt-list-item
+            role="menuitem"
+            :navigation-type="navigationType"
+            @click="close"
+          >
+            Menu Item 1
+          </dt-list-item>
+          <dt-dropdown-separator />
+          <dt-list-item
+            role="menuitem"
+            :navigation-type="navigationType"
+            @click="close"
+          >
+            Menu Item 2
+          </dt-list-item>
+        </dt-dropdown-list>
+        <dt-dropdown-separator />
+        <dt-dropdown-list
+          :list-class="listClass"
+          heading="Menu Heading B"
+        >
+          <dt-list-item
+            role="menuitem"
+            :navigation-type="navigationType"
+            @click="close"
+          >
+            Menu Item 3
+          </dt-list-item>
+        </dt-dropdown-list>
+      </template>
+    </dt-dropdown>
   </div>
 </template>
 
 <script>
 import DtDropdown from './dropdown';
+import DtDropdownList from './dropdown_list';
+import DtDropdownSeparator from './dropdown_separator';
 import { DtListItem } from '../list_item';
 import { DtButton } from '../button';
 import { DROPDOWN_STORY_ITEMS } from './dropdown_story_constants';
@@ -43,7 +175,7 @@ import { DROPDOWN_STORY_ITEMS } from './dropdown_story_constants';
 export default {
   name: 'DtDropdownVariants',
 
-  components: { DtDropdown, DtListItem, DtButton },
+  components: { DtDropdown, DtListItem, DtButton, DtDropdownList, DtDropdownSeparator },
 
   data () {
     return {


### PR DESCRIPTION
# Hackathon Project > Right click contextual menu

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added support of headings and separators in the dropdown component.

https://dialpad.atlassian.net/wiki/spaces/EPD/pages/447545345/Right+Click+Contextual+Menu+Hackathon+Project+TL+DR

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [ ] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

https://user-images.githubusercontent.com/83774467/184994344-a2e7e2a9-4d90-458a-a9da-168c0865e3d2.mp4

## :link: Sources

<!--- Add any links to external reference material -->
