### PR TITLE
chore(semantic-release): add refactor type to release rules

### DIFF
--- a/.github/COMMIT_CONVENTION.md
+++ b/.github/COMMIT_CONVENTION.md
@@ -30,13 +30,13 @@ Must be one of the following:
 * **docs**: documentation changes.
 * **feat**: a new feature (corresponding with `MINOR` in SemVer).
 * **fix**: a bug fix (corresponding with `PATCH` in SemVer).
-* **perf**: performance improvements.
-* **refactor**: changes that neither fix a bug nor add a feature.
+* **perf**: performance improvements (corresponding with `PATCH` in SemVer).
+* **refactor**: changes that neither fix a bug nor add a feature (corresponding with `PATCH` in SemVer).
 * **revert**: changes that revert a commit.
 * **style**: not relevant changes (whitespace, code formatting, semicolons, etc).
 * **test**: changes that add or modify tests.
 
-> Only `feat`, `fix` and `perf` types trigger a new release. Commits with `BREAKING CHANGE:` in the footer of the commit message, regardless of type, will generate a `MAJOR` release.
+> Only `feat`, `fix`, `perf` and `refactor` types trigger a new release. Commits with `BREAKING CHANGE:` in the footer of the commit message, regardless of type, will generate a `MAJOR` release.
 
 ### Scope:
 

--- a/release-ci.config.js
+++ b/release-ci.config.js
@@ -12,7 +12,12 @@ module.exports = {
     },
   ],
   plugins: [
-    '@semantic-release/commit-analyzer',
+    ['@semantic-release/commit-analyzer', {
+      preset: 'angular',
+      releaseRules: [
+        { type: 'refactor', release: 'patch' },
+      ],
+    }],
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],

--- a/release-local.config.js
+++ b/release-local.config.js
@@ -13,7 +13,12 @@ module.exports = {
     },
   ],
   plugins: [
-    '@semantic-release/commit-analyzer',
+    ['@semantic-release/commit-analyzer', {
+      preset: 'angular',
+      releaseRules: [
+        { type: 'refactor', release: 'patch' },
+      ],
+    }],
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],


### PR DESCRIPTION
# Add refactor type to release rules

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Same update to the release config proposed in Dialtone https://github.com/dialpad/dialtone/pull/741

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
