### PR TITLE
refactor: allow default list item to truncate vue3

### DIFF
--- a/components/list_item/default_list_item.vue
+++ b/components/list_item/default_list_item.vue
@@ -8,7 +8,7 @@
       <!-- @slot Slot for the left content -->
       <slot name="left" />
     </section>
-    <section class="d-fl-grow1">
+    <section class="d-fl-grow1 d-of-hidden">
       <div v-if="$slots.default">
         <!-- @slot Slot for the main content -->
         <slot />


### PR DESCRIPTION
# Allow default list item to truncate vue3

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [ ] Feature
- [x] Refactoring
- [ ] Documentation

## :book: Description

Add `d-of-hidden` to the flex container for the main content of the default list item to allow the contents to be truncated.

## :bulb: Context

I don't think it's possible to get this content to truncate without this change. The instances I've seen using dt-list-item and truncation are using the "custom" type – maybe for this exact reason. This is the use case that this should fix:
```
  <DtListItem>
    <p class="d-truncate">
      {{ long_content }}
    </p>
  </DtListItem>
```

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes

## :camera: Screenshots / GIFs

Before:
![image](https://user-images.githubusercontent.com/50376477/202576236-ac2ecdf4-87cd-44d0-956f-f8735368dd3c.png)

After:
![image](https://user-images.githubusercontent.com/50376477/202576270-0e84ae1b-12b4-496e-a04f-a494e41e353f.png)

