### PR TITLE
feat: list item group component

### DIFF
--- a/components/dropdown/dropdown_separator.vue
+++ b/components/dropdown/dropdown_separator.vue
@@ -1,7 +1,7 @@
 <template>
   <li
     aria-hidden="true"
-    class="dt-list-separator d-bgc-black-075 d-my8"
+    class="dt-list-separator d-bgc-black-300 d-my8"
   />
 </template>
 

--- a/components/dropdown/dropdown_variants.story.vue
+++ b/components/dropdown/dropdown_variants.story.vue
@@ -125,7 +125,8 @@
           slot="list"
           slot-scope="{ close }"
         >
-          <dt-dropdown-list
+          <dt-list-item-group
+            heading-class="d-p6 d-fw-bold"
             :list-class="listClass"
             heading="Menu Heading A"
           >
@@ -144,10 +145,11 @@
             >
               Menu Item 2
             </dt-list-item>
-          </dt-dropdown-list>
+          </dt-list-item-group>
           <dt-dropdown-separator />
-          <dt-dropdown-list
+          <dt-list-item-group
             :list-class="listClass"
+            heading-class="d-p6 d-fw-bold"
             heading="Menu Heading B"
           >
             <dt-list-item
@@ -157,7 +159,7 @@
             >
               Menu Item 3
             </dt-list-item>
-          </dt-dropdown-list>
+          </dt-list-item-group>
         </template>
       </dt-dropdown>
     </div>
@@ -183,7 +185,7 @@
           >
             <div
               v-bind="attrs"
-              class="d-ba d-bas-dashed d-w264 d-py48 d-ta-center d-bgc-black-025"
+              class="d-ba d-bas-dashed d-w264 d-py48 d-ta-center d-bgc-black-300"
             >
               Right click to open
             </div>
@@ -211,6 +213,7 @@
 <script>
 import DtDropdown from './dropdown';
 import DtDropdownList from './dropdown_list';
+import DtListItemGroup from '../list_item_group/list_item_group.vue';
 import DtDropdownSeparator from './dropdown_separator';
 import { DtListItem } from '../list_item';
 import { DtButton } from '../button';
@@ -219,7 +222,7 @@ import { DROPDOWN_STORY_ITEMS } from './dropdown_story_constants';
 export default {
   name: 'DtDropdownVariants',
 
-  components: { DtDropdown, DtListItem, DtButton, DtDropdownList, DtDropdownSeparator },
+  components: { DtDropdown, DtListItem, DtButton, DtListItemGroup, DtDropdownList, DtDropdownSeparator },
 
   data () {
     return {

--- a/components/list_item_group/index.js
+++ b/components/list_item_group/index.js
@@ -1,0 +1,2 @@
+export { default as DtListItemGroup } from './list_item_group.vue';
+export {} from './list_item_group_constants';

--- a/components/list_item_group/list_item_group.mdx
+++ b/components/list_item_group/list_item_group.mdx
@@ -1,0 +1,65 @@
+import { Canvas, Story, Subtitle, ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
+import DtListItemGroup from './list_item_group';
+
+# List Item Group
+
+<Subtitle>
+  The "List Item Group" component uses a non interactive heading which groups list items.
+</Subtitle>
+
+## Base Style
+
+You should use this component when you have multiple list items you would like to group into different
+categories.
+
+The heading is unstyled by default. You will likely have to pass utility classes to the headingClass prop to make the
+heading look how you wish.
+
+<Canvas>
+  <Story id="components-list-item-group--default" />
+</Canvas>
+
+## Slots, Props & Events
+
+<ArgsTable story={PRIMARY_STORY} />
+
+## Usage
+
+### Import
+
+```jsx
+import { DtListItemGroup } from '@dialpad/dialtone-vue';
+```
+
+### Usage
+
+```jsx
+<dt-list-item-group
+  heading="Example Heading"
+  headingClass="d-fw-bold"
+>
+  <dt-list-item
+    navigation-type="tab"
+  >
+    item1
+  </dt-list-item>
+  <dt-list-item
+    navigation-type="tab"
+  >
+    item2
+  </dt-list-item>
+  <dt-list-item
+    navigation-type="tab"
+  >
+    item3
+  </dt-list-item>
+</dt-list-item-group>
+
+```
+
+## Accessibility
+
+The List Item Group does not implement arrow-keys keyboard navigation. You will however get arrow-keys
+keyboard navigation when using this within list based Dialtone components such as Dropdown or Combobox.
+
+The aria label for the List Item Group will be set by the content of the heading.

--- a/components/list_item_group/list_item_group.stories.js
+++ b/components/list_item_group/list_item_group.stories.js
@@ -1,0 +1,45 @@
+import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import DtListItemGroup from './list_item_group';
+import DtListItemGroupMdx from './list_item_group.mdx';
+import DtListItemGroupDefaultTemplate from './list_item_group_default.story.vue';
+
+// Default Prop Values
+export const argsData = {
+  heading: 'Example Heading',
+};
+export const argTypesData = {
+  // Slots
+  default: {
+    control: 'none',
+    table: {
+      type: {
+        summary: 'VNode',
+      },
+    },
+  },
+};
+
+// Story Collection
+export default {
+  title: 'Components/List Item Group',
+  component: DtListItemGroup,
+  args: argsData,
+  argTypes: argTypesData,
+  excludeStories: /.*Data$/,
+  parameters: {
+    docs: {
+      page: DtListItemGroupMdx,
+    },
+  },
+};
+
+// Templates
+const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  DtListItemGroupDefaultTemplate,
+);
+
+// Stories
+export const Default = DefaultTemplate.bind({});
+Default.args = {};

--- a/components/list_item_group/list_item_group.stories.js
+++ b/components/list_item_group/list_item_group.stories.js
@@ -17,6 +17,15 @@ export const argTypesData = {
       },
     },
   },
+  // Slots
+  headingSlot: {
+    control: 'text',
+    table: {
+      type: {
+        summary: 'VNode',
+      },
+    },
+  },
 };
 
 // Story Collection

