### PR TITLE
fix: dp-58864 update hover background color in Call Bar Button

### DIFF
--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -128,6 +128,8 @@ export default {
         'dt-recipe-callbar-button',
         'd-stack4',
         'd-px0',
+        'h:d-bgc-black-200',
+        'h:d-bgo50',
         {
           'dt-recipe-callbar-button--circle': this.circle,
           'dt-recipe-callbar-button--active': this.active,
@@ -142,10 +144,6 @@ export default {
 .dt-recipe-callbar-button:not(.dt-recipe-callbar-button--circle) {
   letter-spacing: -0.011rem;
   line-height: 1.6rem;
-}
-
-.dt-recipe-callbar-button:hover {
-  --button--bgc: var(--black-200);
 }
 
 .dt-recipe-callbar-button--circle {

--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -144,6 +144,10 @@ export default {
   line-height: 1.6rem;
 }
 
+.dt-recipe-callbar-button:hover {
+  --button--bgc: var(--black-200);
+}
+
 .dt-recipe-callbar-button--circle {
   border-radius: var(--br-circle);
 }


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

JIRA: https://dialpad.atlassian.net/browse/DP-58864

Currently hover background color in Call Bar Button is light and barely noticeable, this pull request update it to darker background.



## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

No need release. This fix is not urgent at all.

## :camera: Screenshots / GIFs

This is original hover background:
![image](https://user-images.githubusercontent.com/61763780/199101761-efe86cb0-8be7-4790-8835-ad6cbe90bbd9.png)

This is new hover background (black-200): 
![image](https://user-images.githubusercontent.com/61763780/199101781-6cd7abf4-a745-432f-8a55-e201e597645f.png)

