### PR TITLE
feat(collapsible): update `DtCollapsible` to show content when collapsed

### DIFF
--- a/components/collapsible/collapsible.stories.js
+++ b/components/collapsible/collapsible.stories.js
@@ -16,7 +16,15 @@ const argTypesData = {
       },
     },
   },
-  content: {
+  contentOnCollapsed: {
+    control: 'text',
+    table: {
+      type: {
+        summary: 'VNode',
+      },
+    },
+  },
+  contentOnExpanded: {
     control: 'text',
     table: {
       type: {

--- a/components/collapsible/collapsible.stories.js
+++ b/components/collapsible/collapsible.stories.js
@@ -90,6 +90,12 @@ const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
   DtCollapsibleDefaultStory,
 );
 
+// Stories
+export const Default = DefaultTemplate.bind({});
+Default.args = {
+  maxWidth: '512px',
+};
+
 const VariantTemplate = (args, { argTypes }) => createTemplateFromVueFile(
   args,
   argTypes,
@@ -97,9 +103,3 @@ const VariantTemplate = (args, { argTypes }) => createTemplateFromVueFile(
 );
 
 export const Variants = VariantTemplate.bind({});
-
-// Stories
-export const Default = DefaultTemplate.bind({});
-Default.args = {
-  maxWidth: '512px',
-};

--- a/components/collapsible/collapsible.stories.js
+++ b/components/collapsible/collapsible.stories.js
@@ -1,9 +1,10 @@
+import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import {
   DtCollapsible,
 } from './';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import CollapsibleMdx from './collapsible.mdx';
 import DtCollapsibleDefaultStory from './collapsible_default.story.vue';
+import DtCollapsibleVariantsStory from './collapsible_variants.story.vue';
 
 const argTypesData = {
   // Slots
@@ -80,6 +81,14 @@ const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
   argTypes,
   DtCollapsibleDefaultStory,
 );
+
+const VariantTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  DtCollapsibleVariantsStory,
+);
+
+export const Variants = VariantTemplate.bind({});
 
 // Stories
 export const Default = DefaultTemplate.bind({});

--- a/components/collapsible/collapsible.test.js
+++ b/components/collapsible/collapsible.test.js
@@ -23,16 +23,8 @@ describe('Dialtone vue Collapsible Component Tests', function () {
   let anchorSlotElement;
 
   // Environment
-  let slots = { contentOnExpanded, contentOnCollapsed };
-  let propsData = baseProps;
-
-  const _clearChildWrappers = () => {
-    contentWrapperElement = undefined;
-    contentOnExpandedElement = undefined;
-    contentOnCollapsedElement = undefined;
-    anchorElement = undefined;
-    anchorSlotElement = undefined;
-  };
+  const defaultSlots = { contentOnExpanded, contentOnCollapsed };
+  const defaultPropsData = baseProps;
 
   const findAllElements = () => {
     anchorElement = wrapper.find('[data-qa="dt-button"]');
@@ -42,7 +34,7 @@ describe('Dialtone vue Collapsible Component Tests', function () {
     contentWrapperElement = wrapper.findComponent({ ref: 'contentWrapper' });
   };
 
-  const mountWrapper = () => {
+  const mountWrapper = ({ propsData = defaultPropsData, slots = defaultSlots } = {}) => {
     wrapper = mount(DtCollapsible, {
       propsData,
       slots,
@@ -68,12 +60,6 @@ describe('Dialtone vue Collapsible Component Tests', function () {
     config.renderStubDefaultSlot = false;
   });
 
-  afterEach(async function () {
-    propsData = baseProps;
-    slots = { contentOnExpanded, contentOnCollapsed };
-    _clearChildWrappers();
-  });
-
   describe('Test default rendering', function () {
     it('should render the component', function () {
       assert.isTrue(wrapper.exists(), 'wrapper exists');
@@ -94,8 +80,9 @@ describe('Dialtone vue Collapsible Component Tests', function () {
 
   describe('When scoped slot is provided for anchor', function () {
     beforeEach(function () {
-      slots = { anchor };
-      mountWrapper();
+      mountWrapper({
+        slots: { anchor },
+      });
     });
 
     it('should render the anchor slot', function () {
@@ -105,8 +92,9 @@ describe('Dialtone vue Collapsible Component Tests', function () {
 
   describe('When scoped slot is not provided for any content', function () {
     beforeEach(function () {
-      slots = { };
-      mountWrapper();
+      mountWrapper({
+        slots: {},
+      });
     });
 
     it('should NOT render any content if no slot is passed', function () {
@@ -130,19 +118,15 @@ describe('Dialtone vue Collapsible Component Tests', function () {
         assert.isFalse(contentOnExpandedElement.exists());
         assert.isTrue(contentOnCollapsedElement.isVisible());
       });
-    });
-
-    describe('when user clicks anchor when it is collapsed', function () {
-      beforeEach(async function () {
-        // need to trigger twice since the initial state of the
-        // wrapper is expanded. We want it to be collapsed initially.
-        await anchorElement.trigger('click');
-        await anchorElement.trigger('click');
-      });
-      it('should be expanded', function () {
-        findAllElements();
-        assert.isTrue(contentOnExpandedElement.isVisible());
-        assert.isFalse(contentOnCollapsedElement.exists());
+      describe('when user clicks anchor when it is collapsed', function () {
+        beforeEach(async function () {
+          await anchorElement.trigger('click');
+        });
+        it('should be expanded', function () {
+          findAllElements();
+          assert.isTrue(contentOnExpandedElement.isVisible());
+          assert.isFalse(contentOnCollapsedElement.exists());
+        });
       });
     });
   });
@@ -182,11 +166,12 @@ describe('Dialtone vue Collapsible Component Tests', function () {
 
     describe('Test open prop set to false', function () {
       beforeEach(async function () {
-        propsData = {
-          ...baseProps,
-          open: false,
-        };
-        mountWrapper();
+        mountWrapper({
+          propsData: {
+            ...baseProps,
+            open: false,
+          },
+        });
       });
 
       it('content starts collapsed', function () {
@@ -224,8 +209,9 @@ describe('Dialtone vue Collapsible Component Tests', function () {
 
     beforeEach(async function () {
       consoleErrorSpy = sinon.spy(console, 'error');
-      propsData = { ...baseProps, anchorText: undefined };
-      mountWrapper();
+      mountWrapper({
+        propsData: { ...baseProps, anchorText: undefined },
+      });
     });
 
     afterEach(function () {
@@ -241,11 +227,12 @@ describe('Dialtone vue Collapsible Component Tests', function () {
   describe('Accessibility Tests', function () {
     describe('Anchor aria-label', function () {
       beforeEach(async function () {
-        propsData = {
-          ...baseProps,
-          ariaLabel: 'Anchor Aria Label',
-        };
-        mountWrapper();
+        mountWrapper({
+          propsData: {
+            ...baseProps,
+            ariaLabel: 'Anchor Aria Label',
+          },
+        });
       });
       it('should correctly set the aria-label attribute on anchor button', async function () {
         assert.equal(anchorElement.attributes('aria-label'), 'Anchor Aria Label');
@@ -254,8 +241,9 @@ describe('Dialtone vue Collapsible Component Tests', function () {
 
     describe('Content wrapper `aria-hidden` property when contentOnCollapsed does not exist', function () {
       beforeEach(function () {
-        slots = { contentOnExpanded };
-        mountWrapper();
+        mountWrapper({
+          slots: { contentOnExpanded },
+        });
       });
       it('should set aria-hidden to false when content expanded exists', function () {
         assert.equal(contentWrapperElement.attributes('aria-hidden'), 'false');
@@ -274,8 +262,9 @@ describe('Dialtone vue Collapsible Component Tests', function () {
 
     describe('Content wrapper `aria-hidden` property when contentOnCollapsed exists', function () {
       beforeEach(function () {
-        slots = { contentOnExpanded, contentOnCollapsed };
-        mountWrapper();
+        mountWrapper({
+          slots: { contentOnExpanded, contentOnCollapsed },
+        });
       });
       it('should set aria-hidden to false when content expanded exists', function () {
         assert.equal(contentWrapperElement.attributes('aria-hidden'), 'false');

--- a/components/collapsible/collapsible.test.js
+++ b/components/collapsible/collapsible.test.js
@@ -13,7 +13,7 @@ const baseProps = {
   anchorText: 'anchor text',
 };
 
-describe('Dialtone vue Collapsible Component Tests', function () {
+describe.only('Dialtone vue Collapsible Component Tests', function () {
   // Wrappers
   let wrapper;
   let contentOnExpandedElement;
@@ -34,7 +34,7 @@ describe('Dialtone vue Collapsible Component Tests', function () {
     anchorSlotElement = undefined;
   };
 
-  const _setChildWrappers = () => {
+  const findAllElements = () => {
     anchorElement = wrapper.find('[data-qa="dt-button"]');
     anchorSlotElement = wrapper.find('[data-qa="anchor-element"]');
     contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
@@ -42,13 +42,13 @@ describe('Dialtone vue Collapsible Component Tests', function () {
     contentWrapperElement = wrapper.findComponent({ ref: 'contentWrapper' });
   };
 
-  const _mountWrapper = () => {
+  const mountWrapper = () => {
     wrapper = mount(DtCollapsible, {
       propsData,
       slots,
       attachTo: document.body,
     });
-    _setChildWrappers();
+    findAllElements();
   };
 
   before(function () {
@@ -58,7 +58,7 @@ describe('Dialtone vue Collapsible Component Tests', function () {
   });
 
   beforeEach(function () {
-    _mountWrapper();
+    mountWrapper();
   });
 
   after(function () {
@@ -95,7 +95,7 @@ describe('Dialtone vue Collapsible Component Tests', function () {
   describe('When scoped slot is provided for anchor', function () {
     beforeEach(function () {
       slots = { anchor };
-      _mountWrapper();
+      mountWrapper();
     });
 
     it('should render the anchor slot', function () {
@@ -106,12 +106,10 @@ describe('Dialtone vue Collapsible Component Tests', function () {
   describe('When scoped slot is not provided for any content', function () {
     beforeEach(function () {
       slots = { };
-      _mountWrapper();
+      mountWrapper();
     });
 
     it('should NOT render any content if no slot is passed', function () {
-      contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
-      contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
       assert.isFalse(contentOnExpandedElement.exists());
       assert.isFalse(contentOnCollapsedElement.exists());
     });
@@ -126,14 +124,12 @@ describe('Dialtone vue Collapsible Component Tests', function () {
     it('should toggle the content when clicked', async function () {
       await anchorElement.trigger('click');
       // re-query the wrapper after template update
-      contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
-      contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
+      findAllElements();
       assert.isFalse(contentOnExpandedElement.exists());
       assert.isTrue(contentOnCollapsedElement.isVisible());
 
       await anchorElement.trigger('click');
-      contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
-      contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
+      findAllElements();
       assert.isTrue(contentOnExpandedElement.isVisible());
       assert.isFalse(contentOnCollapsedElement.exists());
     });
@@ -145,22 +141,20 @@ describe('Dialtone vue Collapsible Component Tests', function () {
         await wrapper.setProps({ open: true });
       });
 
-      it('content is expanded when open = true', function () {
+      it('content is expanded', function () {
         assert.isTrue(contentOnExpandedElement.isVisible());
       });
 
       it('clicking does NOT collapse content', async function () {
         await anchorElement.trigger('click');
-        contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
-        contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
+        findAllElements();
         assert.isTrue(contentOnExpandedElement.isVisible());
         assert.isFalse(contentOnCollapsedElement.exists());
       });
 
       it('updating open prop does collapse content', async function () {
         await wrapper.setProps({ open: false });
-        contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
-        contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
+        findAllElements();
         assert.isFalse(contentOnExpandedElement.exists());
         assert.isTrue(contentOnCollapsedElement.isVisible());
       });
@@ -172,22 +166,20 @@ describe('Dialtone vue Collapsible Component Tests', function () {
       });
 
       it('content starts collapsed', function () {
-        contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
+        findAllElements();
         assert.isFalse(contentOnExpandedElement.exists());
       });
 
       it('clicking does NOT expand content', async function () {
         await anchorElement.trigger('click');
-        contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
-        contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
+        findAllElements();
         assert.isFalse(contentOnExpandedElement.exists());
         assert.isTrue(contentOnCollapsedElement.isVisible());
       });
 
       it('updating open prop does expand content', async function () {
         await wrapper.setProps({ open: true });
-        contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
-        contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
+        findAllElements();
         assert.isTrue(contentOnExpandedElement.isVisible());
         assert.isFalse(contentOnCollapsedElement.exists());
       });
@@ -200,7 +192,7 @@ describe('Dialtone vue Collapsible Component Tests', function () {
     beforeEach(async function () {
       consoleErrorSpy = sinon.spy(console, 'error');
       propsData = { ...baseProps, anchorText: undefined };
-      _mountWrapper();
+      mountWrapper();
     });
 
     afterEach(function () {
@@ -215,7 +207,7 @@ describe('Dialtone vue Collapsible Component Tests', function () {
 
   describe('Accessibility Tests', function () {
     describe('Anchor aria-label', function () {
-      it('should should correctly set the aria-label attribute on anchor', async function () {
+      it('should correctly set the aria-label attribute on anchor', async function () {
         await wrapper.setProps({ ariaLabel: 'Anchor Aria Label' });
         const anchorWrapper = wrapper.findComponent({ ref: 'anchor' });
         assert.equal(anchorWrapper.attributes('aria-label'), 'Anchor Aria Label');
@@ -225,14 +217,13 @@ describe('Dialtone vue Collapsible Component Tests', function () {
     describe('Content wrapper `aria-hidden` property when contentOnCollapsed does not exist', function () {
       beforeEach(function () {
         slots = { contentOnExpanded };
-        _mountWrapper();
+        mountWrapper();
       });
       it(`should aria-hidden to true if
         content is collapsed contentOnCollapsed slot is not provided `, async function () {
-        contentWrapperElement = wrapper.findComponent({ ref: 'contentWrapper' });
         assert.equal(contentWrapperElement.attributes('aria-hidden'), 'false');
         await anchorElement.trigger('click');
-        contentWrapperElement = wrapper.findComponent({ ref: 'contentWrapper' });
+        findAllElements();
         assert.equal(contentWrapperElement.attributes('aria-hidden'), 'true');
       });
     });
@@ -240,14 +231,14 @@ describe('Dialtone vue Collapsible Component Tests', function () {
     describe('Content wrapper `aria-hidden` property when contentOnCollapsed exists', function () {
       beforeEach(function () {
         slots = { contentOnExpanded, contentOnCollapsed };
-        _mountWrapper();
+        mountWrapper();
       });
       it(`should aria-hidden to false if
         content is collapsed contentOnCollapsed slot is provided `, async function () {
         contentWrapperElement = wrapper.findComponent({ ref: 'contentWrapper' });
         assert.equal(contentWrapperElement.attributes('aria-hidden'), 'false');
         await anchorElement.trigger('click');
-        contentWrapperElement = wrapper.findComponent({ ref: 'contentWrapper' });
+        findAllElements();
         assert.equal(contentWrapperElement.attributes('aria-hidden'), 'false');
       });
     });

--- a/components/collapsible/collapsible.test.js
+++ b/components/collapsible/collapsible.test.js
@@ -5,7 +5,10 @@ import sinon from 'sinon';
 import axe from 'axe-core';
 import configA11y from '../../storybook/scripts/storybook-a11y-test.config';
 
-const content = '<div data-qa="content-element"> Test Text </div>';
+const contentOnExpanded = '<div data-qa="content-on-expanded-element"> Expanded Test Text </div>';
+const contentOnCollapsed = '<div data-qa="content-on-collapsed-element"> Collapsed Test Text </div>';
+const anchor = '<button data-qa="anchor-element">click me</button>';
+
 const baseProps = {
   anchorText: 'anchor text',
 };
@@ -13,35 +16,35 @@ const baseProps = {
 describe('Dialtone vue Collapsible Component Tests', function () {
   // Wrappers
   let wrapper;
-  let contentElement;
+  let contentOnExpandedElement;
+  let contentOnCollapsedElement;
   let contentWrapperElement;
   let anchorElement;
-  let scopedSlots = {};
   let anchorSlotElement;
 
   // Environment
-  const slots = { content };
+  let slots = { contentOnExpanded, contentOnCollapsed };
   let propsData = baseProps;
 
   const _clearChildWrappers = () => {
-    contentElement = undefined;
     contentWrapperElement = undefined;
+    contentOnExpandedElement = undefined;
+    contentOnCollapsedElement = undefined;
     anchorElement = undefined;
     anchorSlotElement = undefined;
-    scopedSlots = {};
   };
 
   const _setChildWrappers = () => {
     anchorElement = wrapper.find('[data-qa="dt-button"]');
     anchorSlotElement = wrapper.find('[data-qa="anchor-element"]');
-    contentElement = wrapper.find('[data-qa="content-element"]');
+    contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
+    contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
     contentWrapperElement = wrapper.findComponent({ ref: 'contentWrapper' });
   };
 
   const _mountWrapper = () => {
     wrapper = mount(DtCollapsible, {
       propsData,
-      scopedSlots,
       slots,
       attachTo: document.body,
     });
@@ -67,45 +70,72 @@ describe('Dialtone vue Collapsible Component Tests', function () {
 
   afterEach(async function () {
     propsData = baseProps;
+    slots = { contentOnExpanded, contentOnCollapsed };
     _clearChildWrappers();
   });
 
   describe('Test default rendering', function () {
     it('should render the component', function () {
-      assert.exists(wrapper, 'wrapper exists');
+      assert.isTrue(wrapper.exists(), 'wrapper exists');
     });
 
     it('should render the anchor', function () {
-      assert.exists(anchorElement, 'anchor exists');
+      assert.isTrue(anchorElement.exists(), 'anchor exists');
     });
 
-    it('should render the content', function () {
-      assert.exists(contentElement, 'content exists');
+    it('should render the content on expanded element', function () {
+      assert.isTrue(contentOnExpandedElement.exists(), 'content exists');
+    });
+
+    it('should NOT render the content on collapsed element', function () {
+      assert.isFalse(contentOnCollapsedElement.exists(), 'collapsed content does not exist');
     });
   });
 
-  describe('When scoped slot is provided', function () {
+  describe('When scoped slot is provided for anchor', function () {
     beforeEach(function () {
-      const anchor = '<button data-qa="anchor-element">click me</button>';
-      scopedSlots = { anchor };
+      slots = { anchor };
+      _mountWrapper();
     });
 
-    it('should render the scoped slot', function () {
-      assert.exists(anchorSlotElement, 'anchor slot exists');
+    it('should render the anchor slot', function () {
+      assert.isTrue(anchorSlotElement.exists(), 'anchor slot exists');
+    });
+  });
+
+  describe('When scoped slot is not provided for any content', function () {
+    beforeEach(function () {
+      slots = { };
+      _mountWrapper();
+    });
+
+    it('should NOT render any content if no slot is passed', function () {
+      contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
+      contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
+      assert.isFalse(contentOnExpandedElement.exists());
+      assert.isFalse(contentOnCollapsedElement.exists());
     });
   });
 
   describe('Test open prop undefined', function () {
     it('content should be expanded by default', function () {
-      assert.isTrue(contentElement.isVisible());
+      assert.isTrue(contentOnExpandedElement.isVisible());
+      assert.isFalse(contentOnCollapsedElement.exists());
     });
 
     it('should toggle the content when clicked', async function () {
       await anchorElement.trigger('click');
-      assert.isFalse(contentElement.isVisible());
+      // re-query the wrapper after template update
+      contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
+      contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
+      assert.isFalse(contentOnExpandedElement.exists());
+      assert.isTrue(contentOnCollapsedElement.isVisible());
 
       await anchorElement.trigger('click');
-      assert.isTrue(contentElement.isVisible());
+      contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
+      contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
+      assert.isTrue(contentOnExpandedElement.isVisible());
+      assert.isFalse(contentOnCollapsedElement.exists());
     });
   });
 
@@ -115,18 +145,24 @@ describe('Dialtone vue Collapsible Component Tests', function () {
         await wrapper.setProps({ open: true });
       });
 
-      it('content is expanded', function () {
-        assert.isTrue(contentElement.isVisible());
+      it('content is expanded when open = true', function () {
+        assert.isTrue(contentOnExpandedElement.isVisible());
       });
 
-      it('clicking does not collapse content', async function () {
+      it('clicking does NOT collapse content', async function () {
         await anchorElement.trigger('click');
-        assert.isTrue(contentElement.isVisible());
+        contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
+        contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
+        assert.isTrue(contentOnExpandedElement.isVisible());
+        assert.isFalse(contentOnCollapsedElement.exists());
       });
 
       it('updating open prop does collapse content', async function () {
         await wrapper.setProps({ open: false });
-        assert.isFalse(contentElement.isVisible());
+        contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
+        contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
+        assert.isFalse(contentOnExpandedElement.exists());
+        assert.isTrue(contentOnCollapsedElement.isVisible());
       });
     });
 
@@ -136,17 +172,24 @@ describe('Dialtone vue Collapsible Component Tests', function () {
       });
 
       it('content starts collapsed', function () {
-        assert.isFalse(contentElement.isVisible());
+        contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
+        assert.isFalse(contentOnExpandedElement.exists());
       });
 
-      it('clicking does not expand content', async function () {
+      it('clicking does NOT expand content', async function () {
         await anchorElement.trigger('click');
-        assert.isFalse(contentElement.isVisible());
+        contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
+        contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
+        assert.isFalse(contentOnExpandedElement.exists());
+        assert.isTrue(contentOnCollapsedElement.isVisible());
       });
 
-      it('updating open prop does collapse content', async function () {
+      it('updating open prop does expand content', async function () {
         await wrapper.setProps({ open: true });
-        assert.isTrue(contentElement.isVisible());
+        contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
+        contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
+        assert.isTrue(contentOnExpandedElement.isVisible());
+        assert.isFalse(contentOnCollapsedElement.exists());
       });
     });
   });
@@ -171,6 +214,44 @@ describe('Dialtone vue Collapsible Component Tests', function () {
   });
 
   describe('Accessibility Tests', function () {
+    describe('Anchor aria-label', function () {
+      it('should should correctly set the aria-label attribute on anchor', async function () {
+        await wrapper.setProps({ ariaLabel: 'Anchor Aria Label' });
+        const anchorWrapper = wrapper.findComponent({ ref: 'anchor' });
+        assert.equal(anchorWrapper.attributes('aria-label'), 'Anchor Aria Label');
+      });
+    });
+
+    describe('Content wrapper `aria-hidden` property when contentOnCollapsed does not exist', function () {
+      beforeEach(function () {
+        slots = { contentOnExpanded };
+        _mountWrapper();
+      });
+      it(`should aria-hidden to true if
+        content is collapsed contentOnCollapsed slot is not provided `, async function () {
+        contentWrapperElement = wrapper.findComponent({ ref: 'contentWrapper' });
+        assert.equal(contentWrapperElement.attributes('aria-hidden'), 'false');
+        await anchorElement.trigger('click');
+        contentWrapperElement = wrapper.findComponent({ ref: 'contentWrapper' });
+        assert.equal(contentWrapperElement.attributes('aria-hidden'), 'true');
+      });
+    });
+
+    describe('Content wrapper `aria-hidden` property when contentOnCollapsed exists', function () {
+      beforeEach(function () {
+        slots = { contentOnExpanded, contentOnCollapsed };
+        _mountWrapper();
+      });
+      it(`should aria-hidden to false if
+        content is collapsed contentOnCollapsed slot is provided `, async function () {
+        contentWrapperElement = wrapper.findComponent({ ref: 'contentWrapper' });
+        assert.equal(contentWrapperElement.attributes('aria-hidden'), 'false');
+        await anchorElement.trigger('click');
+        contentWrapperElement = wrapper.findComponent({ ref: 'contentWrapper' });
+        assert.equal(contentWrapperElement.attributes('aria-hidden'), 'false');
+      });
+    });
+
     describe('Content is expanded', function () {
       beforeEach(async function () {
         await wrapper.setProps({ open: true, id: 'contentId' });

--- a/components/collapsible/collapsible.vue
+++ b/components/collapsible/collapsible.vue
@@ -51,7 +51,7 @@
       :aria-hidden="`${!isOpen}`"
       :aria-labelledby="labelledBy"
       :aria-label="ariaLabel"
-      :show="isOpen"
+      :is-expanded="isOpen"
       :element-type="contentElementType"
       :class="[
         'd-dt-collapsible__content',
@@ -249,6 +249,7 @@ export default {
 
   methods: {
     onLeaveTransitionComplete () {
+      console.log('onLeaveTransitionComplete');
       this.$emit('opened', false);
       if (this.open !== null) {
         this.$emit('update:open', false);
@@ -256,6 +257,7 @@ export default {
     },
 
     onEnterTransitionComplete () {
+      console.log('onEnterTransitionComplete');
       this.$emit('opened', true, this.$refs.content);
       if (this.open !== null) {
         this.$emit('update:open', true);

--- a/components/collapsible/collapsible.vue
+++ b/components/collapsible/collapsible.vue
@@ -64,7 +64,6 @@
       tabindex="-1"
       appear
       v-on="$listeners"
-      @transitionfinished="onTransitionFinished"
     >
       <template #contentOnExpanded>
         <!-- @slot Slot for content that is shown when collapsible is expanded -->
@@ -253,21 +252,13 @@ export default {
 
   methods: {
 
-    onTransitionFinished () {
-      this.$emit('opened', this.isOpen);
-      if (this.open !== null) {
-        this.$emit('update:open', this.isOpen);
-      }
-    },
-
     defaultToggleOpen () {
+      this.$emit('opened', !this.isOpen);
       if (this.open === null) {
-        this.toggleOpen();
+        this.isOpen = !this.isOpen;
+      } else {
+        this.$emit('update:open', !this.isOpen);
       }
-    },
-
-    toggleOpen () {
-      this.isOpen = !this.isOpen;
     },
 
     validateProperAnchor () {

--- a/components/collapsible/collapsible.vue
+++ b/components/collapsible/collapsible.vue
@@ -64,8 +64,7 @@
       tabindex="-1"
       appear
       v-on="$listeners"
-      @after-leave="onLeaveTransitionComplete"
-      @after-enter="onEnterTransitionComplete"
+      @transitionfinished="onTransitionFinished"
     >
       <!-- @slot Slot for the collapsible element that is expanded by the anchor -->
       <template #contentOnExpanded>
@@ -248,19 +247,11 @@ export default {
   },
 
   methods: {
-    onLeaveTransitionComplete () {
-      console.log('onLeaveTransitionComplete');
-      this.$emit('opened', false);
-      if (this.open !== null) {
-        this.$emit('update:open', false);
-      }
-    },
 
-    onEnterTransitionComplete () {
-      console.log('onEnterTransitionComplete');
-      this.$emit('opened', true, this.$refs.content);
+    onTransitionFinished () {
+      this.$emit('opened', this.isOpen);
       if (this.open !== null) {
-        this.$emit('update:open', true);
+        this.$emit('update:open', this.isOpen);
       }
     },
 

--- a/components/collapsible/collapsible.vue
+++ b/components/collapsible/collapsible.vue
@@ -8,6 +8,7 @@
     <div
       :id="!ariaLabelledBy && labelledBy"
       ref="anchor"
+      :aria-label="ariaLabel"
       :class="[
         'd-dt-collapsibe__anchor',
         anchorClass,
@@ -48,9 +49,8 @@
     <dt-collapsible-lazy-show
       :id="id"
       ref="contentWrapper"
-      :aria-hidden="`${!isOpen}`"
+      :aria-hidden="`${!isOpen && !hasContentOnCollapse}`"
       :aria-labelledby="labelledBy"
-      :aria-label="ariaLabel"
       :is-expanded="isOpen"
       :element-type="contentElementType"
       :class="[
@@ -66,12 +66,13 @@
       v-on="$listeners"
       @transitionfinished="onTransitionFinished"
     >
-      <!-- @slot Slot for the collapsible element that is expanded by the anchor -->
+      <!-- @slot Slot for content that is shown when collapsible is expanded -->
       <template #contentOnExpanded>
         <slot
           name="contentOnExpanded"
         />
       </template>
+      <!-- @slot Slot for content that is shown when collapsible is collapsed -->
       <template #contentOnCollapsed>
         <slot
           name="contentOnCollapsed"
@@ -183,7 +184,7 @@ export default {
     },
 
     /**
-     * Label on the collapsible content. Should provide this or ariaLabelledBy but not both.
+     * Label on the anchor. Should provide this or ariaLabelledBy but not both.
      */
     ariaLabel: {
       type: String,
@@ -227,6 +228,10 @@ export default {
       // aria-labelledby should be set only if aria-labelledby is passed as a prop, or if
       // there is no aria-label and the labelledby should point to the anchor
       return this.ariaLabelledBy || (!this.ariaLabel && getUniqueString('DtCollapsible__anchor'));
+    },
+
+    hasContentOnCollapse () {
+      return !!this.$slots.contentOnCollapsed;
     },
   },
 

--- a/components/collapsible/collapsible.vue
+++ b/components/collapsible/collapsible.vue
@@ -68,9 +68,16 @@
       @after-enter="onEnterTransitionComplete"
     >
       <!-- @slot Slot for the collapsible element that is expanded by the anchor -->
-      <slot
-        name="content"
-      />
+      <template #contentOnExpanded>
+        <slot
+          name="contentOnExpanded"
+        />
+      </template>
+      <template #contentOnCollapsed>
+        <slot
+          name="contentOnCollapsed"
+        />
+      </template>
     </dt-collapsible-lazy-show>
   </component>
 </template>

--- a/components/collapsible/collapsible.vue
+++ b/components/collapsible/collapsible.vue
@@ -66,14 +66,14 @@
       v-on="$listeners"
       @transitionfinished="onTransitionFinished"
     >
-      <!-- @slot Slot for content that is shown when collapsible is expanded -->
       <template #contentOnExpanded>
+        <!-- @slot Slot for content that is shown when collapsible is expanded -->
         <slot
           name="contentOnExpanded"
         />
       </template>
-      <!-- @slot Slot for content that is shown when collapsible is collapsed -->
       <template #contentOnCollapsed>
+        <!-- @slot Slot for content that is shown when collapsible is collapsed -->
         <slot
           name="contentOnCollapsed"
         />

--- a/components/collapsible/collapsible.vue
+++ b/components/collapsible/collapsible.vue
@@ -8,7 +8,6 @@
     <div
       :id="!ariaLabelledBy && labelledBy"
       ref="anchor"
-      :aria-label="ariaLabel"
       :class="[
         'd-dt-collapsibe__anchor',
         anchorClass,
@@ -28,6 +27,7 @@
           kind="muted"
           :aria-controls="id"
           :aria-expanded="`${isOpen}`"
+          :aria-label="ariaLabel"
           :style="{
             'width': maxWidth,
           }"

--- a/components/collapsible/collapsible_default.story.vue
+++ b/components/collapsible/collapsible_default.story.vue
@@ -23,7 +23,7 @@
         v-html="anchor"
       />
     </template>
-    <template slot="content">
+    <template #contentOnExpanded>
       <div
         v-if="content"
         v-html="content"

--- a/components/collapsible/collapsible_default.story.vue
+++ b/components/collapsible/collapsible_default.story.vue
@@ -25,8 +25,8 @@
     </template>
     <template #contentOnExpanded>
       <div
-        v-if="content"
-        v-html="content"
+        v-if="contentOnExpanded"
+        v-html="contentOnExpanded"
       />
       <div
         v-else
@@ -55,6 +55,12 @@
           est.
         </p>
       </div>
+    </template>
+    <template #contentOnCollapsed>
+      <div
+        v-if="contentOnCollapsed"
+        v-html="contentOnCollapsed"
+      />
     </template>
   </dt-collapsible>
 </template>

--- a/components/collapsible/collapsible_lazy_show.vue
+++ b/components/collapsible/collapsible_lazy_show.vue
@@ -5,12 +5,6 @@
     mode="out-in"
     enter-active-class="enter-active"
     leave-active-class="leave-active"
-    @before-enter="beforeEnter"
-    @enter="enter"
-    @after-enter="afterEnter"
-    @before-leave="beforeLeave"
-    @leave="leave"
-    @after-leave="afterLeave"
     v-on="$listeners"
   >
     <!-- IMPORTANT:
@@ -75,68 +69,6 @@ export default {
     elementType: {
       type: String,
       default: 'div',
-    },
-  },
-
-  methods: {
-    /**
-     * @param {HTMLElement} element
-     */
-    beforeEnter (element) {
-      requestAnimationFrame(() => {
-        if (!element.style.height) {
-          element.style.height = '0px';
-        }
-
-        element.style.display = null;
-      });
-    },
-
-    /**
-     * @param {HTMLElement} element
-     */
-    enter (element) {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          element.style.height = `${element.scrollHeight}px`;
-        });
-      });
-    },
-
-    /**
-     * @param {HTMLElement} element
-     */
-    afterEnter (element) {
-      element.style.height = null;
-    },
-
-    /**
-     * @param {HTMLElement} element
-     */
-    beforeLeave (element) {
-      requestAnimationFrame(() => {
-        if (!element.style.height) {
-          element.style.height = `${element.offsetHeight}px`;
-        }
-      });
-    },
-
-    /**
-     * @param {HTMLElement} element
-     */
-    leave (element) {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          element.style.height = '0px';
-        });
-      });
-    },
-
-    /**
-     * @param {HTMLElement} element
-     */
-    afterLeave (element) {
-      element.style.height = null;
     },
   },
 };

--- a/components/collapsible/collapsible_lazy_show.vue
+++ b/components/collapsible/collapsible_lazy_show.vue
@@ -2,6 +2,7 @@
   <!-- applies the transition on initial render -->
   <transition
     :appear="appear"
+    mode="out-in"
     enter-active-class="enter-active"
     leave-active-class="leave-active"
     @before-enter="beforeEnter"
@@ -12,13 +13,34 @@
     @after-leave="afterLeave"
     v-on="$listeners"
   >
+    <!-- IMPORTANT:
+      Since both elements are the same type, the Vue VDOM cannot
+      distinguish between them whenever they mount/unmount.
+      This causes the transition to think that they're both referring
+      to the same element and as a result the transition animation
+      does not apply.
+
+      To differentiate them, we need to add a unique
+      key attribute on both instances to let the VDOM know that
+      they're both different nodes.
+    -->
     <component
       :is="elementType"
-      v-show="show"
+      v-if="isExpanded"
+      key="onOpen"
       v-on="$listeners"
     >
-      <!-- @slot slot for Content within collapsible -->
-      <slot v-if="initialized" />
+      <!-- @slot slot for Content when collapsible is expanded -->
+      <slot name="contentOnExpanded" />
+    </component>
+    <component
+      :is="elementType"
+      v-else
+      key="onClose"
+      v-on="$listeners"
+    >
+      <!-- @slot slot for Content when collapsible is collapsed -->
+      <slot name="contentOnCollapsed" />
     </component>
   </transition>
 </template>
@@ -34,7 +56,7 @@ export default {
     /**
      * Whether the child slot is shown.
      */
-    show: {
+    isExpanded: {
       type: Boolean,
       default: null,
     },
@@ -53,26 +75,6 @@ export default {
     elementType: {
       type: String,
       default: 'div',
-    },
-  },
-
-  /******************
-   *      DATA      *
-   ******************/
-  data () {
-    return {
-      initialized: !!this.show,
-    };
-  },
-
-  /******************
-   *      WATCH     *
-   ******************/
-  watch: {
-    show: function (newValue) {
-      if (!newValue || this.initialized) return;
-
-      this.initialized = true;
     },
   },
 
@@ -141,9 +143,19 @@ export default {
 </script>
 
 <style>
-  .enter-active,
-  .leave-active {
-    overflow: hidden;
-    transition: height .3s linear;
+.enter-active {
+  animation: fade-in 0.2s;
+}
+.leave-active {
+  animation: fade-in 0.2s reverse;
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
   }
+  100% {
+    opacity: 1;
+  }
+}
 </style>

--- a/components/collapsible/collapsible_lazy_show.vue
+++ b/components/collapsible/collapsible_lazy_show.vue
@@ -6,6 +6,12 @@
     enter-active-class="enter-active"
     leave-active-class="leave-active"
     v-on="$listeners"
+    @before-enter="beforeEnter"
+    @enter="enter"
+    @after-enter="afterEnter"
+    @before-leave="beforeLeave"
+    @leave="leave"
+    @after-leave="afterLeave"
   >
     <!-- IMPORTANT:
       Since both elements are the same type, the Vue VDOM cannot
@@ -71,23 +77,72 @@ export default {
       default: 'div',
     },
   },
+
+  methods: {
+
+    beforeEnter (element) {
+      requestAnimationFrame(() => {
+        if (!element.style.height) {
+          element.style.height = '0px';
+        }
+        element.style.display = null;
+      });
+    },
+
+    /**
+     * @param {HTMLElement} element
+     */
+    enter (element) {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          element.style.height = `${element.scrollHeight}px`;
+        });
+      });
+    },
+
+    /**
+     * @param {HTMLElement} element
+     */
+    afterEnter (element) {
+      element.style.height = null;
+    },
+
+    /**
+     * @param {HTMLElement} element
+     */
+    beforeLeave (element) {
+      requestAnimationFrame(() => {
+        if (!element.style.height) {
+          element.style.height = `${element.offsetHeight}px`;
+        }
+      });
+    },
+
+    /**
+     * @param {HTMLElement} element
+     */
+    leave (element) {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          element.style.height = '0px';
+        });
+      });
+    },
+
+    /**
+     * @param {HTMLElement} element
+     */
+    afterLeave (element) {
+      element.style.height = null;
+    },
+  },
 };
 </script>
 
 <style>
-.enter-active {
-  animation: fade-in 0.2s;
-}
-.leave-active {
-  animation: fade-in 0.2s reverse;
-}
-
-@keyframes fade-in {
-  0% {
-    opacity: 0;
+  .enter-active,
+  .leave-active {
+    overflow: hidden;
+    transition: height .3s linear;
   }
-  100% {
-    opacity: 1;
-  }
-}
 </style>

--- a/components/collapsible/collapsible_lazy_show.vue
+++ b/components/collapsible/collapsible_lazy_show.vue
@@ -23,10 +23,14 @@
       To differentiate them, we need to add a unique
       key attribute on both instances to let the VDOM know that
       they're both different nodes.
+
+      Only render the element if the slot underneath is defined.
+      This prevents unnecessary animation from taking place if
+      a particular slot is not defined
     -->
     <component
       :is="elementType"
-      v-if="isExpanded"
+      v-if="(isExpanded && $slots.contentOnExpanded)"
       key="onOpen"
       v-on="$listeners"
     >
@@ -35,7 +39,7 @@
     </component>
     <component
       :is="elementType"
-      v-else
+      v-else-if="(!isExpanded && $slots.contentOnCollapsed)"
       key="onClose"
       v-on="$listeners"
     >
@@ -78,8 +82,6 @@ export default {
     },
   },
 
-  emits: ['transitionfinished'],
-
   methods: {
 
     beforeEnter (element) {
@@ -107,11 +109,6 @@ export default {
      */
     afterEnter (element) {
       element.style.height = null;
-      // Note: since the mode out transition is "out-in"
-      // the 'enter' event will be the one triggered last in this
-      // transition. It will mark the end of the transition, hence
-      // the trigger of the event below
-      this.$emit('transitionfinished');
     },
 
     /**

--- a/components/collapsible/collapsible_lazy_show.vue
+++ b/components/collapsible/collapsible_lazy_show.vue
@@ -78,6 +78,8 @@ export default {
     },
   },
 
+  emits: ['transitionfinished'],
+
   methods: {
 
     beforeEnter (element) {
@@ -105,6 +107,11 @@ export default {
      */
     afterEnter (element) {
       element.style.height = null;
+      // Note: since the mode out transition is "out-in"
+      // the 'enter' event will be the one triggered last in this
+      // transition. It will mark the end of the transition, hence
+      // the trigger of the event below
+      this.$emit('transitionfinished');
     },
 
     /**

--- a/components/collapsible/collapsible_variants.story.vue
+++ b/components/collapsible/collapsible_variants.story.vue
@@ -1,40 +1,24 @@
 <template>
   <div>
     <dt-collapsible
-      anchor-text="With Unreads"
+      anchor-text="Favorites"
       content-element-type="ol"
       class="d-p0 d-w100p"
-      @opened="onOpenUpdate"
     >
       <template #contentOnExpanded>
         <li
           v-for="item in items"
-          :key="item"
+          :key="item.name"
         >
-          {{ item }}
+          {{ item.name }}
         </li>
       </template>
       <template #contentOnCollapsed>
         <li
           v-for="item in unreadItems"
-          :key="item"
+          :key="item.name"
         >
-          {{ item }}
-        </li>
-      </template>
-    </dt-collapsible>
-    <dt-collapsible
-      anchor-text="Without Unread Items"
-      content-element-type="ol"
-      class="d-p0 d-w100p"
-      @opened="onOpenUpdate"
-    >
-      <template #contentOnExpanded>
-        <li
-          v-for="datum in items"
-          :key="datum"
-        >
-          {{ datum }}
+          {{ item.name }}
         </li>
       </template>
     </dt-collapsible>
@@ -45,7 +29,7 @@
 import DtCollapsible from './collapsible';
 
 export default {
-  name: 'DtCollapsibleDefaultStory',
+  name: 'DtCollapsibleVariantsStory',
 
   components: {
     DtCollapsible,
@@ -53,24 +37,26 @@ export default {
 
   data () {
     return {
-      isOpen: true,
       items: [
-        'Hello',
-        'World',
-        'Item',
+        {
+          name: 'Item 1',
+          unread: false,
+        },
+        {
+          name: 'Item 2',
+          unread: false,
+        },
+        {
+          name: 'Unread Item 3',
+          unread: true,
+        },
       ],
     };
   },
 
   computed: {
     unreadItems () {
-      return ['Unread Item'];
-    },
-  },
-
-  methods: {
-    onOpenUpdate (shouldBeOpen) {
-      console.log('onOpenUpdate', shouldBeOpen);
+      return this.items.filter(item => item.unread);
     },
   },
 };

--- a/components/collapsible/collapsible_variants.story.vue
+++ b/components/collapsible/collapsible_variants.story.vue
@@ -1,10 +1,12 @@
 <template>
   <div>
+    <p>Collapsible is open: {{ isOpenLocal }}</p>
     <dt-collapsible
       anchor-text="Favorites"
       aria-label="Favorites, click to expand or collapse"
       content-element-type="ol"
       class="d-p0 d-w100p"
+      :open.sync="isOpenLocal"
     >
       <template #contentOnExpanded>
         <li
@@ -38,6 +40,7 @@ export default {
 
   data () {
     return {
+      isOpenLocal: true,
       items: [
         {
           name: 'Item 1',

--- a/components/collapsible/collapsible_variants.story.vue
+++ b/components/collapsible/collapsible_variants.story.vue
@@ -2,6 +2,7 @@
   <div>
     <dt-collapsible
       anchor-text="Favorites"
+      aria-label="Favorites, click to expand or collapse"
       content-element-type="ol"
       class="d-p0 d-w100p"
     >

--- a/components/collapsible/collapsible_variants.story.vue
+++ b/components/collapsible/collapsible_variants.story.vue
@@ -1,0 +1,77 @@
+<template>
+  <div>
+    <dt-collapsible
+      anchor-text="With Unreads"
+      content-element-type="ol"
+      class="d-p0 d-w100p"
+      @opened="onOpenUpdate"
+    >
+      <template #contentOnExpanded>
+        <li
+          v-for="item in items"
+          :key="item"
+        >
+          {{ item }}
+        </li>
+      </template>
+      <template #contentOnCollapsed>
+        <li
+          v-for="item in unreadItems"
+          :key="item"
+        >
+          {{ item }}
+        </li>
+      </template>
+    </dt-collapsible>
+    <dt-collapsible
+      anchor-text="Without Unread Items"
+      content-element-type="ol"
+      class="d-p0 d-w100p"
+      @opened="onOpenUpdate"
+    >
+      <template #contentOnExpanded>
+        <li
+          v-for="datum in items"
+          :key="datum"
+        >
+          {{ datum }}
+        </li>
+      </template>
+    </dt-collapsible>
+  </div>
+</template>
+
+<script>
+import DtCollapsible from './collapsible';
+
+export default {
+  name: 'DtCollapsibleDefaultStory',
+
+  components: {
+    DtCollapsible,
+  },
+
+  data () {
+    return {
+      isOpen: true,
+      items: [
+        'Hello',
+        'World',
+        'Item',
+      ],
+    };
+  },
+
+  computed: {
+    unreadItems () {
+      return ['Unread Item'];
+    },
+  },
+
+  methods: {
+    onOpenUpdate (shouldBeOpen) {
+      console.log('onOpenUpdate', shouldBeOpen);
+    },
+  },
+};
+</script>


### PR DESCRIPTION
# Update `DtCollapsible` to show content when collapsed

This use-case is needed in several parts of our new app. We need to be able to show content when collapsible is collapsed.

Jira: https://dialpad.atlassian.net/browse/DT-843

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Feature

## :book: Description

**Note**: this is breaking change since we change the slot name from `content` to `contentOnExpanded` to indicate clearly that this is content that is shown when expanded, as opposed to `contentOnCollapsed` which will be shown only when the content is collapsible is collapsed.

## :bulb: Context

Jira: https://dialpad.atlassian.net/browse/DT-843

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

![Collapsible Update GIF](https://user-images.githubusercontent.com/88498639/205170358-bcccdff6-0032-4878-b7a2-8790a791d10e.gif)

