### PR TITLE
fix(popover): prevent default context menu when openOnContext is true

### DIFF
--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -22,7 +22,7 @@
         data-qa="dt-popover-anchor"
         :tabindex="openOnContext ? 0 : undefined"
         @click.capture="defaultToggleOpen"
-        @contextmenu.prevent="onContext"
+        @contextmenu="onContext"
         @keydown.up.prevent="onArrowKeyPress"
         @keydown.down.prevent="onArrowKeyPress"
         @wheel="(e) => (isOpen && modal) && e.preventDefault()"
@@ -668,6 +668,8 @@ export default {
 
     onContext (event) {
       if (!this.openOnContext) { return; }
+
+      event.preventDefault();
 
       this.tip?.setProps({
         placement: 'right-start',


### PR DESCRIPTION
# Prevent default context menu when openOnContext is true

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Vue 3 version of https://github.com/dialpad/dialtone-vue/pull/587

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [ ] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
