### PR TITLE
build: add GHA to update dialtone7 after staging PR merge

### DIFF
--- a/.github/workflows/update-dialtone7.yml
+++ b/.github/workflows/update-dialtone7.yml
@@ -1,0 +1,29 @@
+name: Update Dialtone 7 branch
+
+on:
+  push:
+    branches:
+      - staging
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  update_version_7:
+    runs-on: ubuntu-latest
+    name: Cherry pick into dialtone7
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Cherry pick
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.1
+        with:
+          branch: dialtone7
+          labels: |
+            cherry-pick
+          reviewers: |
+            braddialpad
+            josedialpad
+            juliodialpad


### PR DESCRIPTION
# Add GHA to update dialtone7 branch after merging PR into staging

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added a GHA to cherry-pick commits from last PR into version7 branch.

## :bulb: Context

We have many branches to maintain updated now that we are migrating to dialtone7, this will help us to keep branches updated.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root