--- a/components/list_item_group/list_item_group.test.js
+++ b/components/list_item_group/list_item_group.test.js
@@ -1,0 +1,70 @@
+import { assert } from 'chai';
+import { createLocalVue, mount } from '@vue/test-utils';
+import DtListItemGroup from './list_item_group.vue';
+
+// Constants
+const basePropsData = {
+  heading: 'Heading',
+  id: 'list-item-group',
+};
+
+describe('DtListItemGroup Tests', function () {
+  // Wrappers
+  let wrapper;
+  let heading;
+
+  // Environment
+  let propsData = basePropsData;
+  let attrs = {};
+  let slots = {};
+  let provide = {};
+
+  // Helpers
+  const _setChildWrappers = () => {
+    heading = wrapper.find('[data-qa="dt-dropdown-list-heading"]');
+  };
+
+  const _setWrappers = () => {
+    wrapper = mount(DtListItemGroup, {
+      propsData,
+      attrs,
+      slots,
+      provide,
+      localVue: this.localVue,
+    });
+    _setChildWrappers();
+  };
+
+  // Setup
+  before(function () {
+    this.localVue = createLocalVue();
+  });
+  beforeEach(function () {
+    _setWrappers();
+  });
+
+  // Teardown
+  afterEach(function () {
+    propsData = basePropsData;
+    attrs = {};
+    slots = {};
+    provide = {};
+  });
+  after(function () {});
+
+  describe('Presentation Tests', function () {
+    describe('List Group has a heading set', function () {
+      it('displays the heading correctly', function () {
+        assert.strictEqual(heading.text(), basePropsData.heading);
+      });
+    });
+  });
+
+  describe('Accessibility Tests', function () {
+    describe('List Group has a heading set', function () {
+      it('the root ul is aria-labelledby the id of the header element', function () {
+        assert.strictEqual(wrapper.attributes('aria-labelledby'), basePropsData.id + '-heading');
+      });
+    });
+  });
+});

--- a/components/list_item_group/list_item_group.vue
+++ b/components/list_item_group/list_item_group.vue
@@ -1,0 +1,63 @@
+<template>
+  <ul
+    :id="id"
+    :class="['d-ps-relative', 'd-px0', listClass]"
+    data-qa="dt-dropdown-list-wrapper"
+    :aria-labelledby="`${id}-heading`"
+  >
+    <li
+      v-if="heading"
+      :id="`${id}-heading`"
+      role="presentation"
+      data-qa="dt-dropdown-list-heading"
+      :class="['dt-dropdown-list--header', headingClass]"
+    >
+      {{ heading }}
+    </li>
+    <!-- @slot Slot for the list component -->
+    <slot />
+  </ul>
+</template>
+
+<script>
+import {} from './list_item_group_constants.js';
+import { getUniqueString } from '@/common/utils';
+
+export default {
+  name: 'DtListItemGroup',
+
+  props: {
+    /**
+     * Id of the List Item Group
+     */
+    id: {
+      type: String,
+      default () { return getUniqueString(); },
+    },
+
+    /**
+     * List's heading.
+     */
+    heading: {
+      type: String,
+      default: '',
+    },
+
+    /**
+     * Additional class to style the heading
+     */
+    headingClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+
+    /**
+     * Additional class for the wrapper list element.
+     */
+    listClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+  },
+};
+</script>

--- a/components/list_item_group/list_item_group.vue
+++ b/components/list_item_group/list_item_group.vue
@@ -2,6 +2,7 @@
   <ul
     :id="id"
     :class="['d-ps-relative', 'd-px0', listClass]"
+    role="group"
     data-qa="dt-dropdown-list-wrapper"
     :aria-labelledby="`${id}-heading`"
   >
@@ -12,7 +13,10 @@
       data-qa="dt-dropdown-list-heading"
       :class="['dt-dropdown-list--header', headingClass]"
     >
