### PR TITLE
feat: dp-57015 grouped chip recipe

### DIFF
--- a/components/chip/chip.vue
+++ b/components/chip/chip.vue
@@ -1,6 +1,7 @@
 <template>
   <span class="d-chip">
     <component
+      v-bind="$attrs"
       :is="interactive ? 'button' : 'span'"
       :id="id"
       :type="interactive && 'button'"
@@ -53,7 +54,10 @@
 <script>
 import IconClose from '@dialpad/dialtone/lib/dist/vue/icons/IconClose';
 import { DtButton } from '../button';
-import { CHIP_CLOSE_BUTTON_SIZE_MODIFIERS, CHIP_SIZE_MODIFIERS } from './chip_constants';
+import {
+  CHIP_CLOSE_BUTTON_SIZE_MODIFIERS,
+  CHIP_SIZE_MODIFIERS,
+} from './chip_constants';
 import { getUniqueString } from '@/common/utils';
 
 /**
@@ -69,6 +73,8 @@ export default {
     IconClose,
     DtButton,
   },
+
+  inheritAttrs: false,
 
   props: {
     /**
@@ -190,7 +196,7 @@ export default {
   methods: {
     chipClasses () {
       return [
-        'd-chip__label',
+        this.$attrs['grouped-chip'] ? 'd-chip' : 'd-chip__label',
         CHIP_SIZE_MODIFIERS[this.size],
       ];
     },

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ export * from './recipes/buttons/callbar_button_with_popover';
 export * from './recipes/list_items/contact_info';
 export * from './recipes/notices/top_banner_info';
 export * from './recipes/cards/ivr_node';
+export * from './recipes/chips/grouped_chip';
 
 // Mixins
 export * from './common/mixins';

--- a/recipes/chips/grouped_chip/grouped_chip.mdx
+++ b/recipes/chips/grouped_chip/grouped_chip.mdx
@@ -1,0 +1,65 @@
+import { Canvas, Story, Subtitle, ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
+import DtRecipeGroupedChip from './grouped_chip';
+
+# DtRecipeGroupedChip
+
+<Subtitle>
+  Grouped Chip is a format used to present related information such as callbar timers.
+</Subtitle>
+
+## Base Style
+
+Grouped chip component has related info split in two combination chips. Common use cases represented
+are split callbar timers showing call time and hold time on the left hand and right hand side respectively.
+
+This component has 4 slots: **leftIcon**, **leftContent**, **rightIcon** and **rightContent** slot.
+
+**leftIcon** is used to display an icon that best represents the leftContent.
+
+**leftContent** is used to display content and is placed on the left hand side.
+
+**rightIcon** is used to display an icon that best represents the rightContent.
+
+**rightContent** is used to display content and is placed on the right hand side.
+
+<Canvas>
+  <Story id="recipes-chips-grouped-chips--default" />
+</Canvas>
+
+## Slots, Props & Events
+
+<ArgsTable story={PRIMARY_STORY} />
+
+## Usage
+
+### Import
+
+```jsx
+import { DtRecipeGroupedChip } from '@dialpad/dialtone-vue';
+```
+
+### Split Combination Chip showing both left and right hand side content.
+
+```html
+import IconTime from '@dialpad/dialtone/lib/dist/vue/icons/IconTime';
+import IconPause from '@dialpad/dialtone/lib/dist/vue/icons/IconPause.vue';
+
+<dt-recipe-grouped-chip>
+  <template #leftIcon>
+    <icon-time />
+  </template>
+  <template #leftContent>
+    <div>
+      0.15
+    </div>
+  </template>
+  <template #rightIcon>
+    <icon-pause class="d-svg d-svg--system d-fc-purple-600" />
+  </template>
+  <template #rightContent>
+    <div>
+      0.15
+    </div>
+  </template>
+</dt-recipe-grouped-chip>
+```

--- a/recipes/chips/grouped_chip/grouped_chip.stories.js
+++ b/recipes/chips/grouped_chip/grouped_chip.stories.js
@@ -1,0 +1,106 @@
+import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import DtRecipeGroupedChip from './grouped_chip';
+import DtRecipeGroupedChipMdx from './grouped_chip.mdx';
+import DtRecipeGroupedChipDefaultTemplate from './grouped_chip_default.story.vue';
+
+// Default Prop Values
+export const argsData = {};
+
+export const argTypesData = {
+  // Props
+
+  // Slots
+  leftContent: {
+    control: 'text',
+    description: 'Slot left hand side content. Ex. ongoing call time value',
+    table: {
+      category: 'slots',
+      type: {
+        summary: 'VNode',
+      },
+    },
+  },
+
+  leftIcon: {
+    name: 'leftIcon',
+    description: 'Slot for left hand chip icon',
+    table: {
+      category: 'slots',
+      type: {
+        summary: 'VNode',
+      },
+    },
+    control: {
+      type: 'select',
+      options: getIconNames(),
+    },
+  },
+
+  rightContent: {
+    control: 'text',
+    description: 'Slot right hand side content. Ex. ongoing call hold time value',
+    table: {
+      category: 'slots',
+      type: {
+        summary: 'VNode',
+      },
+    },
+  },
+
+  rightIcon: {
+    name: 'rightIcon',
+    description: 'Slot for right hand chip icon',
+    table: {
+      category: 'slots',
+      type: {
+        summary: 'VNode',
+      },
+    },
+    control: {
+      type: 'select',
+      options: getIconNames(),
+    },
+  },
+};
+
+// Story Collection
+export default {
+  title: 'Recipes/Chips/Grouped Chips',
+  component: DtRecipeGroupedChip,
+  args: argsData,
+  argTypes: argTypesData,
+  excludeStories: /.*Data$/,
+  parameters: {
+    controls: {
+      sort: 'requiredFirst',
+    },
+    docs: {
+      page: DtRecipeGroupedChipMdx,
+    },
+    options: {
+      showPanel: true,
+    },
+  },
+};
+
+// Templates
+const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  DtRecipeGroupedChipDefaultTemplate,
+);
+
+// Stories
+export const Default = DefaultTemplate.bind({});
+Default.args = {
+  leftIcon: 'IconTime',
+  leftContent: `<div>
+    0.13
+</div>`,
+  rightIcon: 'IconPause',
+  rightContent: `<div>
+    0.25
+</div>`,
+};
+
+Default.parameters = {};

--- a/recipes/chips/grouped_chip/grouped_chip.test.js
+++ b/recipes/chips/grouped_chip/grouped_chip.test.js
@@ -1,0 +1,103 @@
+import { assert } from 'chai';
+import { createLocalVue, mount } from '@vue/test-utils';
+import DtRecipeGroupedChip from './grouped_chip.vue';
+import IconTime from '@dialpad/dialtone/lib/dist/vue/icons/IconTime.vue';
+import IconPause from '@dialpad/dialtone/lib/dist/vue/icons/IconPause.vue';
+
+// Constants
+const basePropsData = {};
+const baseSlotsData = {
+  leftIcon: IconTime,
+  leftContent: `<div>0.13</div>`,
+  rightIcon: IconPause,
+  rightContent: `<div>0.33</div>`,
+};
+
+describe('DtRecipeGroupedChip Tests', function () {
+  // Wrappers
+  let wrapper;
+  let rootElement;
+  let leftChipIconElement;
+  let rightChipIconElement;
+  let leftChipContentElement;
+  let rightChipContentElement;
+
+  // Environment
+  let propsData = basePropsData;
+  let attrs = {};
+  let slots = {};
+  let provide = {};
+
+  // Helpers
+  const _setChildWrappers = () => {
+    rootElement = wrapper.find('[data-qa="grouped-chip"]');
+
+    leftChipIconElement = wrapper.find('[data-qa="left-grouped-chip-icon"]');
+    rightChipIconElement = wrapper.find('[data-qa="right-grouped-chip-icon"]');
+
+    leftChipContentElement = wrapper.find('[data-qa="left-grouped-chip-content"]');
+    rightChipContentElement = wrapper.find('[data-qa="right-grouped-chip-content"]');
+  };
+
+  const _setWrappers = () => {
+    wrapper = mount(DtRecipeGroupedChip, {
+      propsData,
+      attrs,
+      slots,
+      provide,
+      localVue: this.localVue,
+    });
+    _setChildWrappers();
+  };
+
+  // Setup
+  before(function () {
+    this.localVue = createLocalVue();
+  });
+
+  // Teardown
+  afterEach(function () {
+    propsData = basePropsData;
+    attrs = {};
+    slots = {};
+    provide = {};
+  });
+
+  describe('Presentation Tests', function () {
+    /*
+     * Test(s) to ensure that the component is correctly rendering
+     */
+
+    describe('Split chip state render', function () {
+      beforeEach(async function () {
+        slots = baseSlotsData;
+        _setWrappers();
+      });
+
+      it('Should render grouped chip component', function () {
+        assert.isTrue(wrapper.exists());
+        assert.isTrue(rootElement.exists());
+      });
+
+      it('Should render left side chip icon element', function () {
+        assert.isTrue(leftChipIconElement.findComponent(IconTime).exists());
+      });
+
+      it('Should render left side chip content', function () {
+        assert.strictEqual(leftChipContentElement.text(), '0.13');
+      });
+
+      it('Should not render right side chip component', function () {
+        assert.isTrue(rightChipIconElement.exists());
+      });
+
+      it('Should render right side chip icon element', function () {
+        assert.isTrue(rightChipIconElement.findComponent(IconPause).exists());
+      });
+
+      it('Should render right side chip content', function () {
+        assert.strictEqual(rightChipContentElement.text(), '0.33');
+      });
+    });
+  });
+});

