### PR TITLE
refactor: remove extra attrs from combobox wrapper

### DIFF
--- a/components/combobox/combobox.vue
+++ b/components/combobox/combobox.vue
@@ -1,11 +1,5 @@
-<!-- eslint-disable vuejs-accessibility/interactive-supports-focus -->
 <template>
   <div
-    role="combobox"
-    :aria-expanded="showList.toString()"
-    :aria-controls="listId"
-    :aria-owns="listId"
-    aria-haspopup="listbox"
     @keydown.esc.stop="onKeyValidation($event, 'onEscapeKey')"
     @keydown.enter.exact="onKeyValidation($event, 'onEnterKey')"
     @keydown.up.stop.prevent="onKeyValidation($event, 'onUpKey')"


### PR DESCRIPTION
# refactor: remove extra attrs from combobox wrapper

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [ ] Feature
- [x] Refactoring
- [ ] Documentation

## :book: Description

The vue2 version of this component was refactored a while ago and these attrs were moved onto the input. For the vue3 version these were not removed from the wrapper, so it was having duplicated attributes. This change unifies the vue2 and vue3 versions and after this change the code is exactly the same for both versions.