### PR TITLE
feat: add `DtPresence` (vue3)

### DIFF
--- a/components/presence/index.js
+++ b/components/presence/index.js
@@ -1,0 +1,5 @@
+export { default as DtPresence } from './presence.vue';
+export {
+  PRESENCE_STATES,
+  PRESENCE_STATES_LIST,
+} from './presence_constants';

--- a/components/presence/presence.mdx
+++ b/components/presence/presence.mdx
@@ -1,0 +1,83 @@
+import { Canvas, Story, Subtitle, ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
+import Presence from './presence.vue';
+
+# Presence
+
+<Subtitle>
+    This component displays a presence circle indicating the current status.
+</Subtitle>
+
+## Base Style
+
+Presence can be initialized by passing `presence` prop that can take one of 4 values: 'away', 'active', 'offline', and 'busy'.
+By default, it's set to 'active'.
+
+<Canvas>
+  <Story id="components-presence--default" />
+</Canvas>
+
+## Variants
+
+<Canvas>
+  <Story id="components-presence--variants" />
+</Canvas>
+
+## Props, Slots & Events
+
+<ArgsTable story={PRIMARY_STORY} />
+
+## Usage
+
+### Import
+
+```jsx
+import { DtPresence } from '@dialpad/dialtone-vue';
+```
+
+### With Presence Prop
+
+```html
+<dt-presence
+  presence="active"
+/>
+```
+
+### With SR text prop
+
+```html
+<dt-presence
+  presence="active"
+  sr-text="User Presence"
+/>
+```
+
+### With Theme prop
+
+```html
+<dt-presence
+  theme="default"
+/>
+```
+
+### Accessibility
+
+The Presence component is purely visual by default, and will not be read out to a screen reader.
+
+If you'd like for a SR to read out any changes to Presence, you should pass the `srText` prop so it is
+read by AT and set the `aria-live` attribute to either 'polite' or 'assertive'.
+Even though the component has a role of "status" to assist SR apps in reading out status changes, its default
+'aria-live' value is set to 'off'.
+
+[See W3C guidelines](https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22)
+for more information.
+
+Example:
+
+```html
+<dt-presence
+  presence="active"
+  sr-text="User {{ user }} is active"
+/>
+```
+
+Abbreviations / symbols should be read out in full for voiceover / screen readers.

--- a/components/presence/presence.stories.js
+++ b/components/presence/presence.stories.js
@@ -1,6 +1,6 @@
 import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import PresenceMdx from './presence.mdx';
-import Presence from './presence.vue';
+import DtPresence from './presence.vue';
 import { PRESENCE_STATES_LIST } from './presence_constants';
 import PresenceDefaultTemplate from './presence_default.story.vue';
 import PresenceVariantsTemplate from './presence_variants.story.vue';
@@ -12,22 +12,19 @@ export const argTypesData = {
         summary: 'string',
       },
     },
