### PR TITLE
build: fix visual tests

### DIFF
--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Check out branch
         uses: actions/checkout@v3
-        with:
-          ref: "refs/pull/${{ github.event.pull_request.number }}/merge"
 
       - name: Use Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
# Fix visual tests

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Removed `ref` from the checkout action, it was failing on pushing to staging.

## :bulb: Context

Visual tests failed when merged #608 due to `ref` variable pointing to `refs/pull/` and that is only correct on pull_request actions not on push.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root