### PR TITLE
fix(contact-info): add a new slot for right hand header qualifier information

### DIFF
--- a/.esplint.rec.json
+++ b/.esplint.rec.json
@@ -8,27 +8,6 @@
     "common/mixins/modal.js": {
       "complexity": 1
     },
-    "components/banner/banner.vue": {
-      "vue/no-deprecated-dollar-listeners-api": 3
-    },
-    "components/button/button.vue": {
-      "vue/no-deprecated-dollar-listeners-api": 2
-    },
-    "components/chip/chip.vue": {
-      "vue/no-deprecated-dollar-listeners-api": 1
-    },
-    "components/collapsible/collapsible.vue": {
-      "vue/no-deprecated-dollar-listeners-api": 2
-    },
-    "components/collapsible/collapsible_lazy_show.vue": {
-      "vue/no-deprecated-dollar-listeners-api": 2
-    },
-    "components/collapsible/transition_collapse_height.vue": {
-      "vue/no-deprecated-dollar-listeners-api": 1
-    },
-    "components/dropdown/dropdown.vue": {
-      "vue/no-deprecated-dollar-listeners-api": 1
-    },
     "components/input/input.vue": {
       "max-lines": 1
     },
@@ -38,17 +17,7 @@
     "components/skeleton/skeleton-paragraph.vue": {
       "complexity": 1
     },
-    "components/toast/toast.vue": {
-      "vue/no-deprecated-dollar-listeners-api": 2
-    },
-    "components/tooltip/tooltip.vue": {
-      "vue/no-deprecated-destroyed-lifecycle": 1
-    },
-    "recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue": {
-      "vue/no-deprecated-dollar-listeners-api": 1
-    },
     "recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue": {
-      "vue/no-deprecated-dollar-listeners-api": 2,
       "max-lines": 1
     }
   }

--- a/recipes/list_items/contact_info/contact_info.mdx
+++ b/recipes/list_items/contact_info/contact_info.mdx
@@ -9,9 +9,12 @@ import { Canvas, Story, Subtitle, ArgsTable, PRIMARY_STORY } from '@storybook/ad
 ## Base Style
 
 The contact information component has 4 slots that can be used for the most common use cases,
-**header**, **subtitle**, **right** and **bottom** slot.
+**header**, **header-right-qualifier**, **subtitle**, **right** and **bottom** slot.
 
 The **header** slot can be used to display html content or Vue component at header area.
+
+The **header-right-qualifier** slot is used as an alternate to the header slot to display qualifier (or additional)
+html content or Vue component. It's used to display the header with additional info. such as call info, call times etc.
 
 The **subtitle** slot can be used to display content below the header slot. The slot has smaller
 text size and lighter color than default slot.
@@ -269,6 +272,46 @@ import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';
     >
       Connect to a record
     </dt-button>
+  </template>
+</dt-recipe-contact-info>
+```
+
+### Contact with items in right header qualifier info
+
+```html
+<dt-recipe-contact-info
+  :avatar-initials="avatarInitials"
+  :avatar-color="avatarColor"
+>
+  <template #header-right-qualifier>
+    <div class="d-d-flex d-ai-center">
+      <div class="d-fw-bold d-fs16">
+        Natalie Woods
+      </div>
+      <div class="d-d-flex d-jc-flex-end d-ml6">
+        <dt-avatar
+          size="sm"
+          class="d-bgc-transparent d-svg--size14 d-as-center d-mr6"
+        >
+          <icon-info />
+        </dt-avatar>
+        <dt-chip
+          :interactive="false"
+          :hide-close="true"
+          size="xs"
+        >
+          <template #icon>
+            <icon-time />
+          </template>
+          <template>
+            0.13
+          </template>
+        </dt-chip>
+      </div>
+    </div>
+  </template>
+  <template #subtitle>
+    +1 (222) 123-4567
   </template>
 </dt-recipe-contact-info>
 ```

--- a/recipes/list_items/contact_info/contact_info.stories.js
+++ b/recipes/list_items/contact_info/contact_info.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { action } from '@storybook/addon-actions';
 import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import DtRecipeContactInfo from './contact_info';
@@ -42,6 +43,17 @@ export const argTypesData = {
   // Slots
   header: {
     description: 'Slot for header information',
+    control: 'text',
+    table: {
+      category: 'slots',
+      type: {
+        summary: 'VNode',
+      },
+    },
+  },
+
+  'header-right-qualifier': {
+    description: 'Slot for header with right hand side qualifier information. Alternate to header.',
     control: 'text',
     table: {
       category: 'slots',
@@ -138,6 +150,26 @@ Default.args = {
     Aerolabs Support
   </div>
 </div>`,
