### PR TITLE
chore: update dialtone-icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.40.0",
       "license": "MIT",
       "dependencies": {
-        "@dialpad/dialtone-icons": "0.0.8",
+        "@dialpad/dialtone-icons": "0.0.12",
         "@linusborg/vue-simple-portal": "^0.1.5",
         "emoji-regex": "^10.1.0",
         "emoji-toolkit": "^6.6.0",
@@ -2902,12 +2902,12 @@
       }
     },
     "node_modules/@dialpad/dialtone-icons": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.8.tgz",
-      "integrity": "sha512-SuMO2lBiCBoTzD/5uUKIVunXlnCSfrGTfc70zXZlk/TkfUxAHgm8CBLgWlgs5clyDVrjdGhmEs/DELrEHwBVwg==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.12.tgz",
+      "integrity": "sha512-LdrESsD9mGN90xxo8puAXUB3gvmk1nakYQGdQSamrGyepaAIdQRsPS4FaA6aHpRIYlaBY51OdHKhBr3GLJFjBw==",
       "dependencies": {
         "core-js": "^3.8.3",
-        "vue": "2.7.13"
+        "vue": ">=2.6"
       },
       "peerDependencies": {
         "vue": ">=2.6"
@@ -33675,12 +33675,12 @@
       }
     },
     "@dialpad/dialtone-icons": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.8.tgz",
-      "integrity": "sha512-SuMO2lBiCBoTzD/5uUKIVunXlnCSfrGTfc70zXZlk/TkfUxAHgm8CBLgWlgs5clyDVrjdGhmEs/DELrEHwBVwg==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.12.tgz",
+      "integrity": "sha512-LdrESsD9mGN90xxo8puAXUB3gvmk1nakYQGdQSamrGyepaAIdQRsPS4FaA6aHpRIYlaBY51OdHKhBr3GLJFjBw==",
       "requires": {
         "core-js": "^3.8.3",
-        "vue": "2.7.13"
+        "vue": ">=2.6"
       }
     },
     "@docsearch/css": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.40.0",
       "license": "MIT",
       "dependencies": {
-        "@dialpad/dialtone-icons": "0.0.12",
+        "@dialpad/dialtone-icons": "0.0.13",
         "@linusborg/vue-simple-portal": "^0.1.5",
         "emoji-regex": "^10.1.0",
         "emoji-toolkit": "^6.6.0",
@@ -2902,9 +2902,9 @@
       }
     },
     "node_modules/@dialpad/dialtone-icons": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.12.tgz",
-      "integrity": "sha512-LdrESsD9mGN90xxo8puAXUB3gvmk1nakYQGdQSamrGyepaAIdQRsPS4FaA6aHpRIYlaBY51OdHKhBr3GLJFjBw==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.13.tgz",
+      "integrity": "sha512-zwS4PYDTKDXAbMqcCT0tjkxH7qC4SYl6Ji58Nq7ktCHvWi9PIu21wy8zdYkISSIURMFh2n1avNMbESFyTECsHQ==",
       "dependencies": {
         "core-js": "^3.8.3",
         "vue": ">=2.6"
@@ -33675,9 +33675,9 @@
       }
     },
     "@dialpad/dialtone-icons": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.12.tgz",
-      "integrity": "sha512-LdrESsD9mGN90xxo8puAXUB3gvmk1nakYQGdQSamrGyepaAIdQRsPS4FaA6aHpRIYlaBY51OdHKhBr3GLJFjBw==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.13.tgz",
+      "integrity": "sha512-zwS4PYDTKDXAbMqcCT0tjkxH7qC4SYl6Ji58Nq7ktCHvWi9PIu21wy8zdYkISSIURMFh2n1avNMbESFyTECsHQ==",
       "requires": {
         "core-js": "^3.8.3",
         "vue": ">=2.6"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "node": "16"
   },
   "dependencies": {
-    "@dialpad/dialtone-icons": "0.0.12",
+    "@dialpad/dialtone-icons": "0.0.13",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "emoji-regex": "^10.1.0",
     "emoji-toolkit": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "node": "16"
   },
   "dependencies": {
-    "@dialpad/dialtone-icons": "0.0.8",
+    "@dialpad/dialtone-icons": "0.0.12",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "emoji-regex": "^10.1.0",
     "emoji-toolkit": "^6.6.0",


### PR DESCRIPTION
# Update dialtone-icons version to include newer icons

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Updated dialtone-icons version

## :bulb: Context

Added icons to dialtone-icons, we need them on dialtone-vue too.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root