--- a/recipes/chips/grouped_chip/grouped_chip.vue
+++ b/recipes/chips/grouped_chip/grouped_chip.vue
@@ -1,0 +1,80 @@
+<template>
+  <div data-qa="grouped-chip">
+    <dt-chip
+      :hide-close="true"
+      :interactive="false"
+      content-class="d-fs12"
+      size="xs"
+      :grouped-chip="true"
+      class="d-blr-pill d-bgc-black-050"
+    >
+      <template
+        v-if="$slots.leftIcon"
+        #icon
+      >
+        <!-- @slot Slot for left chip icon information -->
+        <div
+          v-if="$slots.leftIcon"
+          data-qa="left-grouped-chip-icon"
+        >
+          <slot name="leftIcon" />
+        </div>
+      </template>
+      <template #default>
+        <div
+          v-if="$slots.leftContent"
+          data-qa="left-grouped-chip-content"
+        >
+          <!-- @slot Slot for left chip content information -->
+          <slot name="leftContent" />
+        </div>
+      </template>
+    </dt-chip>
+
+    <!-- Right side split chip -->
+    <dt-chip
+      :hide-close="true"
+      :interactive="false"
+      content-class="d-fs12"
+      size="xs"
+      :grouped-chip="true"
+      class="d-brr-pill d-bgc-purple-200 d-mln6"
+    >
+      <template #icon>
+        <div
+          v-if="$slots.rightIcon"
+          data-qa="right-grouped-chip-icon"
+        >
+          <!-- @slot Slot for right chip content information -->
+          <slot name="rightIcon" />
+        </div>
+      </template>
+      <template #default>
+        <div
+          v-if="$slots.rightContent"
+          data-qa="right-grouped-chip-content"
+        >
+          <!-- @slot Slot for right chip content information -->
+          <slot name="rightContent" />
+        </div>
+      </template>
+    </dt-chip>
+  </div>
+</template>
+
+<script>
+import { DtChip } from '@/components/chip';
+
+export default {
+  name: 'DtRecipeGroupedChip',
+
+  components: {
+    DtChip,
+  },
+
+  computed: {},
+};
+</script>
+
+<style lang="less">
+</style>