+  'header-right-qualifier': `<div class="d-d-flex d-ai-center">
+  <div class="d-fw-bold d-fs16">
+    Natalie Woods
+  </div>
+  <div class="d-d-flex d-jc-flex-end d-ml6">
+    <dt-chip
+      :interactive="false"
+      :hide-close="true"
+      size="xs"
+    >
+      <template #icon>
+        <icon-time />
+      </template>
+      <template>
+        0.13
+      </template>
+    </dt-chip>
+  </div>
+</div>
+ `,
 };
 
 Default.parameters = {
@@ -297,6 +329,44 @@ Variants.parameters = {
         <dt-button link @click.stop="onConnectToARecord">Connect to a record</dt-button>
       </template>
     </dt-recipe-contact-info>
+  </div>
+  <div class="d-m32">
+    <p class="d-my16 d-fs14 d-fw-bold">Contact with items in right header qualifier info</p>
+    <dt-recipe-contact-info
+      :avatar-initials="avatarInitials"
+      :avatar-color="avatarColor"
+     >
+    <template #header-right-qualifier>
+      <div class="d-d-flex d-ai-center">
+        <div class="d-fw-bold d-fs16">
+          Natalie Woods
+        </div>
+        <div class="d-d-flex d-jc-flex-end d-ml6">
+          <dt-avatar
+            size="sm"
+            class="d-bgc-transparent d-svg--size14 d-as-center d-mr6"
+          >
+            <icon-info />
+          </dt-avatar>
+          <dt-chip
+            :interactive="false"
+            :hide-close="true"
+            size="xs"
+          >
+            <template #icon>
+              <icon-time />
+            </template>
+            <template>
+              0.13
+            </template>
+          </dt-chip>
+        </div>
+      </div>
+    </template>
+    <template #subtitle>
+      +1 (222) 123-4567
+    </template>
+   </dt-recipe-contact-info>
   </div>
 </div>
 `,

--- a/recipes/list_items/contact_info/contact_info.test.js
+++ b/recipes/list_items/contact_info/contact_info.test.js
@@ -70,6 +70,7 @@ describe('DtRecipeContactInfo Tests', function () {
     attrs = {};
     slots = baseSlotsData;
     provide = {};
+    wrapper.destroy();
   });
 
   describe('Presentation Tests', function () {
@@ -143,6 +144,25 @@ describe('DtRecipeContactInfo Tests', function () {
       });
       it('Should not display user status indicator', function () {
         assert.isFalse(wrapper.find('[data-qa="contact-info-user-status"]').exists());
+      });
+    });
+
+    describe('When header right qualifier is used', function () {
+      beforeEach(async function () {
+        slots = {
+          headerRightQualifier: 'Natalie Woods',
+          subtitle: '+1 (222) 123-4567',
+        };
+        _setWrappers();
+        await wrapper.vm.$nextTick();
+      });
+
+      it('Should display header with right qualifier info', function () {
+        assert.exists(wrapper.vm.$slots.headerRightQualifier);
+        assert.exists(wrapper.vm.$slots.subtitle);
+        assert.notExists(wrapper.vm.$slots.header);
+        assert.strictEqual(wrapper.vm.$slots.subtitle['0'].text, '+1 (222) 123-4567');
+        assert.strictEqual(wrapper.vm.$slots.headerRightQualifier['0'].text, 'Natalie Woods');
       });
     });
   });

--- a/recipes/list_items/contact_info/contact_info.vue
+++ b/recipes/list_items/contact_info/contact_info.vue
@@ -50,8 +50,16 @@
     </template>
     <template #default>
       <div data-qa="contact-info-header">
+        <!-- @slot Slot for header with right qualifier information -->
+        <slot
+          v-if="showHeaderRightQualifier"
+          name="header-right-qualifier"
+        />
         <!-- @slot Slot for header information -->
-        <slot name="header" />
+        <slot
+          v-else
+          name="header"
+        />
       </div>
     </template>
 
@@ -160,6 +168,10 @@ export default {
   computed: {
     showUserStatus () {
       return this.userStatusColor !== 'none';
+    },
+
+    showHeaderRightQualifier () {
+      return !!this.$scopedSlots['header-right-qualifier'];
     },
   },
 };

--- a/recipes/list_items/contact_info/contact_info_variants.story.vue
+++ b/recipes/list_items/contact_info/contact_info_variants.story.vue
@@ -185,18 +185,72 @@
         </template>
       </dt-recipe-contact-info>
     </div>
+    <div class="d-m32">
+      <p class="d-my16 d-fs14 d-fw-bold">
+        Contact with items in header with right qualifier info
+      </p>
+      <dt-recipe-contact-info
+        :avatar-initials="avatarInitials"
+        :avatar-color="avatarColor"
+      >
+        <template #header-right-qualifier>
+          <div class="d-d-flex d-ai-center">
+            <div class="d-fw-bold d-fs16">
+              Natalie Woods
+            </div>
+            <div class="d-d-flex d-jc-flex-end d-ml6">
+              <dt-avatar
+                size="sm"
+                class="d-bgc-transparent d-svg--size14 d-as-center d-mr6"
+              >
+                <icon-info />
+              </dt-avatar>
+              <dt-chip
+                :interactive="false"
+                :hide-close="true"
+                size="xs"
+              >
+                <template #icon>
+                  <icon-time />
+                </template>
+                <template>
+                  0.13
+                </template>
+              </dt-chip>
+            </div>
+          </div>
+        </template>
+        <template #subtitle>
+          +1 (415) 123-4567
+        </template>
+      </dt-recipe-contact-info>
+    </div>
   </div>
 </template>
 
 <script>
 import DtRecipeContactInfo from './contact_info';
+import DtAvatar from '@/components/avatar/avatar';
 import DtButton from '@/components/button/button';
+import DtChip from '@/components/chip/chip';
 import IconChat from '@dialpad/dialtone/lib/dist/vue/icons/IconChat.vue';
 import IconCheckboxFilled from '@dialpad/dialtone/lib/dist/vue/icons/IconCheckboxFilled';
+import IconInfo from '@dialpad/dialtone/lib/dist/vue/icons/IconInfo';
 import IconMenuHorizontal from '@dialpad/dialtone/lib/dist/vue/icons/IconMenuHorizontal.vue';
+import IconTime from '@dialpad/dialtone/lib/dist/vue/icons/IconTime';
 
 export default {
   name: 'DtRecipeContactInfoVariants',
-  components: { IconChat, IconCheckboxFilled, IconMenuHorizontal, DtButton, DtRecipeContactInfo },
+  components: {
+    IconChat,
+    IconCheckboxFilled,
+    IconInfo,
+    IconMenuHorizontal,
+    IconTime,
+    DtAvatar,
+    DtButton,
+    DtChip,
+    DtRecipeContactInfo,
+  },
 };
 </script>


### PR DESCRIPTION
# PR Title

Add a new slot for right hand side header qualifier information.

## :hammer_and_wrench: Type Of Change

- [X] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Add a new slot for right hand side header qualifier information. Updates based on the new design for callbar. 

## :bulb: Context

This can be used as an alternate to the header slot. It's useful when we want to display additional info such as call time, info icon etc.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [X] I have reviewed my changes
- [X] I have added tests
- [X] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [X] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

N/A

## :camera: Screenshots / GIFs

<img width="393" alt="Screen Shot 2022-09-08 at 9 04 43 AM" src="https://user-images.githubusercontent.com/70488122/189183447-a3d943af-e133-47f8-a2c7-bdb665172769.png">

## :link: Sources

N/A