### PR TITLE
fix(list-item): fix focus ring color in dark background

### DIFF
--- a/components/list_item/list_item.vue
+++ b/components/list_item/list_item.vue
@@ -3,7 +3,7 @@
   <component
     :is="elementType"
     :id="id"
-    :class="['dt-list-item d-ls-none focus-visible', {
+    :class="['dt-list-item d-ls-none', {
       'dt-list-item--focusable': isFocusable,
       'dt-list-item--highlighted': isHighlighted,
       'dt-list-item--static': !isHoverable,
@@ -230,6 +230,8 @@ export default {
 }
 
 .dt-list-item:focus-visible {
-  outline-color: var(--purple-500);
+  border-radius: var(--br4);
+  outline: none;
+  box-shadow: inset 0 0 0 var(--su2) var(--focus-ring);
 }
 </style>


### PR DESCRIPTION
# Fix focus ring color in dark background

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Jira ticket: https://dialpad.atlassian.net/browse/DT-762

We are styling the color of the default focus ring added by the browser. In Chrome, it adds an external white outline that's visible on a dark background. Changed the default outline approach to use the same approach we use in the [link component with box-shadow](https://github.com/dialpad/dialtone/blob/staging/lib/build/less/components/link.less#L43-L47).

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

### List item

<img width="919" alt="2022-11-10 at 16 04 50@2x" src="https://user-images.githubusercontent.com/83774467/201184456-13376c02-7d03-45fb-afea-85cdf1364549.png">

<img width="919" alt="2022-11-10 at 16 06 56@2x" src="https://user-images.githubusercontent.com/83774467/201184468-1a54cfe1-ab7f-4acc-838d-7e6fac232577.png">

<img width="919" alt="2022-11-10 at 16 05 57@2x" src="https://user-images.githubusercontent.com/83774467/201184495-81719670-da74-443a-befe-d9ec02e2c512.png">

<img width="919" alt="2022-11-10 at 16 06 04@2x" src="https://user-images.githubusercontent.com/83774467/201184514-918cc9cb-9447-4b8d-9506-153bbbf15e10.png">

### Dropdown

<img width="1181" alt="2022-11-10 at 16 10 16@2x" src="https://user-images.githubusercontent.com/83774467/201185227-e519465b-4956-426e-91bc-a3541852511f.png">

<img width="1181" alt="2022-11-10 at 16 10 41@2x" src="https://user-images.githubusercontent.com/83774467/201185235-0f321eb8-3ca9-470f-b53f-51be49f69130.png">

## :link: Sources

<!--- Add any links to external reference material -->
