### PR TITLE
refactor: dialtone icons

### DIFF
--- a/common/storybook_utils.js
+++ b/common/storybook_utils.js
@@ -31,21 +31,6 @@ export function getIconNames () {
 }
 
 /**
- * Gets the full list of dialtone SVG icon names from the dialtone package
- * Also sets the context to use Dialtone Vue icons without bundling them.
- * @returns {string[]} icon names
-*/
-export function getV7IconNames () {
-  const requireContext = require.context(
-    '../node_modules/@dialpad/dialtone/lib/dist/svg/v7',
-    false,
-    /[A-Z]\w+\.svg$/i,
-  );
-
-  return [...getComponentFilesFromDir(requireContext).map(item => item.componentName)];
-}
-
-/**
  * Extracts filename and component name from all files in a directory.
  * @param {object} requireContext - a requireContext containing the path of the
  * directory you would like to read files from

--- a/common/utils.js
+++ b/common/utils.js
@@ -109,7 +109,7 @@ export const flushPromises = () => {
 };
 
 /**
- * Transform a string from kebab-case to pascalCase
+ * Transform a string from kebab-case to PascalCase
  * @param string
  * @returns {string}
  */
@@ -119,6 +119,17 @@ export const kebabCaseToPascalCase = (string) => {
     .split('-')
     .map(word => word.charAt(0).toUpperCase() + word.slice(1))
     .join('');
+};
+
+/**
+ * Transform a string from PascalCase to kebab-case
+ * @param string
+ * @returns {string}
+ */
+export const pascalCaseToKebabCase = (string) => {
+  return string
+    .replace(/\.?([A-Z0-9]+)/g, (x, y) => '-' + y.toLowerCase())
+    .replace(/^-/, '');
 };
 
 export default {

--- a/components/icon/icon.stories.js
+++ b/components/icon/icon.stories.js
@@ -4,7 +4,11 @@ import {
 } from './icon_constants';
 import BaseIconMdx from './icon.mdx';
 import IconDefault from './icon_default.story.vue';
-import { createTemplateFromVueFile, getV7IconNames } from '@/common/storybook_utils';
+import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import * as dialtoneIcons from '@dialpad/dialtone-icons';
+import { pascalCaseToKebabCase } from '@/common/utils';
+
+const iconsList = Object.keys(dialtoneIcons).map(name => pascalCaseToKebabCase(name));
 
 export const argTypesData = {
   size: {
@@ -16,7 +20,7 @@ export const argTypesData = {
   name: {
     control: {
       type: 'select',
-      options: getV7IconNames(),
+      options: iconsList,
     },
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dialpad/dialtone-vue",
       "version": "2.36.0",
       "dependencies": {
-        "@dialpad/dialtone-icons": "^0.0.2",
+        "@dialpad/dialtone-icons": "0.0.8",
         "@linusborg/vue-simple-portal": "^0.1.5",
         "emoji-regex": "^10.1.0",
         "emoji-toolkit": "^6.6.0",
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@commitlint/cli": "^17.1.2",
         "@commitlint/config-conventional": "^17.1.0",
-        "@dialpad/dialtone": "^7.4.0",
+        "@dialpad/dialtone": "^7.4.1",
         "@percy/cli": "1.10.2",
         "@percy/storybook": "4.2.1",
         "@semantic-release/changelog": "^6.0.1",
@@ -2853,9 +2853,9 @@
       }
     },
     "node_modules/@dialpad/dialtone": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.4.0.tgz",
-      "integrity": "sha512-TGOSNC71V5q3H/SOYnhEce+SpxRyuG2TyLrR7ahYd8fphUcR4FRCXR9FTSRX0S4IKobxTt/rfQMEJiU2zoAwbQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.4.1.tgz",
+      "integrity": "sha512-WEzNs8bpJGlRUbqooK1yEcIusyGXAUAlYQHDNo0mUVKCxiRXZa2cGMXW0Mq5a3/LfqJKZ/EIs4BV9l65nw/YCg==",
       "dev": true,
       "dependencies": {
         "@docsearch/js": "^3.2.1",
@@ -2866,9 +2866,9 @@
       }
     },
     "node_modules/@dialpad/dialtone-icons": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.2.tgz",
-      "integrity": "sha512-yPfHw9fQCZLr5rWm3LGfGzLbXVagyokp1UZJuXWdMBkhZehNvnvpCDgrI4wmnlN/ikkzFxiQ24JE+kg13xqS/A==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.8.tgz",
+      "integrity": "sha512-SuMO2lBiCBoTzD/5uUKIVunXlnCSfrGTfc70zXZlk/TkfUxAHgm8CBLgWlgs5clyDVrjdGhmEs/DELrEHwBVwg==",
       "dependencies": {
         "core-js": "^3.8.3",
         "vue": "2.7.13"
@@ -31490,9 +31490,9 @@
       }
     },
     "@dialpad/dialtone": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.4.0.tgz",
-      "integrity": "sha512-TGOSNC71V5q3H/SOYnhEce+SpxRyuG2TyLrR7ahYd8fphUcR4FRCXR9FTSRX0S4IKobxTt/rfQMEJiU2zoAwbQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.4.1.tgz",
+      "integrity": "sha512-WEzNs8bpJGlRUbqooK1yEcIusyGXAUAlYQHDNo0mUVKCxiRXZa2cGMXW0Mq5a3/LfqJKZ/EIs4BV9l65nw/YCg==",
       "dev": true,
       "requires": {
         "@docsearch/js": "^3.2.1",
@@ -31500,9 +31500,9 @@
       }
     },
     "@dialpad/dialtone-icons": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.2.tgz",
-      "integrity": "sha512-yPfHw9fQCZLr5rWm3LGfGzLbXVagyokp1UZJuXWdMBkhZehNvnvpCDgrI4wmnlN/ikkzFxiQ24JE+kg13xqS/A==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.8.tgz",
+      "integrity": "sha512-SuMO2lBiCBoTzD/5uUKIVunXlnCSfrGTfc70zXZlk/TkfUxAHgm8CBLgWlgs5clyDVrjdGhmEs/DELrEHwBVwg==",
       "requires": {
         "core-js": "^3.8.3",
         "vue": "2.7.13"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "./emoji": "./dist/emoji.common.js"
   },
   "dependencies": {
-    "@dialpad/dialtone-icons": "^0.0.2",
+    "@dialpad/dialtone-icons": "0.0.8",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "emoji-regex": "^10.1.0",
     "emoji-toolkit": "^6.6.0",
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
-    "@dialpad/dialtone": "^7.4.0",
+    "@dialpad/dialtone": "^7.4.1",
     "@percy/cli": "1.10.2",
     "@percy/storybook": "4.2.1",
     "@semantic-release/changelog": "^6.0.1",


### PR DESCRIPTION
# Refactor Dialtone Icon component

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [ ] Feature
- [x] Refactoring
- [ ] Documentation

## :book: Description

Refactored Dialtone icon component to get the list of icons directly from dialtone-icons package instead of getting from dialtone.

## :bulb: Context

We needed to updated dialtone-icons version but found that icons were out of sync, leaved only one source of truth (dialtone-icons).

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root