### PR TITLE
docs: improve emoji_text_wrapper - modal documentation

### DIFF
--- a/common/mixins/modal.js
+++ b/common/mixins/modal.js
@@ -3,14 +3,19 @@ const tabbableAttrs = `${focusableAttrs}:not([tabindex="-1"])`;
 const focusableElementsList = `button,[href],input,select,textarea,details,[tabindex]`;
 
 /**
- * this mixin provides the methods to automatically trap tab focus within
+ * This mixin provides the methods to automatically trap tab focus within
  * the component this mixin is on, meaning it is not possible to tab out
- * of the component without dismissing it. Useful for accessibility reasons
- * on things like important actionable alerts. Use focusFirstElement to
- * focus on the first tabbable element within your component, and call
+ * of the component without dismissing it.
+ *
+ * Useful for accessibility reasons on things like important actionable alerts.
+ *
+ * Use focusFirstElement to focus on the first tabbable element within your component, and call
  * focusTrappedTabPress every time tab is pressed to trap tab within this
- * component. Note that focusFirstElement WILL focus elements with tabindex="-1",
+ * component.
+ *
+ * Note that focusFirstElement WILL focus elements with tabindex="-1",
  * however focusTrappedTabPress will not.
+ * @displayName Modal Mixin
  */
 export default {
   methods: {

--- a/components/emoji/emoji.vue
+++ b/components/emoji/emoji.vue
@@ -70,7 +70,7 @@ export default {
     /**
      * Additional class name for the emoji img element.
      * Can accept String, Object, and Array, i.e. has the
-     * same api as Vue's built-in handling of the class attribute.
+     * same API as Vue's built-in handling of the class attribute.
      */
     imgClass: {
       type: [String, Object, Array],
@@ -171,5 +171,3 @@ export default {
   },
 };
 </script>
-
-<!-- TODO: Replace @values with values instead of keys -->

--- a/components/emoji_text_wrapper/emoji_text_wrapper.vue
+++ b/components/emoji_text_wrapper/emoji_text_wrapper.vue
@@ -2,6 +2,10 @@
 import { DtEmoji } from '../emoji';
 import { findEmojis, findShortCodes } from '@/common/emoji';
 
+/**
+ * Wrapper to find and replace shortcodes like :smile: or unicode chars such as 😄 with our custom Emojis implementation.
+ * @see https://dialpad.design/components/emoji_text_wrapper.html
+ */
 export default {
   name: 'DtEmojiTextWrapper',
 
@@ -13,7 +17,7 @@ export default {
 
   props: {
     /**
-     * The type of element to use for the wrapper.
+     * Element type (tag name) to use for the wrapper.
      */
     elementType: {
       type: String,

--- a/components/input/input.vue
+++ b/components/input/input.vue
@@ -59,6 +59,7 @@
           data-qa="dt-input-left-icon-wrapper"
           @focusout="onBlur"
         >
+          <!-- @slot Slot for left icon -->
           <slot name="leftIcon" />
         </span>
         <textarea
@@ -92,6 +93,7 @@
           data-qa="dt-input-right-icon-wrapper"
           @focusout="onBlur"
         >
+          <!-- @slot Slot for right icon -->
           <slot name="rightIcon" />
         </span>
       </div>
@@ -117,7 +119,11 @@ import { DtValidationMessages } from '../validation_messages';
 import { MessagesMixin } from '@/common/mixins/input.js';
 
 /**
+ * An input field is an input control that allows users to enter alphanumeric information.
+ * It can have a range of options and supports single line and multi-line lengths,
+ * as well as varying formats, including numbers, masked passwords, etc.
  * @property {Boolean} placeholder attribute
+ * @see https://dialpad.design/components/input.html
  */
 export default {
   name: 'DtInput',
@@ -138,8 +144,9 @@ export default {
     },
 
     /**
-     * Type of the input, one of `text`, `password`, `email`, `number`, `textarea`.
+     * Type of the input, one of: `text`, `password`, `email`, `number`, `textarea`.
      * When `textarea` a `<textarea>` element will be rendered instead of an `<input>` element.
+     * @values text, password, email, number, textarea.
      */
     type: {
       type: String,
@@ -157,6 +164,7 @@ export default {
 
     /**
      * Disables the input
+     * @values true, false
      */
     disabled: {
       type: Boolean,
@@ -181,6 +189,7 @@ export default {
 
     /**
      * Size of the input, one of `xs`, `sm`, `md`, `lg`, `xl`
+     * @values null, xs, sm, md, lg, xl
      */
     size: {
       type: String,
@@ -191,6 +200,7 @@ export default {
     /**
      * Size of the icon. One of `xs`, `sm`, `md`, `lg`, `xl`. If you do not set this the icon will size relative
      * to the input size
+     * @values null, xs, sm, md, lg, xl
      */
     iconSize: {
       type: String,
@@ -200,8 +210,8 @@ export default {
 
     /**
      * Additional class name for the input element.
-     * Can accept all of String, Object, and Array, i.e. has the
-     * same api as Vue's built-in handling of the class attribute.
+     * Can accept String, Object, and Array, i.e. has the
+     * same API as Vue's built-in handling of the class attribute.
      */
     inputClass: {
       type: [String, Object, Array],
@@ -210,7 +220,7 @@ export default {
 
     /**
      * The current character length that the user has entered into the input.
-     * This will only need to be used if you are using validate.length and
+     * This will only need to be used if you are using `validate.length` and
      * the string contains abnormal characters.
      * For example, an emoji could take up many characters in the input, but should only count as 1 character.
      * If no number is provided, a built-in length calculation will be used for the length validation.
@@ -586,6 +596,3 @@ export default {
   },
 };
 </script>
-
-<style lang="less">
-</style>

--- a/components/input_group/input_group.vue
+++ b/components/input_group/input_group.vue
@@ -27,6 +27,12 @@
 import { InputGroupMixin } from '@/common/mixins/input_group';
 import { DtValidationMessages } from '../validation_messages';
 
+/**
+ * Input Groups are convenience components for a grouping of related inputs.
+ * While each input within the group could be independent, the `v-model` on the group
+ * provides a convenient interface for determining the current state of the group.
+ * @see https://dialpad.design/components/input_group.html
+ */
 export default {
   name: 'DtInputGroup',
 

--- a/components/keyboard_shortcut/keyboard_shortcut.stories.js
+++ b/components/keyboard_shortcut/keyboard_shortcut.stories.js
@@ -8,18 +8,9 @@ import DtKeyboardShortcutVariantsTemplate from './keyboard_shortcut_variants.sto
 export const argTypesData = {
   shortcut: {
     description: `Include any of these tokens in your string to render the corresponding symbol:<br>
-      ${SHORTCUTS_ALIASES_LIST.join(' ')}`,
+      ${SHORTCUTS_ALIASES_LIST.join(', ')}`,
     defaultValue: `{cmd}+Ctrl+X`,
     control: 'text',
-  },
-
-  inverted: {
-    description: 'Applies the inverted styles',
-  },
-
-  screenReaderText: {
-    description: `Text entered here will be read by assistive technology. If null this component
-    will be ignored by AT.`,
   },
 };
 

--- a/components/keyboard_shortcut/keyboard_shortcut.vue
+++ b/components/keyboard_shortcut/keyboard_shortcut.vue
@@ -61,6 +61,10 @@ import {
   SHORTCUTS_ICON_SEPARATOR,
 } from './keyboard_shortcut_constants';
 
+/**
+ * This component displays a visual representation of a keyboard shortcut to the user.
+ * @see https://dialpad.design/components/keyboard_shortcut.html
+ */
 export default {
   name: 'DtKeyboardShortcut',
 
@@ -74,16 +78,27 @@ export default {
   },
 
   props: {
+    /**
+     * If true, applies inverted styles.
+     * @values true, false
+     */
     inverted: {
       type: Boolean,
       default: false,
     },
 
+    /**
+     * Include any of these tokens in your string to render the corresponding symbol:
+     * {cmd} {win} {arrow-right} {arrow-left} {arrow-up} {arrow-down}
+     */
     shortcut: {
       type: String,
       required: true,
     },
 
+    /**
+     * Text entered here will be read by assistive technology. If null this component will be ignored by AT.
+     */
     screenReaderText: {
       type: String,
       default: null,

--- a/components/lazy_show/lazy_show.vue
+++ b/components/lazy_show/lazy_show.vue
@@ -9,12 +9,17 @@
       v-show="show"
       v-on="$listeners"
     >
+      <!-- @slot Slot for main content -->
       <slot v-if="initialized" />
     </div>
   </transition>
 </template>
 
 <script>
+/**
+ * Lazy Show is a utility component that prevents its children from being rendered until the first time it is shown.
+ * @see https://dialpad.design/components/lazy_show.html
+ */
 export default {
   name: 'DtLazyShow',
 
@@ -24,8 +29,12 @@ export default {
   props: {
     /**
      * Whether the child slot is shown.
+     * @values true, false
      */
-    show: Boolean,
+    show: {
+      type: Boolean,
+      default: false,
+    },
 
     /**
      * A valid Vue enter/leave CSS transition name.
@@ -35,6 +44,10 @@ export default {
       default: null,
     },
 
+    /**
+     * Enable/Disable transition animation
+     * @values true, false
+     */
     appear: {
       type: Boolean,
       default: false,

--- a/components/link/link.vue
+++ b/components/link/link.vue
@@ -7,6 +7,7 @@
     data-qa="dt-link"
     v-on="$listeners"
   >
+    <!-- @slot Slot for main content -->
     <slot />
   </a>
 </template>
@@ -15,8 +16,10 @@
 import { LINK_VARIANTS, LINK_KIND_MODIFIERS } from './link_constants.js';
 
 /**
+ * A link is a navigational element that can be found on its own, within other text, or directly following content.
  * @property {String} href attribute
  * @property {String} rel attribute
+ * @see https://dialpad.design/components/link.html
  */
 export default {
   name: 'DtLink',
@@ -24,6 +27,7 @@ export default {
   props: {
     /**
      * Applies the link variant styles
+     * @values null, danger, warning, success, muted, inverted
      */
     kind: {
       type: String,

--- a/components/list_item/list_item.vue
+++ b/components/list_item/list_item.vue
@@ -21,9 +21,11 @@
         v-for="(_, slotName) in $slots"
         #[slotName]
       >
+        <!-- @slot named slots for custom list items -->
         <slot :name="slotName" />
       </template>
     </component>
+    <!-- @slot slot for the main content -->
     <slot v-else />
   </component>
 </template>
@@ -36,6 +38,10 @@ import {
 import DtDefaultListItem from './default_list_item';
 import utils from '@/common/utils';
 
+/**
+ * A list item is an element that can be used to represent individual items in a list.
+ * @see https://dialpad.design/components/list_item.html
+ */
 export default {
   name: 'ListItem',
 
@@ -68,7 +74,7 @@ export default {
     },
 
     /**
-     * The type of element to use for the wrapper.
+     * HTML element type (tag name) of the content wrapper element.
      */
     elementType: {
       type: String,
@@ -77,6 +83,7 @@ export default {
 
     /**
      * The type of child list item to use.
+     * @values default, custom
      */
     type: {
       type: String,
@@ -89,6 +96,7 @@ export default {
      * - "arrow-keys" for items that are navigated with UP/DOWN keys.
      * - "tab" for items that are navigated using the TAB key.
      * - "none" for static items that are not interactive.
+     * @values arrow-keys, tab, none
      */
     navigationType: {
       type: String,

--- a/components/modal/modal.vue
+++ b/components/modal/modal.vue
@@ -112,8 +112,9 @@ import { getUniqueString } from '@/common/utils';
 import DtLazyShow from '../lazy_show/lazy_show';
 
 /**
- * Base Vue component for Dialtone Modal.
- * @displayName DtModal
+ * Modals focus the user’s attention exclusively on one task or piece of information
+ * via a window that sits on top of the page content.
+ * @see https://dialpad.design/components/modal.html
  */
 export default {
   name: 'DtModal',
@@ -128,7 +129,8 @@ export default {
 
   props: {
     /**
-     * A set of props to be passed into the modal's close button. Requires an 'ariaLabel' property.
+     * A set of props to be passed into the modal's close button.
+     * Requires an 'ariaLabel' property.
      */
     closeButtonProps: {
       type: Object,
@@ -153,6 +155,7 @@ export default {
      */
     describedById: {
       type: String,
+      default: '',
     },
 
     /**
@@ -164,7 +167,9 @@ export default {
     },
 
     /**
-     * Whether the modal should be shown.  Parent component can sync on this value to control the modal's visibility.
+     * Whether the modal should be shown.
+     * Parent component can sync on this value to control the modal's visibility.
+     * @values true, false
      */
     show: {
       type: Boolean,
@@ -188,9 +193,8 @@ export default {
     },
 
     /**
-     * The theme of the modal.
-     * @values default or danger
-     * kind - default or danger (https://dialpad.design/components/modal/)
+     * The theme of the modal. kind - default or danger,
+     * @values default, danger
      */
     kind: {
       type: String,
@@ -199,9 +203,8 @@ export default {
     },
 
     /**
-     * The size of the modal.
-     * @values default or full
-     * size - default or full (https://dialpad.design/components/modal/)
+     * The size of the modal. size - default or full,
+     * @values default, full
      */
     size: {
       type: String,
@@ -211,8 +214,8 @@ export default {
 
     /**
      * Additional class name for the root modal element.
-     * Can accept all of String, Object, and Array, i.e. has the
-     * same api as Vue's built-in handling of the class attribute.
+     * Can accept String, Object, and Array, i.e. has the
+     * same API as Vue's built-in handling of the class attribute.
      */
     modalClass: {
       type: [String, Object, Array],
@@ -221,8 +224,8 @@ export default {
 
     /**
      * Additional class name for the dialog element within the modal.
-     * Can accept all of String, Object, and Array, i.e. has the
-     * same api as Vue's built-in handling of the class attribute.
+     * Can accept String, Object, and Array, i.e. has the
+     * same API as Vue's built-in handling of the class attribute.
      */
     dialogClass: {
       type: [String, Object, Array],
@@ -231,8 +234,8 @@ export default {
 
     /**
      * Additional class name for the banner element within the modal.
-     * Can accept all of String, Object, and Array, i.e. has the
-     * same api as Vue's built-in handling of the class attribute.
+     * Can accept String, Object, and Array, i.e. has the
+     * same API as Vue's built-in handling of the class attribute.
      */
     bannerClass: {
       type: [String, Object, Array],
@@ -241,6 +244,7 @@ export default {
 
     /**
      * Hides the close button on the modal
+     * @values true, false
      */
     hideClose: {
       type: Boolean,
@@ -249,6 +253,7 @@ export default {
 
     /**
      * Scrollable modal that allows scroll the modal content keeping the header and footer fixed
+     * @values true, false
      */
     fixedHeaderFooter: {
       type: Boolean,


### PR DESCRIPTION
# Improve emoji_text_wrapper - modal documentation

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [ ] Feature
- [ ] Refactoring
- [x] Documentation

## :book: Description
*Closed the old PR and recreated as I made a mistake creating the other and it had Commit lint errors.*

As this will contain a lot of changes... I'll create multiple PR's so it's easier to review them.

- Improved documentation using [JSDoc] and [Vue styleguidist] formatting.
- Didn't documented `list_section` as I couldn't find any usages or documentation, is that component necessary or should I remove it?.

## :bulb: Context

We are exporting documentation using [vue-docgen-api], we are adding all the missing documentation so all the generated documentation is correct.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [x] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :link: Sources

[JSDoc]
[Vue styleguidist]
[vue-docgen-api]

[JSDoc]: https://jsdoc.app/index.html
[Vue styleguidist]: https://vue-styleguidist.github.io/docs/Documenting.html
[vue-docgen-api]: https://vue-styleguidist.github.io/docs/Docgen.html
