### PR TITLE
feat(toggle): add size prop

### DIFF
--- a/components/toggle/toggle.stories.js
+++ b/components/toggle/toggle.stories.js
@@ -4,6 +4,7 @@ import ToggleDefault from './toggle_default.story.vue';
 import ToggleVariants from './toggle_variants.story.vue';
 import ToggleMdx from './toggle.mdx';
 import DtToggle from './toggle';
+import { TOGGLE_SIZE_MODIFIERS } from '@/components/toggle/toggle_constants';
 
 // Default Prop Values
 export const argsData = {
@@ -34,6 +35,14 @@ export const argTypesData = {
       type: {
         summary: 'boolean',
       },
+    },
+  },
+
+  size: {
+    description: 'Used to set the size of the toggle',
+    control: {
+      type: 'select',
+      options: Object.keys(TOGGLE_SIZE_MODIFIERS),
     },
   },
 

--- a/components/toggle/toggle.test.js
+++ b/components/toggle/toggle.test.js
@@ -85,6 +85,11 @@ describe('DtToggle Tests', function () {
           assert.equal(button.attributes().disabled, 'disabled');
           assert.isTrue(button.classes().includes('d-toggle--disabled'));
         });
+
+        it('should set correct size class', async function () {
+          await wrapper.setProps({ size: 'sm' });
+          assert.isTrue(button.classes().includes('d-toggle--small'));
+        });
       });
     });
     describe('Unchecked Toggle', function () {

--- a/components/toggle/toggle.vue
+++ b/components/toggle/toggle.vue
@@ -17,10 +17,7 @@
       :aria-checked="internalChecked.toString()"
       :disabled="disabled"
       :aria-disabled="disabled.toString()"
-      :class="['d-toggle', {
-        'd-toggle--checked': internalChecked,
-        'd-toggle--disabled': disabled,
-      }]"
+      :class="toggleClasses"
       v-bind="$attrs"
       v-on="inputListeners"
     >
@@ -32,6 +29,7 @@
 <script>
 import Vue from 'vue';
 import utils from '@/common/utils';
+import { TOGGLE_SIZE_MODIFIERS } from '@/components/toggle/toggle_constants';
 
 /**
  * A toggle (or "switch") is a button control element that allows the user to make a binary (on/off) selection.
@@ -78,6 +76,16 @@ export default {
     },
 
     /**
+     * The size of the toggle.
+     * @values sm, md
+     */
+    size: {
+      type: String,
+      default: 'md',
+      validator: (s) => Object.keys(TOGGLE_SIZE_MODIFIERS).includes(s),
+    },
+
+    /**
      * Used to customize the label container
      */
     labelClass: {
@@ -112,12 +120,23 @@ export default {
   },
 
   computed: {
-
     inputListeners () {
       return {
         ...this.$listeners,
         click: _ => this.toggleCheckedValue(),
       };
+    },
+
+    toggleClasses () {
+      return [
+        'd-toggle',
+        TOGGLE_SIZE_MODIFIERS[this.size],
+        {
+          'd-toggle--checked': this.internalChecked,
+          'd-toggle--disabled': this.disabled,
+
+        },
+      ];
     },
   },
 

--- a/components/toggle/toggle_constants.js
+++ b/components/toggle/toggle_constants.js
@@ -1,0 +1,8 @@
+export const TOGGLE_SIZE_MODIFIERS = {
+  sm: 'd-toggle--small',
+  md: '',
+};
+
+export default {
+  TOGGLE_SIZE_MODIFIERS,
+};

--- a/components/toggle/toggle_default.story.vue
+++ b/components/toggle/toggle_default.story.vue
@@ -2,6 +2,7 @@
   <dt-toggle
     :checked="checked"
     :disabled="disabled"
+    :size="size"
     :label-class="labelClass"
     :label-child-props="labelChildProps"
     @change="onChange"

--- a/components/toggle/toggle_variants.story.vue
+++ b/components/toggle/toggle_variants.story.vue
@@ -69,6 +69,7 @@
       class="d-mt6"
       label-class="d-mr6"
       label="Small size"
+      size="sm"
     >
       Small size
     </dt-toggle>

--- a/components/toggle/toggle_variants.story.vue
+++ b/components/toggle/toggle_variants.story.vue
@@ -64,6 +64,14 @@
         With V-Model
       </div>
     </dt-toggle>
+
+    <dt-toggle
+      class="d-mt6"
+      label-class="d-mr6"
+      label="Small size"
+    >
+      Small size
+    </dt-toggle>
   </div>
 </template>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@commitlint/cli": "^17.1.2",
         "@commitlint/config-conventional": "^17.1.0",
-        "@dialpad/dialtone": "^7.1.0",
+        "@dialpad/dialtone": "^7.4.0",
         "@percy/cli": "1.10.2",
         "@percy/storybook": "4.2.1",
         "@semantic-release/changelog": "^6.0.1",
@@ -61,7 +61,7 @@
         "node": ">= 16"
       },
       "peerDependencies": {
-        "@dialpad/dialtone": ">=7.1",
+        "@dialpad/dialtone": ">=7.4",
         "vue": ">=2.6"
       }
     },
