### PR TITLE
feat: add `DtPresence`

### DIFF
--- a/components/presence/index.js
+++ b/components/presence/index.js
@@ -1,0 +1,5 @@
+export { default as DtPresence } from './presence.vue';
+export {
+  PRESENCE_STATES,
+  PRESENCE_STATES_LIST,
+} from './presence_constants';

--- a/components/presence/presence.mdx
+++ b/components/presence/presence.mdx
@@ -1,0 +1,83 @@
+import { Canvas, Story, Subtitle, ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
+import Presence from './presence.vue';
+
+# Presence
+
+<Subtitle>
+    This component displays a presence circle indicating the current status.
+</Subtitle>
+
+## Base Style
+
+Presence can be initialized by passing `presence` prop that can take one of 4 values: 'away', 'active', 'offline', and 'busy'.
+
+<Canvas>
+  <Story id="components-presence--default" />
+</Canvas>
+
+## Variants
+
+<Canvas>
+  <Story id="components-presence--variants" />
+</Canvas>
+
+## Props, Slots & Events
+
+<ArgsTable story={PRIMARY_STORY} />
+
+## Usage
+
+### Import
+
+```jsx
+import { DtPresence } from '@dialpad/dialtone-vue';
+```
+
+### With Presence Prop
+
+```html
+<dt-presence
+  presence="active"
+/>
+```
+
+### With SR text prop
+
+```html
+<dt-presence
+  presence="active"
+  sr-text="User Presence"
+/>
+```
+
+### With Theme prop
+
+```html
+<dt-presence
+  theme="default"
+/>
+```
+
+### Accessibility
+
+Keyboard shortcuts should be visible to sighted users and made available to assistive technology.
+The Presence component is purely visual by default, and will not read out to a screen reader.
+
+If you'd like for a SR to read out any changes to Presence, you should pass the `srText` prop so it is
+read by AT.
+
+Example:
+
+```html
+<dt-presence
+  presence="active"
+  sr-text="User {{ user }} is active"
+/>
+```
+
+Abbreviations / symbols should be read out in full for voiceover / screen readers.
+
+### References
+
+- [Keyboard Symbols](http://xahlee.info/comp/unicode_computing_symbols.html)
+- [aria-keyshortcuts](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts)

--- a/components/presence/presence.mdx
+++ b/components/presence/presence.mdx
@@ -64,7 +64,9 @@ import { DtPresence } from '@dialpad/dialtone-vue';
 The Presence component is purely visual by default, and will not be read out to a screen reader.
 
 If you'd like for a SR to read out any changes to Presence, you should pass the `srText` prop so it is
-read by AT. The component has a role of "status" to assist SR apps in reading out status changes.
+read by AT and set the `aria-live` attribute to either 'polite' or 'assertive'.
+Even though the component has a role of "status" to assist SR apps in reading out status changes, its default
+'aria-live' value is set to 'off'.
 
 [See W3C guidelines](https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22)
 for more information.

--- a/components/presence/presence.mdx
+++ b/components/presence/presence.mdx
@@ -10,6 +10,7 @@ import Presence from './presence.vue';
 ## Base Style
 
 Presence can be initialized by passing `presence` prop that can take one of 4 values: 'away', 'active', 'offline', and 'busy'.
+By default, it's set to 'active'.
 
 <Canvas>
   <Story id="components-presence--default" />

--- a/components/presence/presence.mdx
+++ b/components/presence/presence.mdx
@@ -60,11 +60,13 @@ import { DtPresence } from '@dialpad/dialtone-vue';
 
 ### Accessibility
 
-Keyboard shortcuts should be visible to sighted users and made available to assistive technology.
-The Presence component is purely visual by default, and will not read out to a screen reader.
+The Presence component is purely visual by default, and will not be read out to a screen reader.
 
 If you'd like for a SR to read out any changes to Presence, you should pass the `srText` prop so it is
-read by AT.
+read by AT. The component has a role of "status" to assist SR apps in reading out status changes.
+
+[See W3C guidelines](https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22)
+for more information.
 
 Example:
 
@@ -76,8 +78,3 @@ Example:
 ```
 
 Abbreviations / symbols should be read out in full for voiceover / screen readers.
-
-### References
-
-- [Keyboard Symbols](http://xahlee.info/comp/unicode_computing_symbols.html)
-- [aria-keyshortcuts](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts)

--- a/components/presence/presence.stories.js
+++ b/components/presence/presence.stories.js
@@ -17,17 +17,6 @@ export const argTypesData = {
       options: [...PRESENCE_STATES_LIST],
     },
   },
-  theme: {
-    table: {
-      type: {
-        summary: 'string',
-      },
-    },
-    control: {
-      type: 'select',
-      options: ['none', 'default'],
-    },
-  },
 };
 
 // Story Collection

--- a/components/presence/presence.stories.js
+++ b/components/presence/presence.stories.js
@@ -1,0 +1,67 @@
+import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import PresenceMdx from './presence.mdx';
+import Presence from './presence.vue';
+import { PRESENCE_STATES_LIST } from './presence_constants';
+import PresenceDefaultTemplate from './presence_default.story.vue';
+import PresenceVariantsTemplate from './presence_variants.story.vue';
+
+export const argTypesData = {
+  presence: {
+    table: {
+      type: {
+        summary: 'string',
+      },
+    },
+    control: {
+      type: 'select',
+      options: [...PRESENCE_STATES_LIST],
+    },
+  },
+  theme: {
+    table: {
+      type: {
+        summary: 'string',
+      },
+    },
+    control: {
+      type: 'select',
+      options: ['none', 'default'],
+    },
+  },
+};
+
+// Story Collection
+export default {
+  title: 'Components/Presence',
+  component: Presence,
+  argTypes: argTypesData,
+  excludeStories: /.*Data$/,
+  parameters: {
+    docs: {
+      page: PresenceMdx,
+    },
+    options: {
+      showPanel: true,
+    },
+  },
+};
+
+// Templates
+const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  PresenceDefaultTemplate,
+);
+const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  PresenceVariantsTemplate,
+);
+
+// Stories
+export const Default = DefaultTemplate.bind({});
+Default.args = {};
+
+export const Variants = VariantsTemplate.bind({});
+Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/presence/presence.stories.js
+++ b/components/presence/presence.stories.js
@@ -17,6 +17,11 @@ export const argTypesData = {
       options: [...PRESENCE_STATES_LIST],
     },
   },
+  srText: {
+    control: {
+      type: 'text',
+    },
+  },
 };
 
 // Story Collection

--- a/components/presence/presence.stories.js
+++ b/components/presence/presence.stories.js
@@ -37,6 +37,9 @@ export default {
   argTypes: argTypesData,
   excludeStories: /.*Data$/,
   parameters: {
+    controls: {
+      sort: 'requiredFirst',
+    },
     docs: {
       page: PresenceMdx,
     },

--- a/components/presence/presence.test.js
+++ b/components/presence/presence.test.js
@@ -41,14 +41,30 @@ describe('DtPresence Tests', function () {
   });
 
   describe('Presentation Tests', function () {
-    // Shared Examples
-
     describe('When presence renders', function () {
       // Test Setup
       beforeEach(function () { _setWrappers(); });
 
       it('should exist', function () {
         assert.isTrue(presence.exists());
+      });
+    });
+
+    describe('Presence attributes', function () {
+      // Test Setup
+      beforeEach(function () { _setWrappers(); });
+
+      it('should have role=status', function () {
+        assert.strictEqual(presence.attributes('role'), 'status');
+      });
+
+      it('should have aria-live=polite by default', function () {
+        assert.strictEqual(presence.attributes('aria-live'), 'polite');
+      });
+
+      it('should be able to set aria-live attribute', async function () {
+        await wrapper.setProps({ ariaLive: 'assertive' });
+        assert.strictEqual(presence.attributes('aria-live'), 'assertive');
       });
     });
 
@@ -73,20 +89,6 @@ describe('DtPresence Tests', function () {
       it('should contain the content of the srText prop', function () {
         const srSpan = presence.find('span');
         assert.strictEqual(srSpan.text(), srText);
-      });
-    });
-
-    describe('Theme prop', function () {
-      beforeEach(function () {
-        _setWrappers();
-      });
-
-      it('should append no additional classes when no `theme` prop is passed', function () {
-        assert.deepEqual(presence.classes(), ['d-presence']);
-      });
-      it('should append the `d-theme-sidebar-bgc` class when `theme` prop is `default`', async function () {
-        await wrapper.setProps({ theme: 'default' });
-        assert.deepEqual(presence.classes(), ['d-presence', 'd-theme-sidebar-bgc']);
       });
     });
 

--- a/components/presence/presence.test.js
+++ b/components/presence/presence.test.js
@@ -1,0 +1,117 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import { assert } from 'chai';
+import { itBehavesLikeHasCorrectClass } from '../../tests/shared_examples/classes';
+import DtPresence from './presence.vue';
+
+// Constants
+const basePropsData = {};
+
+describe('DtPresence Tests', function () {
+  let wrapper;
+  let presence;
+  let innerPresence;
+  // Environment
+  let propsData = basePropsData;
+  let slots = {};
+
+  // Helpers
+  const _setChildWrappers = () => {
+    presence = wrapper.find('[data-qa="dt-presence"]');
+    innerPresence = wrapper.find('.d-presence__inner');
+  };
+
+  const _setWrappers = () => {
+    wrapper = shallowMount(DtPresence, {
+      propsData,
+      slots,
+      localVue: this.localVue,
+    });
+    _setChildWrappers();
+  };
+
+  // Setup
+  before(function () {
+    this.localVue = createLocalVue();
+  });
+
+  // Teardown
+  afterEach(function () {
+    propsData = basePropsData;
+    slots = {};
+  });
+
+  describe('Presentation Tests', function () {
+    // Shared Examples
+
+    describe('When presence renders', function () {
+      // Test Setup
+      beforeEach(function () { _setWrappers(); });
+
+      it('should exist', function () {
+        assert.isTrue(presence.exists());
+      });
+    });
+
+    describe('SR Text', function () {
+      const srText = 'SR Presence Text';
+      beforeEach(function () {
+        propsData = {
+          ...basePropsData,
+          srText,
+        };
+        _setWrappers();
+      });
+
+      it('should correctly render the screen-reader <span/> when an srText prop is passed', function () {
+        const srSpan = presence.find('span');
+        assert.isTrue(srSpan.exists());
+      });
+      it('should have the `sr-only` class', function () {
+        const srSpan = presence.find('span');
+        assert.isTrue(srSpan.classes().includes('sr-only'));
+      });
+      it('should contain the content of the srText prop', function () {
+        const srSpan = presence.find('span');
+        assert.strictEqual(srSpan.text(), srText);
+      });
+    });
+
+    describe('Theme prop', function () {
+      beforeEach(function () {
+        _setWrappers();
+      });
+
+      it('should append no additional classes when no `theme` prop is passed', function () {
+        assert.deepEqual(presence.classes(), ['d-presence']);
+      });
+      it('should append the `d-theme-sidebar-bgc` class when `theme` prop is `default`', async function () {
+        await wrapper.setProps({ theme: 'default' });
+        assert.deepEqual(presence.classes(), ['d-presence', 'd-theme-sidebar-bgc']);
+      });
+    });
+
+    describe('Presence color when presence is passed through a prop', function () {
+      beforeEach(function () { _setWrappers(); });
+
+      const itBehavesLikeHasCorrectColorClassForPresence = (presence, color) => {
+        it('should have correct color class based on presence', async function () {
+          await wrapper.setProps({ presence });
+          itBehavesLikeHasCorrectClass(innerPresence, color);
+        });
+      };
+
+      describe('When presence is active', function () {
+        itBehavesLikeHasCorrectColorClassForPresence('active', 'd-presence__inner--active');
+      });
+      describe('When presence is away', function () {
+        itBehavesLikeHasCorrectColorClassForPresence('away', 'd-presence__inner--away');
+      });
+      describe('When presence is busy', function () {
+        itBehavesLikeHasCorrectColorClassForPresence('busy', 'd-presence__inner--busy');
+      });
+      describe('When presence is offline', function () {
+        itBehavesLikeHasCorrectColorClassForPresence('offline', 'd-presence__inner--offline');
+      });
+    });
+  });
+});

--- a/components/presence/presence.test.js
+++ b/components/presence/presence.test.js
@@ -58,8 +58,8 @@ describe('DtPresence Tests', function () {
         assert.strictEqual(presence.attributes('role'), 'status');
       });
 
-      it('should have aria-live=polite by default', function () {
-        assert.strictEqual(presence.attributes('aria-live'), 'polite');
+      it('should have aria-live=off by default', function () {
+        assert.strictEqual(presence.attributes('aria-live'), 'off');
       });
 
       it('should be able to set aria-live attribute', async function () {

--- a/components/presence/presence.vue
+++ b/components/presence/presence.vue
@@ -1,8 +1,8 @@
 <template>
   <div
-    v-if="presence"
     :class="['d-presence', BACKGROUND_COLOR_FOR_THEME[theme]]"
     data-qa="dt-presence"
+    role="status"
   >
     <span
       v-if="srText"

--- a/components/presence/presence.vue
+++ b/components/presence/presence.vue
@@ -1,8 +1,9 @@
 <template>
   <div
-    :class="['d-presence', BACKGROUND_COLOR_FOR_THEME[theme]]"
+    class="d-presence"
     data-qa="dt-presence"
     role="status"
+    :aria-live="$attrs.ariaLive || 'polite'"
   >
     <span
       v-if="srText"
@@ -22,7 +23,7 @@
 </template>
 
 <script>
-import { BACKGROUND_COLOR_FOR_THEME, PRESENCE_STATES, PRESENCE_STATES_LIST } from './presence_constants';
+import { PRESENCE_STATES, PRESENCE_STATES_LIST } from './presence_constants';
 /**
  * Presence is a user status visual indicator element.
  * @see https://dialpad.design/components/presence.html
@@ -44,17 +45,6 @@ export default {
     },
 
     /**
-     * A theme prop to customize the color of the outer border of presence
-     */
-    theme: {
-      type: String,
-      default: 'none',
-      validator: (theme) => {
-        return Object.keys(BACKGROUND_COLOR_FOR_THEME).includes(theme);
-      },
-    },
-
-    /**
      * Since Presence is a visual element, we need SRs to read out any state changes
      * that occur.
      * Text entered here will be read by assistive technology. If null this component will be ignored by AT.
@@ -63,13 +53,6 @@ export default {
       type: String,
       default: null,
     },
-
-  },
-
-  data () {
-    return {
-      BACKGROUND_COLOR_FOR_THEME,
-    };
   },
 };
 </script>

--- a/components/presence/presence.vue
+++ b/components/presence/presence.vue
@@ -3,7 +3,7 @@
     class="d-presence"
     data-qa="dt-presence"
     role="status"
-    :aria-live="$attrs.ariaLive || 'polite'"
+    :aria-live="$attrs.ariaLive || 'off'"
   >
     <span
       v-if="srText"

--- a/components/presence/presence.vue
+++ b/components/presence/presence.vue
@@ -1,0 +1,75 @@
+<template>
+  <div
+    v-if="presence"
+    :class="['d-presence', BACKGROUND_COLOR_FOR_THEME[theme]]"
+    data-qa="dt-presence"
+  >
+    <span
+      v-if="srText"
+      data-qa="dt-presence-sr-text"
+      class="sr-only"
+    >{{ srText }} </span>
+    <div
+      class="d-presence__inner"
+      :class="{
+        'd-presence__inner--active': presence === 'active',
+        'd-presence__inner--away': presence === 'away',
+        'd-presence__inner--busy': presence === 'busy',
+        'd-presence__inner--offline': presence === 'offline',
+      }"
+    />
+  </div>
+</template>
+
+<script>
+import { BACKGROUND_COLOR_FOR_THEME, PRESENCE_STATES, PRESENCE_STATES_LIST } from './presence_constants';
+/**
+ * Presence is a user status visual indicator element.
+ * @see https://dialpad.design/components/presence.html
+ */
+export default {
+  name: 'Presence',
+  props: {
+
+    /**
+     * Determines the color of the inner presence circle, indicating status.
+     * Accepts one of 4 values: 'busy', 'away', 'active', 'offline'
+     */
+    presence: {
+      type: String,
+      default: PRESENCE_STATES.ACTIVE,
+      validator: (role) => {
+        return PRESENCE_STATES_LIST.includes(role);
+      },
+    },
+
+    /**
+     * A theme prop to customize the color of the outer border of presence
+     */
+    theme: {
+      type: String,
+      default: 'none',
+      validator: (theme) => {
+        return Object.keys(BACKGROUND_COLOR_FOR_THEME).includes(theme);
+      },
+    },
+
+    /**
+     * Since Presence is a visual element, we need SRs to read out any state changes
+     * that occur.
+     * Text entered here will be read by assistive technology. If null this component will be ignored by AT.
+     */
+    srText: {
+      type: String,
+      default: null,
+    },
+
+  },
+
+  data () {
+    return {
+      BACKGROUND_COLOR_FOR_THEME,
+    };
+  },
+};
+</script>

--- a/components/presence/presence_constants.js
+++ b/components/presence/presence_constants.js
@@ -11,8 +11,3 @@ export const PRESENCE_STATES_LIST = [
   PRESENCE_STATES.OFFLINE,
   PRESENCE_STATES.ACTIVE,
 ];
-
-export const BACKGROUND_COLOR_FOR_THEME = {
-  none: '',
-  default: 'd-theme-sidebar-bgc',
-};

--- a/components/presence/presence_constants.js
+++ b/components/presence/presence_constants.js
@@ -1,0 +1,18 @@
+export const PRESENCE_STATES = {
+  BUSY: 'busy',
+  AWAY: 'away',
+  OFFLINE: 'offline',
+  ACTIVE: 'active',
+};
+
+export const PRESENCE_STATES_LIST = [
+  PRESENCE_STATES.BUSY,
+  PRESENCE_STATES.AWAY,
+  PRESENCE_STATES.OFFLINE,
+  PRESENCE_STATES.ACTIVE,
+];
+
+export const BACKGROUND_COLOR_FOR_THEME = {
+  none: '',
+  default: 'd-theme-sidebar-bgc',
+};

--- a/components/presence/presence_default.story.vue
+++ b/components/presence/presence_default.story.vue
@@ -1,0 +1,14 @@
+<template>
+  <dt-presence
+    presence="active"
+  />
+</template>
+
+<script>
+import DtPresence from './presence.vue';
+
+export default {
+  name: 'Presence',
+  components: { DtPresence },
+};
+</script>

--- a/components/presence/presence_default.story.vue
+++ b/components/presence/presence_default.story.vue
@@ -1,7 +1,6 @@
 <template>
   <dt-presence
     :presence="presence"
-    :theme="theme"
     :sr-text="srText"
   />
 </template>

--- a/components/presence/presence_default.story.vue
+++ b/components/presence/presence_default.story.vue
@@ -1,6 +1,8 @@
 <template>
   <dt-presence
-    presence="active"
+    :presence="presence"
+    :theme="theme"
+    :sr-text="srText"
   />
 </template>
 

--- a/components/presence/presence_variants.story.vue
+++ b/components/presence/presence_variants.story.vue
@@ -1,0 +1,48 @@
+<template>
+  <div>
+    <div class="d-p8 d-d-flex d-ai-center">
+      <h1 class="d-fs-200 d-mx4">
+        Active
+      </h1>
+      <dt-presence
+        presence="active"
+      />
+    </div>
+
+    <div class="d-p8 d-d-flex d-ai-center">
+      <h1 class="d-fs-200 d-mx4">
+        Away
+      </h1>
+      <dt-presence
+        presence="away"
+      />
+    </div>
+
+    <div class="d-p8 d-d-flex d-ai-center">
+      <h1 class="d-fs-200 d-mx4">
+        Busy
+      </h1>
+      <dt-presence
+        presence="busy"
+      />
+    </div>
+
+    <div class="d-p8 d-d-flex d-ai-center">
+      <h1 class="d-fs-200 d-mx4">
+        Offline
+      </h1>
+      <dt-presence
+        presence="offline"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import DtPresence from './presence.vue';
+
+export default {
+  name: 'Presence',
+  components: { DtPresence },
+};
+</script>


### PR DESCRIPTION
# Add presence

Add the new `DtPresence` component.

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Feature
- [x] Documentation

## :book: Description

Add the new `DtPresence` component that consumes `d-presence` styles. Adds the `presence`, `theme`, and `srText` props to customize how the presence circle is rendered.

## :bulb: Context

Follows work on adding Presence styles in Dialtone here: https://github.com/dialpad/dialtone/pull/716

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Integrating `DtPresence` component as part of `DtAvatar`.

## :camera: Screenshots / GIFs

![image](https://user-images.githubusercontent.com/88498639/198329624-1caeafeb-946a-4045-8f7b-32d3c3d5b14f.png)

## :link: Sources

https://dialpad.design/components/presence.html