### PR TITLE
feat: add aria-label for icon

### DIFF
--- a/components/icon/icon.mdx
+++ b/components/icon/icon.mdx
@@ -32,6 +32,13 @@ a height the icon is going to have:
 
 <ArgsTable story={PRIMARY_STORY} />
 
+## Accessibility
+
+If you use an icon to portray something more than just it's visual appearance, make sure to add a description of its
+function to the ariaLabel prop.
+
+Example: A down arrow icon button that opens a dropdown settings menu, set the ariaLabel as 'open settings menu'.
+
 ## Usage
 
 ### Import

--- a/components/icon/icon.test.js
+++ b/components/icon/icon.test.js
@@ -64,6 +64,17 @@ describe('DtIcon Tests', function () {
   });
 
   describe('Accessibility Tests', function () {
-    //
+    describe('When ariaLabel prop is set', function () {
+      beforeEach(async function () {
+        await wrapper.setProps({ ariaLabel: 'icon description' });
+        _setChildWrappers();
+      });
+      it('sets the aria-label attribute', function () {
+        assert.strictEqual(icon.attributes('aria-label'), 'icon description');
+      });
+      it('sets aria-hidden to false', function () {
+        assert.strictEqual(icon.attributes('aria-hidden'), 'false');
+      });
+    });
   });
 });

--- a/components/icon/icon.vue
+++ b/components/icon/icon.vue
@@ -2,6 +2,8 @@
   <component
     :is="currentIcon"
     data-qa="dt-icon"
+    :aria-hidden="ariaLabel ? 'false' : 'true'"
+    :aria-label="ariaLabel"
     :class="iconSize"
   />
 </template>
@@ -35,6 +37,14 @@ export default {
     name: {
       type: String,
       required: true,
+    },
+
+    /**
+     * The label of the icon as read out by a screenreader. Leave this unset if your icon is purely presentational
+     */
+    ariaLabel: {
+      type: String,
+      default: undefined,
     },
   },
 

--- a/components/icon/icon_default.story.vue
+++ b/components/icon/icon_default.story.vue
@@ -2,6 +2,7 @@
   <dt-icon
     :size="size"
     :name="name"
+    :aria-label="ariaLabel"
   />
 </template>
 


### PR DESCRIPTION
# feat: add aria-label for icon

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Adding aria-label for icon component. We have found there are some cases when this is needed. Generally when the icon conveys some other functional meaning than just its visual imagery.

I'll be honest it's very unclear which is the "correct" way to do this. I was reluctant to put aria-label on here because it's only supposed to be for interactive elements. However the official MDN docs recommend doing it exactly this way:

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role#svg_and_roleimg

Also found this article that compares various ways of doing it and how different screen readers respond:

https://www.smashingmagazine.com/2021/05/accessible-svg-patterns-comparison

For the time being I am doing the aria-label way because it's much easier to implement than title since it's not embedded within the svg, and doesn't really seem to be any worse than title for screen readers.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Update dialtone once it contains the `role="img"` change

## :link: Sources

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role#svg_and_roleimg
https://www.smashingmagazine.com/2021/05/accessible-svg-patterns-comparison

