### PR TITLE
feat: dp-57693 remove button padding in callbar_button (vue3)

### DIFF
--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -10,7 +10,7 @@
         icon-position="top"
         :disabled="disabled"
         :aria-label="ariaLabel"
-        label-class="d-fs11"
+        label-class="d-fs-100"
         width="8.4rem"
         :class="callbarButtonClass"
       >


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Background: Dialtone 7 removed 11px font size, and the smallest font size is 12px, so call bar text does not look same as figma design.

## :bulb: Context

After talking with design team, we think 12px text still can fit most buttons, we can just remove the left and right paddings.

Vue2 pull request: https://github.com/dialpad/dialtone-vue/pull/558

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Make a new release.

## :camera: Screenshots / GIFs

![Screen Shot 2022-10-17 at 2 53 35 PM](https://user-images.githubusercontent.com/61763780/196497299-325946d5-567d-4872-86c0-7aa3e2aec446.png)
## :link: Sources

