### PR TITLE
fix(input): fix input readonly attr

### DIFF
--- a/components/input/input.vue
+++ b/components/input/input.vue
@@ -54,7 +54,7 @@
       </div>
       <div
         :class="inputWrapperClasses()"
-        :read-only="disabled"
+        :read-only="disabled === true ? true : undefined"
       >
         <span
           v-if="$slots.leftIcon"


### PR DESCRIPTION
# fix input readonly attr

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

The [attrs in Vue3 with false values are no longer removed](https://v3-migration.vuejs.org/breaking-changes/attribute-coercion.html#:~:text=BREAKING%3A%20No%20longer%20removes%20attribute%20if%20the%20value%20is%20boolean%20false.%20Instead%2C%20it%27s%20set%20as%20attr%3D%22false%22.%20To%20remove%20the%20attribute%2C%20use%20null%20or%20undefined.) so we need to set the attr to `null` or `undefined` to not apply in the element.

## :bulb: Context

Fixes the background-color bug in the Vue3 version:

![image](https://user-images.githubusercontent.com/83774467/197070699-6ae17979-113f-48bd-9cff-51a40bf494d1.png)

https://vue.dialpad.design/vue3/?path=/story/components-input--with-both-icons

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