-    control: {
-      type: 'select',
-      options: [...PRESENCE_STATES_LIST],
-    },
+    options: [...PRESENCE_STATES_LIST],
+    control: 'select',
   },
   srText: {
-    control: {
-      type: 'text',
-    },
+    description: 'Screen reader text read out whenver the presence changes',
+    control: 'text',
   },
 };
 
 // Story Collection
 export default {
   title: 'Components/Presence',
-  component: Presence,
+  component: DtPresence,
   argTypes: argTypesData,
   excludeStories: /.*Data$/,
   parameters: {
@@ -44,14 +41,12 @@ export default {
 };
 
 // Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+const DefaultTemplate = (args) => createTemplateFromVueFile(
   args,
-  argTypes,
   PresenceDefaultTemplate,
 );
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+const VariantsTemplate = (args) => createTemplateFromVueFile(
   args,
-  argTypes,
   PresenceVariantsTemplate,
 );
 

--- a/components/presence/presence.stories.js
+++ b/components/presence/presence.stories.js
@@ -1,0 +1,64 @@
+import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import PresenceMdx from './presence.mdx';
+import Presence from './presence.vue';
+import { PRESENCE_STATES_LIST } from './presence_constants';
+import PresenceDefaultTemplate from './presence_default.story.vue';
+import PresenceVariantsTemplate from './presence_variants.story.vue';
+
+export const argTypesData = {
+  presence: {
+    table: {
+      type: {
+        summary: 'string',
+      },
+    },
+    control: {
+      type: 'select',
+      options: [...PRESENCE_STATES_LIST],
+    },
+  },
+  srText: {
+    control: {
+      type: 'text',
+    },
+  },
+};
+
+// Story Collection
+export default {
+  title: 'Components/Presence',
+  component: Presence,
+  argTypes: argTypesData,
+  excludeStories: /.*Data$/,
+  parameters: {
+    controls: {
+      sort: 'requiredFirst',
+    },
+    docs: {
+      page: PresenceMdx,
+    },
+    options: {
+      showPanel: true,
+    },
+  },
+};
+
+// Templates
+const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  PresenceDefaultTemplate,
+);
+const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  PresenceVariantsTemplate,
+);
+
+// Stories
+export const Default = DefaultTemplate.bind({});
+Default.args = {};
+
+export const Variants = VariantsTemplate.bind({});
+Variants.args = {};
+Variants.parameters = { controls: { disable: true }, actions: { disable: true }, options: { showPanel: false } };

--- a/components/presence/presence.test.js
+++ b/components/presence/presence.test.js
@@ -1,4 +1,4 @@
-import { createLocalVue, shallowMount } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { assert } from 'chai';
 import { itBehavesLikeHasCorrectClass } from '../../tests/shared_examples/classes';
 import DtPresence from './presence.vue';