@@ -2840,9 +2840,9 @@
       }
     },
     "node_modules/@dialpad/dialtone": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.1.0.tgz",
-      "integrity": "sha512-qiMkr77lmChIjmJrZmnfNvSe3Kk3LdvPPdFMAdwhOk317ruZ6zzjOfB5T92gSmt6EUVY18VX6Uyr3dVBFWjyNg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.4.0.tgz",
+      "integrity": "sha512-TGOSNC71V5q3H/SOYnhEce+SpxRyuG2TyLrR7ahYd8fphUcR4FRCXR9FTSRX0S4IKobxTt/rfQMEJiU2zoAwbQ==",
       "dev": true,
       "dependencies": {
         "@docsearch/js": "^3.2.1",
@@ -31466,9 +31466,9 @@
       }
     },
     "@dialpad/dialtone": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.1.0.tgz",
-      "integrity": "sha512-qiMkr77lmChIjmJrZmnfNvSe3Kk3LdvPPdFMAdwhOk317ruZ6zzjOfB5T92gSmt6EUVY18VX6Uyr3dVBFWjyNg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.4.0.tgz",
+      "integrity": "sha512-TGOSNC71V5q3H/SOYnhEce+SpxRyuG2TyLrR7ahYd8fphUcR4FRCXR9FTSRX0S4IKobxTt/rfQMEJiU2zoAwbQ==",
       "dev": true,
       "requires": {
         "@docsearch/js": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
-    "@dialpad/dialtone": "^7.1.0",
+    "@dialpad/dialtone": "^7.4.0",
     "@percy/cli": "1.10.2",
     "@percy/storybook": "4.2.1",
     "@semantic-release/changelog": "^6.0.1",
@@ -86,7 +86,7 @@
     "yo": "^4.3.0"
   },
   "peerDependencies": {
-    "@dialpad/dialtone": ">=7.1",
+    "@dialpad/dialtone": ">=7.4",
     "vue": ">=2.6"
   },
   "engineStrict": true,


### PR DESCRIPTION
# add size prop

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Add prop for `size` with the values: `md` (default) and `sm`

~⚠️ Depends on the dialtone changes on this branch: [feature/toggle-small-variant](https://github.com/dialpad/dialtone/tree/feature/toggle-small-variant)~
Updated PR with the changes released in [Dialtone 7.4.0](https://github.com/dialpad/dialtone/releases/tag/v7.4.0)

## :bulb: Context

Jira ticket: https://dialpad.atlassian.net/browse/DT-737

Changes included in this PR:
- [x] add prop for size: toggles .d-toggle--small class.
- [ ] add prop to hide icons: suppresses .d-toggle__inner. https://github.com/dialpad/dialtone-vue/pull/573
- [ ] add prop for indeterminate state. https://github.com/dialpad/dialtone-vue/pull/579

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
