### PR TITLE
docs(contact-info): update avatarSrc doc

### DIFF
--- a/recipes/list_items/contact_info/contact_info.mdx
+++ b/recipes/list_items/contact_info/contact_info.mdx
@@ -20,8 +20,8 @@ The **right** slot works the same way, but its contents are placed to the right 
 
 The **bottom** slot can be used to display content below the subtitle slot.
 
-Avatar is optional. When `avatarSrc` is specified, the avatar image will be displayed at the left and
-is required to provide a value in `avatarInitials` to use in the alt attribute of the avatar image.
+Avatar is optional. When `avatarSrc` is specified, the avatar image will be displayed on the left and
+it is required to provide a value in `avatarInitials` to use in the alt attribute of the avatar image.
 If `avatarSrc` is empty, it will fallback to `avatarInitials`, and user initials will be displayed
 in avatar.
 

--- a/recipes/list_items/contact_info/contact_info.mdx
+++ b/recipes/list_items/contact_info/contact_info.mdx
@@ -20,7 +20,8 @@ The **right** slot works the same way, but its contents are placed to the right 
 
 The **bottom** slot can be used to display content below the subtitle slot.
 
-Avatar is optional. When `avatarSrc` is specified, the avatar image will be displayed at the left.
+Avatar is optional. When `avatarSrc` is specified, the avatar image will be displayed at the left and
+is required to provide a value in `avatarInitials` to use in the alt attribute of the avatar image.
 If `avatarSrc` is empty, it will fallback to `avatarInitials`, and user initials will be displayed
 in avatar.
 

--- a/recipes/list_items/contact_info/contact_info.vue
+++ b/recipes/list_items/contact_info/contact_info.vue
@@ -118,6 +118,8 @@ export default {
 
     /**
      * Optional avatar image url.
+     * if provided, it's also required to provide a value in the `avatarInitials` prop to use
+     * in the alt attribute of the avatar.
      */
     avatarSrc: {
       type: String,


### PR DESCRIPTION
# update avatarSrc doc in contact info recipe

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [ ] Feature
- [ ] Refactoring
- [x] Documentation

## :book: Description

I realized there's no documentation stating that providing a value to `avatarInitials` is required when `avatarSrc` is passed to be used in the alt attribute of the avatar image https://github.com/dialpad/dialtone-vue/blob/staging/recipes/list_items/contact_info/contact_info.vue#L19-L20.
They reported as a bug in dialtone-vue but they just need to pass a value to `avatarInitials` https://github.com/dialpad/firespotter/blob/master/ubervoice/static/js/single/components/callbar/callbar_contact_info.vue#L2-L4 so the warning is not logged in the console.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [x] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
