### PR TITLE
feat(modal): update danger style

### DIFF
--- a/components/modal/modal.vue
+++ b/components/modal/modal.vue
@@ -91,7 +91,6 @@
           importance="clear"
           :aria-label="closeButtonProps.ariaLabel"
           v-bind="closeButtonProps"
-          :kind="kind"
           @click="close"
         >
           <template #icon>

--- a/components/modal/modal_default.story.vue
+++ b/components/modal/modal_default.story.vue
@@ -46,16 +46,16 @@
         />
         <div v-else>
           <dt-button
-            :kind="$attrs.kind"
-            importance="primary"
-          >
-            Confirm
-          </dt-button>
-          <dt-button
-            :kind="$attrs.kind"
+            :kind="kind"
             importance="clear"
           >
             Cancel
+          </dt-button>
+          <dt-button
+            :kind="kind"
+            importance="primary"
+          >
+            Confirm
           </dt-button>
         </div>
       </template>

--- a/components/modal/modal_default.story.vue
+++ b/components/modal/modal_default.story.vue
@@ -46,13 +46,13 @@
         />
         <div v-else>
           <dt-button
-            :kind="kind"
+            :kind="$attrs.kind"
             importance="clear"
           >
             Cancel
           </dt-button>
           <dt-button
-            :kind="kind"
+            :kind="$attrs.kind"
             importance="primary"
           >
             Confirm

--- a/components/modal/modal_default.story.vue
+++ b/components/modal/modal_default.story.vue
@@ -46,7 +46,6 @@
         />
         <div v-else>
           <dt-button
-            kind="muted"
             importance="clear"
           >
             Cancel

--- a/components/modal/modal_default.story.vue
+++ b/components/modal/modal_default.story.vue
@@ -46,7 +46,7 @@
         />
         <div v-else>
           <dt-button
-            :kind="$attrs.kind"
+            kind="muted"
             importance="clear"
           >
             Cancel
@@ -54,6 +54,7 @@
           <dt-button
             :kind="$attrs.kind"
             importance="primary"
+            class="d-ml6"
           >
             Confirm
           </dt-button>


### PR DESCRIPTION
# Update danger modal style - Vue 3

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

This is to make dialtone-vue's modal component match the styles of dialtone.

The corresponding change in dialtone was made in this PR https://github.com/dialpad/dialtone/pull/689

## :bulb: Context

To match modal styles of dialtone.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size

## :camera: Screenshots / GIFs

![Screenshot 2022-11-06 at 9 56 20 PM](https://user-images.githubusercontent.com/79533776/200182450-2ae5f5e4-816b-4b8b-a485-839f03df85ec.png)