-      {{ heading }}
+      <!-- @slot Slot for heading, will override heading prop. -->
+      <slot name="headingSlot">
+        {{ heading }}
+      </slot>
     </li>
     <!-- @slot Slot for the list component -->
     <slot />

--- a/components/list_item_group/list_item_group_constants.js
+++ b/components/list_item_group/list_item_group_constants.js
@@ -1,0 +1,5 @@
+export const DEFAULT_CONSTANTS = null;
+
+export default {
+  DEFAULT_CONSTANTS,
+};

--- a/components/list_item_group/list_item_group_default.story.vue
+++ b/components/list_item_group/list_item_group_default.story.vue
@@ -22,6 +22,12 @@
     >
       item3
     </dt-list-item>
+    <template
+      v-if="headingSlot"
+      slot="headingSlot"
+    >
+      <span v-html="headingSlot" />
+    </template>
   </dt-list-item-group>
 </template>
 

--- a/components/list_item_group/list_item_group_default.story.vue
+++ b/components/list_item_group/list_item_group_default.story.vue
@@ -1,0 +1,36 @@
+<template>
+  <dt-list-item-group
+    :heading="heading"
+    :heading-class="headingClass"
+    :list-class="listClass"
+  >
+    <dt-list-item
+      class="d-pl8"
+      navigation-type="tab"
+    >
+      item1
+    </dt-list-item>
+    <dt-list-item
+      class="d-pl8"
+      navigation-type="tab"
+    >
+      item2
+    </dt-list-item>
+    <dt-list-item
+      class="d-pl8"
+      navigation-type="tab"
+    >
+      item3
+    </dt-list-item>
+  </dt-list-item-group>
+</template>
+
+<script>
+import DtListItemGroup from './list_item_group';
+import DtListItem from '../list_item/list_item';
+
+export default {
+  name: 'DtListItemGroupDefault',
+  components: { DtListItemGroup, DtListItem },
+};
+</script>

--- a/components/list_item_group/list_item_group_default.story.vue
+++ b/components/list_item_group/list_item_group_default.story.vue
@@ -1,34 +1,36 @@
 <template>
-  <dt-list-item-group
-    :heading="heading"
-    :heading-class="headingClass"
-    :list-class="listClass"
-  >
-    <dt-list-item
-      class="d-pl8"
-      navigation-type="tab"
+  <div role="list">
+    <dt-list-item-group
+      :heading="heading"
+      :heading-class="headingClass"
+      :list-class="listClass"
     >
-      item1
-    </dt-list-item>
-    <dt-list-item
-      class="d-pl8"
-      navigation-type="tab"
-    >
-      item2
-    </dt-list-item>
-    <dt-list-item
-      class="d-pl8"
-      navigation-type="tab"
-    >
-      item3
-    </dt-list-item>
-    <template
-      v-if="headingSlot"
-      slot="headingSlot"
-    >
-      <span v-html="headingSlot" />
-    </template>
-  </dt-list-item-group>
+      <dt-list-item
+        class="d-pl8"
+        navigation-type="tab"
+      >
+        item1
+      </dt-list-item>
+      <dt-list-item
+        class="d-pl8"
+        navigation-type="tab"
+      >
+        item2
+      </dt-list-item>
+      <dt-list-item
+        class="d-pl8"
+        navigation-type="tab"
+      >
+        item3
+      </dt-list-item>
+      <template
+        v-if="headingSlot"
+        slot="headingSlot"
+      >
+        <span v-html="headingSlot" />
+      </template>
+    </dt-list-item-group>
+  </div>
 </template>
 
 <script>

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ export * from './components/modal';
 export * from './components/lazy_show';
 export * from './components/list_section';
 export * from './components/list_item';
+export * from './components/list_item_group';
 export * from './components/link';
 export * from './components/notice';
 export * from './components/pagination';


### PR DESCRIPTION
# New Component - List Item Group

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Request for this from @MikaDialpad and @dbecherdialpad for contacts search.

This is very similar to the "Dropdown List" component Jose did for dropdown. Just made it a standalone component and individually documented so it could be used outside of dropdown. Changed the header to use `role="presentation"` rather than the nested `li` method as it is simpler and still accessible.

Already updated the example on dropdown to use this new component. Will remove the old "Dropdown List" component in a future PR, want to make sure it's removal is not going to break anything.

I banged this out pretty quick today so please let me know if you notice any oversights.

## :bulb: Context

To make grouped list items useable anywhere and properly documented.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

- Add a link to this vue only component to Dialtone site.
- Publish the similar "List Item Separator" component in the same way.
- Remove the existing "dropdown list" component.

## :camera: Screenshots / GIFs

![Screenshot 2022-11-04 at 1 47 33 PM](https://user-images.githubusercontent.com/64808812/200071986-fe24a654-7707-426b-bfe5-e46b946a6c3d.png)

## :link: Sources

Example of the `role=presentation` method for group headers
https://w3c.github.io/aria-practices/examples/listbox/listbox-grouped.html