--- a/recipes/chips/grouped_chip/grouped_chip_default.story.vue
+++ b/recipes/chips/grouped_chip/grouped_chip_default.story.vue
@@ -1,0 +1,41 @@
+<template>
+  <dt-recipe-grouped-chip>
+    <!-- Left hand Chip -->
+    <template
+      v-if="leftIcon"
+      slot="leftIcon"
+    >
+      <component :is="leftIcon" />
+    </template>
+    <template #leftContent>
+      <span v-html="leftContent" />
+    </template>
+    <!-- Right hand Chip -->
+    <template
+      v-if="rightIcon"
+      slot="rightIcon"
+    >
+      <component :is="rightIcon" />
+    </template>
+    <template
+      v-if="rightContent"
+      #rightContent
+    >
+      <span v-html="rightContent" />
+    </template>
+  </dt-recipe-grouped-chip>
+</template>
+
+<script>
+import DtRecipeGroupedChip from './grouped_chip';
+import icon from '@/common/mixins/icon';
+
+export default {
+  name: 'DtRecipeGroupedChipDefault',
+  components: {
+    DtRecipeGroupedChip,
+  },
+
+  mixins: [icon],
+};
+</script>

--- a/recipes/chips/grouped_chip/index.js
+++ b/recipes/chips/grouped_chip/index.js
@@ -1,0 +1,1 @@
+export { default as DtRecipeGroupedChip } from './grouped_chip.vue';


### PR DESCRIPTION
# PR Title

Recipe for split combination chips

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [X] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

New split chip combination recipe to put together relevant info. and actions.

## :bulb: Context

Split chip combination recipe puts together relevant info. and actions. ex. callbar call time and hold time. The right side chip is optional and displayed only when the info is available.

This also modifies the existing chip component to be able to style the pill shapes on left and right sides.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [X] I have reviewed my changes
- [X] I have added tests
- [X] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [X] I have considered the performance impact of my change
- [X] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

N/A

## :camera: Screenshots / GIFs

<img width="916" alt="one" src="https://user-images.githubusercontent.com/70488122/193119074-9b062a55-0dda-4058-b296-d5370a9ec4fe.png">
<img width="928" alt="two" src="https://user-images.githubusercontent.com/70488122/193119082-bbb77b12-59c6-4e78-bb06-b6566ff4f271.png">


## :link: Sources

N/A
