### PR TITLE
feat: dp-57689 add `contentClass` to `DtRecipeCallbarButtonWithPopover`

### DIFF
--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
@@ -67,6 +67,13 @@ export const argTypesData = {
       },
     },
   },
+  contentClass: {
+    table: {
+      type: {
+        summary: ['string', 'array', 'object'],
+      },
+    },
+  },
 
   // Popover slots
   content: {
@@ -193,6 +200,7 @@ Default.args = {
   ariaLabel: 'Button',
   arrowButtonLabel: 'Open popover',
   content: 'Popover body content',
+  contentClass: ['d-h464', 'd-w512'],
   headerContent: 'Header content',
   showCloseButton: true,
   forceShowArrow: false,

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -30,7 +30,7 @@
       :show-close-button="showCloseButton"
       padding="none"
       class="dt-recipe--callbar-button-with-popover--popover-wrapper"
-      dialog-class="d-h464 d-w512 dt-recipe--callbar-button-with-popover--popover"
+      :dialog-class="['dt-recipe--callbar-button-with-popover--popover', contentClass]"
       header-class="d-d-flex d-ai-center d-fw-normal d-px12"
       v-bind="$attrs"
       @opened="onModalIsOpened"
@@ -197,6 +197,14 @@ export default {
      * Additional class name for the button wrapper element.
      */
     buttonClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+
+    /**
+     * Additional class name for the popover content wrapper element.
+     */
+    contentClass: {
       type: [String, Array, Object],
       default: '',
     },

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_default.story.vue
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_default.story.vue
@@ -11,6 +11,7 @@
     :active="active"
     :danger="danger"
     :button-class="buttonClass"
+    :content-class="contentClass"
     @arrow-click="onClick"
     @click="onClick"
   >


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [x] Documentation

## :book: Description

The new design of VM drop requires an arrow button which shows a popover after click. I think the simplest way to implement this arrow button is: re-using existing `DtRecipeCallbarButtonWithPopover`. However, the width and hight of current popover is hard coded class in `DtRecipeCallbarButtonWithPopover`, so I want to add an prop to customize the width and hight of popover. 
![Screen Shot 2022-10-11 at 5 50 53 PM](https://user-images.githubusercontent.com/61763780/195224727-a814f93e-1905-4b28-aeda-20a922d7de31.png)


## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Make a new release of Dialtone-Vue after this pull request is merged.

