### PR TITLE
fix(emoji): fixed incorrectly mapped unicode keys

### DIFF
--- a/common/emoji.js
+++ b/common/emoji.js
@@ -136,7 +136,8 @@ export function shortcodeToEmojiData (shortcode) {
 
 // Takes in an emoji unicode character(s) and converts it to an emoji string in the format the emoji data object expects
 // as a key. There can be multiple unicode characters in an emoji to denote the emoji itself, skin tone, gender
-// and such.
+// and such. Note that this function does NOT return variation selectors (fe0f) or zero width joiners (200d), as these
+// are not included as part of the key in the emoji.json.
 //
 // Example:
 // return value for smile emoji (no skin tone): 1f600
@@ -144,6 +145,10 @@ export function shortcodeToEmojiData (shortcode) {
 export function unicodeToString (emoji) {
   let key = '';
   for (const codePoint of emoji) {
+    const codepoint = codePoint.codePointAt(0).toString(16);
+
+    // skip 200d and fe0f as these are not included in emoji_strategy.json keys
+    if (['200d', 'fe0f'].includes(codepoint)) continue;
     if (key !== '') { key = key + '-'; }
     key = key + codePoint.codePointAt(0).toString(16);
   }


### PR DESCRIPTION
# fix(emoji): fixed incorrectly mapped unicode keys

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

When using a unicode emoji as the code in the emoji component, many emojis were incorrectly mapped. This is because the key in the emoji.json file does not include the special unicode characters 'fe0f' and '200d' which are used as "joiners" to create alternate emojis. Removed these from our unicodeToString function and it fixed the issue. Noticed this while working on hackathon project.

## :crystal_ball: Next Steps

Update in DPM

## :link: Sources

https://emojipedia.org/zero-width-joiner/
https://emojipedia.org/emoji/%EF%B8%8F/
