### PR TITLE
fix(popover): fix popover on the initial load in vue3 version

### DIFF
--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -51,7 +51,7 @@
         :aria-modal="`${!modal}`"
         :transition="transition"
         :show="isOpen"
-        appear
+        :appear="contentAppear"
         :class="['d-popover__dialog', { 'd-popover__dialog--modal': modal }, dialogClass]"
         :style="{
           'max-height': maxHeight,
@@ -265,6 +265,14 @@ export default {
       type: String,
       default: null,
       validator: contentWidth => POPOVER_CONTENT_WIDTHS.includes(contentWidth),
+    },
+
+    /**
+     * Whether to apply transition on initial render in the content lazy show component.
+     */
+    contentAppear: {
+      type: Boolean,
+      default: false,
     },
 
     /**

--- a/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue
+++ b/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue
@@ -46,6 +46,7 @@
         role="listbox"
         :external-anchor="externalAnchor"
         :content-width="contentWidth"
+        :content-appear="true"
         :content-tabindex="null"
         :modal="false"
         :auto-focus="false"

--- a/recipes/comboboxes/combobox_with_popover/combobox_with_popover_default.story.vue
+++ b/recipes/comboboxes/combobox_with_popover/combobox_with_popover_default.story.vue
@@ -96,7 +96,7 @@ export default {
   methods: {
     onComboboxSelect (i) {
       this.$attrs.onSelect(i);
-      this.value = this.items[i].number;
+      this.value = this.$attrs.items[i].number;
     },
 
     onComboboxEscape () {


### PR DESCRIPTION
# fix popover on the initial load in vue3 version

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Since we have the [`appear` prop set in the lazy show component](https://github.com/dialpad/dialtone-vue/blob/vue3/components/popover/popover.vue#L54) in the popover's content, the hooks for the transition were being executed in the first load. It's only needed to be set in the combobox with popover to get these transition hooks fired and enable the keyboard navigation.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
