### PR TITLE
fix: update icon color to primary color in active state in DtRecipeCallbarButton

### DIFF
--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -158,11 +158,6 @@ export default {
   border-color: unset;
 }
 
-.dt-recipe-callbar-button--active {
-  --button--fc: var(--muted-color-hover);
-  --button--bgc: hsla(var(--muted-color-hsl) ~' / ' 15%);
-}
-
 .dt-recipe-callbar-button--danger.dt-recipe-callbar-button--active {
   --button--bgc: hsla(var(--error-color-hsl) ~' / ' 10%);
   --button--fc: var(--error-color-hover);
@@ -171,5 +166,12 @@ export default {
 .dt-recipe-callbar-button--danger.dt-recipe-callbar-button--active:hover {
   --button--bgc: hsla(var(--error-color-hsl)  ~' / ' 20%);
   --button--fc: var(--error-color-hover);
+}
+
+.dt-recipe-callbar-button--active,
+.dt-recipe-callbar-button--active:hover{
+  .base-button__icon {
+    color: var(--primary-color);
+  }
 }
 </style>


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

This pull request updates icon color to primary color in `active` state in `DtRecipeCallbarButton` component.

## :bulb: Context
In new design, when a button is in `selected` state (aka `active` state), we should change the icon color to primary color:
![Screen Shot 2022-11-22 at 3 11 42 PM](https://user-images.githubusercontent.com/61763780/203439756-f927d25f-f2ab-4021-aa2e-fae46ed24057.png)
This rule should also apply to hover state as well.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Make a new release for Dialtone-vue.

## :camera: Screenshots / GIFs

Normal State:

![Screen Shot 2022-11-22 at 2 55 29 PM](https://user-images.githubusercontent.com/61763780/203440103-9e793d4f-c87e-484e-8096-d6633fb3efad.png)

Active State:

![Screen Shot 2022-11-22 at 2 55 21 PM](https://user-images.githubusercontent.com/61763780/203440156-6a0193fd-7b66-4ce7-b954-3d39fffb9c26.png)

Normal State (with hover):

![Screen Shot 2022-11-22 at 2 55 46 PM](https://user-images.githubusercontent.com/61763780/203440273-c043fcd9-48d4-4931-aaa1-8dca67542f90.png)

Active State (with hover):

![Screen Shot 2022-11-22 at 2 55 37 PM](https://user-images.githubusercontent.com/61763780/203440268-1225ca84-d421-452f-9972-24b6efeb7f6c.png)



## :link: Sources

Figma design: https://www.figma.com/file/lGKE93k5Ydn16NF6fLe5r9/%E2%9C%A8-%5BDP-39438-EPIC%5D-Call-Workflow-Stakeholder-Presentations?node-id=3944%3A151081