@@ -24,15 +24,9 @@ describe('DtPresence Tests', function () {
     wrapper = shallowMount(DtPresence, {
       propsData,
       slots,
-      localVue: this.localVue,
     });
     _setChildWrappers();
   };
-
-  // Setup
-  before(function () {
-    this.localVue = createLocalVue();
-  });
 
   // Teardown
   afterEach(function () {

--- a/components/presence/presence.test.js
+++ b/components/presence/presence.test.js
@@ -1,0 +1,119 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import { assert } from 'chai';
+import { itBehavesLikeHasCorrectClass } from '../../tests/shared_examples/classes';
+import DtPresence from './presence.vue';
+
+// Constants
+const basePropsData = {};
+
+describe('DtPresence Tests', function () {
+  let wrapper;
+  let presence;
+  let innerPresence;
+  // Environment
+  let propsData = basePropsData;
+  let slots = {};
+
+  // Helpers
+  const _setChildWrappers = () => {
+    presence = wrapper.find('[data-qa="dt-presence"]');
+    innerPresence = wrapper.find('.d-presence__inner');
+  };
+
+  const _setWrappers = () => {
+    wrapper = shallowMount(DtPresence, {
+      propsData,
+      slots,
+      localVue: this.localVue,
+    });
+    _setChildWrappers();
+  };
+
+  // Setup
+  before(function () {
+    this.localVue = createLocalVue();
+  });
+
+  // Teardown
+  afterEach(function () {
+    propsData = basePropsData;
+    slots = {};
+  });
+
+  describe('Presentation Tests', function () {
+    describe('When presence renders', function () {
+      // Test Setup
+      beforeEach(function () { _setWrappers(); });
+
+      it('should exist', function () {
+        assert.isTrue(presence.exists());
+      });
+    });
+
+    describe('Presence attributes', function () {
+      // Test Setup
+      beforeEach(function () { _setWrappers(); });
+
+      it('should have role=status', function () {
+        assert.strictEqual(presence.attributes('role'), 'status');
+      });
+
+      it('should have aria-live=off by default', function () {
+        assert.strictEqual(presence.attributes('aria-live'), 'off');
+      });
+
+      it('should be able to set aria-live attribute', async function () {
+        await wrapper.setProps({ ariaLive: 'assertive' });
+        assert.strictEqual(presence.attributes('aria-live'), 'assertive');
+      });
+    });
+
+    describe('SR Text', function () {
+      const srText = 'SR Presence Text';
+      beforeEach(function () {
+        propsData = {
+          ...basePropsData,
+          srText,
+        };
+        _setWrappers();
+      });
+
+      it('should correctly render the screen-reader <span/> when an srText prop is passed', function () {
+        const srSpan = presence.find('span');
+        assert.isTrue(srSpan.exists());
+      });
+      it('should have the `sr-only` class', function () {
+        const srSpan = presence.find('span');
+        assert.isTrue(srSpan.classes().includes('sr-only'));
+      });
+      it('should contain the content of the srText prop', function () {
+        const srSpan = presence.find('span');
+        assert.strictEqual(srSpan.text(), srText);
+      });
+    });
+
+    describe('Presence color when presence is passed through a prop', function () {
+      beforeEach(function () { _setWrappers(); });
+
+      const itBehavesLikeHasCorrectColorClassForPresence = (presence, color) => {
+        it('should have correct color class based on presence', async function () {
+          await wrapper.setProps({ presence });
+          itBehavesLikeHasCorrectClass(innerPresence, color);
+        });
+      };
+
+      describe('When presence is active', function () {
+        itBehavesLikeHasCorrectColorClassForPresence('active', 'd-presence__inner--active');
+      });
+      describe('When presence is away', function () {
+        itBehavesLikeHasCorrectColorClassForPresence('away', 'd-presence__inner--away');
+      });
+      describe('When presence is busy', function () {
+        itBehavesLikeHasCorrectColorClassForPresence('busy', 'd-presence__inner--busy');
+      });
+      describe('When presence is offline', function () {
+        itBehavesLikeHasCorrectColorClassForPresence('offline', 'd-presence__inner--offline');
+      });
+    });
+  });
+});

--- a/components/presence/presence.vue
+++ b/components/presence/presence.vue
@@ -1,0 +1,58 @@
+<template>
+  <div
+    class="d-presence"
+    data-qa="dt-presence"
+    role="status"
+    :aria-live="$attrs.ariaLive || 'off'"
+  >
+    <span
+      v-if="srText"
+      data-qa="dt-presence-sr-text"
+      class="sr-only"
+    >{{ srText }} </span>
+    <div
+      class="d-presence__inner"
+      :class="{
+        'd-presence__inner--active': presence === 'active',
+        'd-presence__inner--away': presence === 'away',
+        'd-presence__inner--busy': presence === 'busy',
+        'd-presence__inner--offline': presence === 'offline',
+      }"
+    />
+  </div>
+</template>
+
+<script>
+import { PRESENCE_STATES, PRESENCE_STATES_LIST } from './presence_constants';
+/**
+ * Presence is a user status visual indicator element.
+ * @see https://dialpad.design/components/presence.html
+ */
+export default {
+  name: 'Presence',
+  props: {
+
+    /**
+     * Determines the color of the inner presence circle, indicating status.
+     * Accepts one of 4 values: 'busy', 'away', 'active', 'offline'
+     */
+    presence: {
+      type: String,
+      default: PRESENCE_STATES.ACTIVE,
+      validator: (role) => {
+        return PRESENCE_STATES_LIST.includes(role);
+      },
+    },
+
+    /**
+     * Since Presence is a visual element, we need SRs to read out any state changes
+     * that occur.
+     * Text entered here will be read by assistive technology. If null this component will be ignored by AT.
+     */
+    srText: {
+      type: String,
+      default: null,
+    },
+  },
+};
+</script>

--- a/components/presence/presence.vue
+++ b/components/presence/presence.vue
@@ -29,7 +29,7 @@ import { PRESENCE_STATES, PRESENCE_STATES_LIST } from './presence_constants';
  * @see https://dialpad.design/components/presence.html
  */
 export default {
-  name: 'Presence',
+  name: 'DtPresence',
   props: {
 
     /**

--- a/components/presence/presence_constants.js
+++ b/components/presence/presence_constants.js
@@ -1,0 +1,13 @@
+export const PRESENCE_STATES = {
+  BUSY: 'busy',
+  AWAY: 'away',
+  OFFLINE: 'offline',
+  ACTIVE: 'active',
+};
+
+export const PRESENCE_STATES_LIST = [
+  PRESENCE_STATES.BUSY,
+  PRESENCE_STATES.AWAY,
+  PRESENCE_STATES.OFFLINE,
+  PRESENCE_STATES.ACTIVE,
+];

--- a/components/presence/presence_default.story.vue
+++ b/components/presence/presence_default.story.vue
@@ -1,0 +1,15 @@
+<template>
+  <dt-presence
+    :presence="presence"
+    :sr-text="srText"
+  />
+</template>
+
+<script>
+import DtPresence from './presence.vue';
+
+export default {
+  name: 'Presence',
+  components: { DtPresence },
+};
+</script>

--- a/components/presence/presence_default.story.vue
+++ b/components/presence/presence_default.story.vue
@@ -1,7 +1,7 @@
 <template>
   <dt-presence
-    :presence="presence"
-    :sr-text="srText"
+    :presence="$attrs.presence"
+    :sr-text="$attrs.srText"
   />
 </template>
 
@@ -9,7 +9,7 @@
 import DtPresence from './presence.vue';
 
 export default {
-  name: 'Presence',
+  name: 'DtPresenceDefaultStory',
   components: { DtPresence },
 };
 </script>

--- a/components/presence/presence_variants.story.vue
+++ b/components/presence/presence_variants.story.vue
@@ -1,0 +1,48 @@
+<template>
+  <div>
+    <div class="d-p8 d-d-flex d-ai-center">
+      <h1 class="d-fs-200 d-mx4">
+        Active
+      </h1>
+      <dt-presence
+        presence="active"
+      />
+    </div>
+
+    <div class="d-p8 d-d-flex d-ai-center">
+      <h1 class="d-fs-200 d-mx4">
+        Away
+      </h1>
+      <dt-presence
+        presence="away"
+      />
+    </div>
+
+    <div class="d-p8 d-d-flex d-ai-center">
+      <h1 class="d-fs-200 d-mx4">
+        Busy
+      </h1>
+      <dt-presence
+        presence="busy"
+      />
+    </div>
+
+    <div class="d-p8 d-d-flex d-ai-center">
+      <h1 class="d-fs-200 d-mx4">
+        Offline
+      </h1>
+      <dt-presence
+        presence="offline"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import DtPresence from './presence.vue';
+
+export default {
+  name: 'Presence',
+  components: { DtPresence },
+};
+</script>

--- a/components/presence/presence_variants.story.vue
+++ b/components/presence/presence_variants.story.vue
@@ -42,7 +42,7 @@
 import DtPresence from './presence.vue';
 
 export default {
-  name: 'Presence',
+  name: 'DtPresenceVariantsStory',
   components: { DtPresence },
 };
 </script>


### PR DESCRIPTION
# Add presence (vue3)

Add the new `DtPresence` component.

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Feature
- [x] Documentation

## :book: Description

Add the new `DtPresence` component that consumes `d-presence` styles. Adds the `presence`, `theme`, and `srText` props to customize how the presence circle is rendered.

## :bulb: Context

Follows work on adding Presence styles in Dialtone here: https://github.com/dialpad/dialtone/pull/716

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Integrating `DtPresence` component as part of `DtAvatar`.

## :camera: Screenshots / GIFs

![image](https://user-images.githubusercontent.com/88498639/198329624-1caeafeb-946a-4045-8f7b-32d3c3d5b14f.png)

## :link: Sources

https://dialpad.design/components/presence.html