### PR TITLE
feat(collapsible): collapsible updates to vue3

### DIFF
--- a/components/collapsible/collapsible.mdx
+++ b/components/collapsible/collapsible.mdx
@@ -9,11 +9,13 @@ import { Canvas, Story, Subtitle, ArgsTable, PRIMARY_STORY } from '@storybook/ad
 
 ## Basic Style
 
-The collapsible has two components. The anchor and the content.
+The collapsible has three components. The anchor, contentOnExpanded, and contentOnCollapsed.
 
 The **anchor** will default to a basic button with some text if the slot is not filled.
 
-The **content** must be provided and is the element that can be hidden or shown when the anchor is clicked.
+The **contentOnExpanded** is the element that is shown when the anchor is expanded.
+
+The **contentOnCollapsed** is the element that is shown when the anchor is collapsed.
 
 <Canvas>
   <Story id="components-collapsible--default" />
@@ -34,7 +36,7 @@ import { DtCollapsible } from '@dialpad/dialtone-vue';
   :anchor-text="Click Me!"
   @opened="onOpen"
 >
-  <template #content>
+  <template #contentOnExpanded>
     <p>
       This will be shown in the expanded area.
     </p>
@@ -58,9 +60,39 @@ import { DtCollapsible, DtButton } from '@dialpad/dialtone-vue';
       Click Me!
     </dt-button>
   </template>
-  <template #content>
+  <template #contentOnExpanded>
     <p>
       This will be shown in the expanded area.
+    </p>
+  </template>
+</dt-collapsible>
+```
+
+### Basic Usage with `contentOnCollapsed`
+
+You can also choose to show content when under the anchor when it is collapsed. To do so,
+you need to use the `contentOnCollapsed` slot and render any elements inside of it that needs to be
+shown when the content is collapsed.
+
+```js
+import { DtCollapsible, DtButton } from '@dialpad/dialtone-vue';
+```
+
+```html
+<dt-collapsible @opened="onOpen">
+  <template #anchor={ attrs }>
+    <dt-button v-bind="attrs">
+      Click Me!
+    </dt-button>
+  </template>
+  <template #contentOnExpanded>
+    <p>
+      This will be shown when the anchor is expanded.
+    </p>
+  </template>
+    <template #contentOnCollapsed>
+    <p>
+      This will be shown when the anchor is collapsed.
     </p>
   </template>
 </dt-collapsible>

--- a/components/collapsible/collapsible.mdx
+++ b/components/collapsible/collapsible.mdx
@@ -70,7 +70,7 @@ import { DtCollapsible, DtButton } from '@dialpad/dialtone-vue';
 
 ### Basic Usage with `contentOnCollapsed`
 
-You can also choose to show content when under the anchor when it is collapsed. To do so,
+You can also choose to show content under the anchor when it is collapsed. To do so,
 you need to use the `contentOnCollapsed` slot and render any elements inside of it that needs to be
 shown when the content is collapsed.
 

--- a/components/collapsible/collapsible.stories.js
+++ b/components/collapsible/collapsible.stories.js
@@ -1,9 +1,10 @@
+import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import {
   DtCollapsible,
 } from './';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import CollapsibleMdx from './collapsible.mdx';
 import DtCollapsibleDefaultStory from './collapsible_default.story';
+import DtCollapsibleVariantsStory from './collapsible_variants.story.vue';
 
 const argsTypesData = {
   // Slots
@@ -15,7 +16,15 @@ const argsTypesData = {
       },
     },
   },
-  content: {
+  contentOnCollapsed: {
+    control: 'text',
+    table: {
+      type: {
+        summary: 'VNode',
+      },
+    },
+  },
+  contentOnExpanded: {
     control: 'text',
     table: {
       type: {
@@ -85,3 +94,10 @@ export const Default = DefaultTemplate.bind({});
 Default.args = {
   maxWidth: '512px',
 };
+
+const VariantTemplate = (args) => createTemplateFromVueFile(
+  args,
+  DtCollapsibleVariantsStory,
+);
+
+export const Variants = VariantTemplate.bind({});

--- a/components/collapsible/collapsible.test.js
+++ b/components/collapsible/collapsible.test.js
@@ -5,7 +5,10 @@ import sinon from 'sinon';
 import axe from 'axe-core';
 import configA11y from '../../storybook/scripts/storybook-a11y-test.config';
 
-const content = '<div data-qa="content-element"> Test Text </div>';
+const contentOnExpanded = '<div data-qa="content-on-expanded-element"> Expanded Test Text </div>';
+const contentOnCollapsed = '<div data-qa="content-on-collapsed-element"> Collapsed Test Text </div>';
+const anchor = '<button data-qa="anchor-element">click me</button>';
+
 const baseProps = {
   anchorText: 'anchor text',
 };
@@ -13,36 +16,32 @@ const baseProps = {
 describe('Dialtone vue Collapsible Component Tests', function () {
   // Wrappers
   let wrapper;
-  let contentElement;
+  let contentOnExpandedElement;
+  let contentOnCollapsedElement;
   let contentWrapperElement;
   let anchorElement;
   let anchorSlotElement;
-  let slots = { content };
 
   // Environment
   const attrs = {
     css: false, // Important attr to let test-utils fire the (after-enter and after-leave) events correctly
   };
-  let props = baseProps;
 
-  const _clearChildWrappers = () => {
-    contentElement = undefined;
-    contentWrapperElement = undefined;
-    anchorElement = undefined;
-    anchorSlotElement = undefined;
-    slots = { content };
-  };
+  // Environment
+  const defaultSlots = { contentOnExpanded, contentOnCollapsed };
+  const defaultPropsData = baseProps;
 
-  const _setChildWrappers = () => {
+  const findAllElements = () => {
     anchorElement = wrapper.find('[data-qa="dt-button"]');
     anchorSlotElement = wrapper.find('[data-qa="anchor-element"]');
-    contentElement = wrapper.find('[data-qa="content-element"]');
-    contentWrapperElement = wrapper.getComponent('.d-dt-collapsible__content');
+    contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
+    contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
+    contentWrapperElement = wrapper.findComponent({ ref: 'contentWrapper' });
   };
 
-  const _mountWrapper = () => {
+  const mountWrapper = ({ propsData = defaultPropsData, slots = defaultSlots } = {}) => {
     wrapper = mount(DtCollapsible, {
-      props,
+      props: propsData,
       slots,
       attrs,
       global: {
@@ -52,7 +51,7 @@ describe('Dialtone vue Collapsible Component Tests', function () {
       },
       attachTo: document.body,
     });
-    _setChildWrappers();
+    findAllElements();
   };
 
   before(function () {
@@ -62,7 +61,7 @@ describe('Dialtone vue Collapsible Component Tests', function () {
   });
 
   beforeEach(function () {
-    _mountWrapper();
+    mountWrapper();
   });
 
   after(function () {
@@ -72,46 +71,74 @@ describe('Dialtone vue Collapsible Component Tests', function () {
     config.renderStubDefaultSlot = false;
   });
 
-  afterEach(async function () {
-    props = baseProps;
-    _clearChildWrappers();
-  });
-
   describe('Test default rendering', function () {
     it('should render the component', function () {
-      assert.exists(wrapper, 'wrapper exists');
+      assert.isTrue(wrapper.exists(), 'wrapper exists');
     });
 
     it('should render the anchor', function () {
-      assert.exists(anchorElement, 'anchor exists');
+      assert.isTrue(anchorElement.exists(), 'anchor exists');
     });
 
-    it('should render the content', function () {
-      assert.exists(contentElement, 'content exists');
+    it('should render the content on expanded element', function () {
+      assert.isTrue(contentOnExpandedElement.exists(), 'content exists');
+    });
+
+    it('should NOT render the content on collapsed element', function () {
+      assert.isFalse(contentOnCollapsedElement.exists(), 'collapsed content does not exist');
     });
   });
 
-  describe('When scoped slot is provided', function () {
-    beforeEach(async function () {
-      const anchor = '<button data-qa="anchor-element">click me</button>';
-      slots = { anchor };
+  describe('When scoped slot is provided for anchor', function () {
+    beforeEach(function () {
+      mountWrapper({
+        slots: { anchor },
+      });
     });
-    it('should render the scoped slot', function () {
-      assert.exists(anchorSlotElement, 'anchor slot exists');
+
+    it('should render the anchor slot', function () {
+      assert.isTrue(anchorSlotElement.exists(), 'anchor slot exists');
+    });
+  });
+
+  describe('When scoped slot is not provided for any content', function () {
+    beforeEach(function () {
+      mountWrapper({
+        slots: {},
+      });
+    });
+
+    it('should NOT render any content if no slot is passed', function () {
+      assert.isFalse(contentOnExpandedElement.exists());
+      assert.isFalse(contentOnCollapsedElement.exists());
     });
   });
 
   describe('Test open prop undefined', function () {
     it('content should be expanded by default', function () {
-      assert.isTrue(contentElement.isVisible());
+      assert.isTrue(contentOnExpandedElement.isVisible());
+      assert.isFalse(contentOnCollapsedElement.exists());
     });
 
-    it('should toggle the content when clicked', async function () {
-      await anchorElement.trigger('click');
-      assert.isFalse(contentElement.isVisible());
-
-      await anchorElement.trigger('click');
-      assert.isTrue(contentElement.isVisible());
+    describe('when user clicks anchor when it is expanded', function () {
+      beforeEach(async function () {
+        await anchorElement.trigger('click');
+      });
+      it('should be collapsed', async function () {
+        findAllElements();
+        assert.isFalse(contentOnExpandedElement.exists());
+        assert.isTrue(contentOnCollapsedElement.isVisible());
+      });
+      describe('when user clicks anchor when it is collapsed', function () {
+        beforeEach(async function () {
+          await anchorElement.trigger('click');
+        });
+        it('should be expanded', function () {
+          findAllElements();
+          assert.isTrue(contentOnExpandedElement.isVisible());
+          assert.isFalse(contentOnCollapsedElement.exists());
+        });
+      });
     });
   });
 
@@ -122,37 +149,68 @@ describe('Dialtone vue Collapsible Component Tests', function () {
       });
 
       it('content is expanded', function () {
-        assert.isTrue(contentElement.isVisible());
+        assert.isTrue(contentOnExpandedElement.isVisible());
       });
 
-      it('clicking does not collapse content', async function () {
-        await anchorElement.trigger('click');
-        assert.isTrue(contentElement.isVisible());
+      describe('clicking on anchor', function () {
+        beforeEach(async function () {
+          await anchorElement.trigger('click');
+        });
+        it('clicking does NOT collapse content', async function () {
+          findAllElements();
+          assert.isTrue(contentOnExpandedElement.isVisible());
+          assert.isFalse(contentOnCollapsedElement.exists());
+        });
       });
 
-      it('updating open prop does collapse content', async function () {
-        await wrapper.setProps({ open: false });
-        assert.isFalse(contentElement.isVisible());
+      describe('updating open prop', function () {
+        beforeEach(async function () {
+          await wrapper.setProps({ open: false });
+        });
+        it('updating open prop does collapse content', async function () {
+          findAllElements();
+          assert.isFalse(contentOnExpandedElement.exists());
+          assert.isTrue(contentOnCollapsedElement.isVisible());
+        });
       });
     });
 
     describe('Test open prop set to false', function () {
       beforeEach(async function () {
-        await wrapper.setProps({ open: false });
+        mountWrapper({
+          propsData: {
+            ...baseProps,
+            open: false,
+          },
+        });
       });
 
       it('content starts collapsed', function () {
-        assert.isFalse(contentElement.isVisible());
+        findAllElements();
+        assert.isFalse(contentOnExpandedElement.exists());
+        assert.isTrue(contentOnCollapsedElement.isVisible());
       });
 
-      it('clicking does not expand content', async function () {
-        await anchorElement.trigger('click');
-        assert.isFalse(contentElement.isVisible());
+      describe('when user clicks anchor and collapsible is closed', function () {
+        beforeEach(async function () {
+          await anchorElement.trigger('click');
+        });
+        it('clicking does NOT expand content', async function () {
+          findAllElements();
+          assert.isFalse(contentOnExpandedElement.exists());
+          assert.isTrue(contentOnCollapsedElement.isVisible());
+        });
       });
 
-      it('updating open prop does collapse content', async function () {
-        await wrapper.setProps({ open: true });
-        assert.isTrue(contentElement.isVisible());
+      describe('when open prop is updated', function () {
+        beforeEach(async function () {
+          await wrapper.setProps({ open: true });
+        });
+        it('updating open prop does expand content', async function () {
+          findAllElements();
+          assert.isTrue(contentOnExpandedElement.isVisible());
+          assert.isFalse(contentOnCollapsedElement.exists());
+        });
       });
     });
   });
@@ -162,8 +220,9 @@ describe('Dialtone vue Collapsible Component Tests', function () {
 
     beforeEach(async function () {
       consoleErrorSpy = sinon.spy(console, 'error');
-      props = { ...baseProps, anchorText: undefined };
-      _mountWrapper();
+      mountWrapper({
+        propsData: { ...baseProps, anchorText: undefined },
+      });
     });
 
     afterEach(function () {
@@ -177,6 +236,62 @@ describe('Dialtone vue Collapsible Component Tests', function () {
   });
 
   describe('Accessibility Tests', function () {
+    describe('Anchor aria-label', function () {
+      beforeEach(async function () {
+        mountWrapper({
+          propsData: {
+            ...baseProps,
+            ariaLabel: 'Anchor Aria Label',
+          },
+        });
+      });
+      it('should correctly set the aria-label attribute on anchor button', async function () {
+        assert.equal(anchorElement.attributes('aria-label'), 'Anchor Aria Label');
+      });
+    });
+
+    describe('Content wrapper `aria-hidden` property when contentOnCollapsed does not exist', function () {
+      beforeEach(function () {
+        mountWrapper({
+          slots: { contentOnExpanded },
+        });
+      });
+      it('should set aria-hidden to false when content expanded exists', function () {
+        assert.equal(contentWrapperElement.attributes('aria-hidden'), 'false');
+      });
+      describe('when user clicks anchor', function () {
+        beforeEach(async function () {
+          await anchorElement.trigger('click');
+        });
+        it(`should set aria-hidden to true if
+        content is collapsed and contentOnCollapsed slot is not provided `, async function () {
+          findAllElements();
+          assert.equal(contentWrapperElement.attributes('aria-hidden'), 'true');
+        });
+      });
+    });
+
+    describe('Content wrapper `aria-hidden` property when contentOnCollapsed exists', function () {
+      beforeEach(function () {
+        mountWrapper({
+          slots: { contentOnExpanded, contentOnCollapsed },
+        });
+      });
+      it('should set aria-hidden to false when content expanded exists', function () {
+        assert.equal(contentWrapperElement.attributes('aria-hidden'), 'false');
+      });
+      describe('when user clicks anchor', function () {
+        beforeEach(async function () {
+          await anchorElement.trigger('click');
+        });
+        it(`should set aria-hidden to false if
+        content is collapsed and and contentOnCollapsed slot is provided `, async function () {
+          findAllElements();
+          assert.equal(contentWrapperElement.attributes('aria-hidden'), 'false');
+        });
+      });
+    });
+
     describe('Content is expanded', function () {
       beforeEach(async function () {
         await wrapper.setProps({ open: true, id: 'contentId' });

--- a/components/collapsible/collapsible.test.js
+++ b/components/collapsible/collapsible.test.js
@@ -36,7 +36,7 @@ describe('Dialtone vue Collapsible Component Tests', function () {
     anchorSlotElement = wrapper.find('[data-qa="anchor-element"]');
     contentOnExpandedElement = wrapper.find('[data-qa="content-on-expanded-element"]');
     contentOnCollapsedElement = wrapper.find('[data-qa="content-on-collapsed-element"]');
-    contentWrapperElement = wrapper.findComponent({ ref: 'contentWrapper' });
+    contentWrapperElement = wrapper.find('[data-qa="contentWrapper"]');
   };
 
   const mountWrapper = ({ propsData = defaultPropsData, slots = defaultSlots } = {}) => {
@@ -46,7 +46,7 @@ describe('Dialtone vue Collapsible Component Tests', function () {
       attrs,
       global: {
         stubs: {
-          transition: false,
+          transition: true,
         },
       },
       attachTo: document.body,
@@ -294,7 +294,13 @@ describe('Dialtone vue Collapsible Component Tests', function () {
 
     describe('Content is expanded', function () {
       beforeEach(async function () {
-        await wrapper.setProps({ open: true, id: 'contentId' });
+        mountWrapper({
+          propsData: {
+            open: true,
+            id: 'contentId',
+            anchorText: 'hello',
+          },
+        });
       });
 
       it('should pass axe-core accessibility rules', async function () {

--- a/components/collapsible/collapsible.vue
+++ b/components/collapsible/collapsible.vue
@@ -7,7 +7,6 @@
     <div
       :id="!ariaLabelledBy && labelledBy"
       ref="anchor"
-      :aria-label="ariaLabel"
       :class="[
         'd-dt-collapsibe__anchor',
         anchorClass,
@@ -49,7 +48,8 @@
     <dt-collapsible-lazy-show
       :id="id"
       ref="contentWrapper"
-      :aria-hidden="`${!isOpen && !hasContentOnCollapse}`"
+      data-qa="contentWrapper"
+      :aria-hidden="`${!isOpen && !$slots.contentOnCollapsed}`"
       :aria-labelledby="labelledBy"
       :is-expanded="isOpen"
       :element-type="contentElementType"
@@ -264,7 +264,7 @@ export default {
     },
 
     validateProperAnchor () {
-      if (!this.anchorText && !this.$slots.anchor) {
+      if (!this.anchorText && !this.$slots.$anchor) {
         console.error('anchor text and anchor slot content cannot both be falsy');
       }
     },

--- a/components/collapsible/collapsible_default.story.vue
+++ b/components/collapsible/collapsible_default.story.vue
@@ -22,10 +22,10 @@
         v-html="$attrs.anchor"
       />
     </template>
-    <template #content>
+    <template #contentOnExpanded>
       <div
-        v-if="$attrs.content"
-        v-html="$attrs.content"
+        v-if="$attrs.contentOnExpanded"
+        v-html="$attrs.contentOnExpanded"
       />
       <div
         v-else
@@ -54,6 +54,12 @@
           est.
         </p>
       </div>
+    </template>
+    <template #contentOnCollapsed>
+      <div
+        v-if="$attrs.contentOnCollapsed"
+        v-html="$attrs.contentOnCollapsed"
+      />
     </template>
   </dt-collapsible>
 </template>

--- a/components/collapsible/collapsible_lazy_show.vue
+++ b/components/collapsible/collapsible_lazy_show.vue
@@ -29,7 +29,7 @@
     -->
     <component
       :is="elementType"
-      v-if="(isExpanded && $slots.contentOnExpanded)"
+      v-if="(isExpanded && hasExpandedContent)"
       key="onOpen"
     >
       <!-- @slot slot for Content when collapsible is expanded -->
@@ -37,7 +37,7 @@
     </component>
     <component
       :is="elementType"
-      v-else-if="(!isExpanded && $slots.contentOnCollapsed)"
+      v-else-if="(!isExpanded && hasCollapsedContent)"
       key="onClose"
     >
       <!-- @slot slot for Content when collapsible is collapsed -->
@@ -77,6 +77,18 @@ export default {
     elementType: {
       type: String,
       default: 'div',
+    },
+  },
+
+  computed: {
+    hasCollapsedContent () {
+      // element [0] refers to the @slot comment
+      return this.$slots.contentOnCollapsed()[1].children.length > 0;
+    },
+
+    hasExpandedContent () {
+      // element [0] refers to the @slot comment
+      return this.$slots.contentOnExpanded()[1].children.length > 0;
     },
   },
 

--- a/components/collapsible/collapsible_lazy_show.vue
+++ b/components/collapsible/collapsible_lazy_show.vue
@@ -2,6 +2,7 @@
   <!-- applies the transition on initial render -->
   <transition
     :appear="appear"
+    mode="out-in"
     enter-active-class="enter-active"
     leave-active-class="leave-active"
     v-bind="$attrs"
@@ -12,13 +13,38 @@
     @leave="leave"
     @after-leave="afterLeave"
   >
+    <!-- IMPORTANT:
+      Since both elements are the same type, the Vue VDOM cannot
+      distinguish between them whenever they mount/unmount.
+      This causes the transition to think that they're both referring
+      to the same element and as a result the transition animation
+      does not apply.
+
+      To differentiate them, we need to add a unique
+      key attribute on both instances to let the VDOM know that
+      they're both different nodes.
+
+      Only render the element if the slot underneath is defined.
+      This prevents unnecessary animation from taking place if
+      a particular slot is not defined
+    -->
     <component
       :is="elementType"
-      v-show="show"
+      v-if="(isExpanded && $slots.contentOnExpanded)"
+      key="onOpen"
       v-bind="$attrs"
     >
-      <!-- @slot slot for Content within collapsible -->
-      <slot v-if="initialized" />
+      <!-- @slot slot for Content when collapsible is expanded -->
+      <slot name="contentOnExpanded" />
+    </component>
+    <component
+      :is="elementType"
+      v-else-if="(!isExpanded && $slots.contentOnCollapsed)"
+      key="onClose"
+      v-bind="$attrs"
+    >
+      <!-- @slot slot for Content when collapsible is collapsed -->
+      <slot name="contentOnCollapsed" />
     </component>
   </transition>
 </template>
@@ -26,7 +52,6 @@
 <script>
 export default {
   name: 'DtCollapsibleLazyShow',
-
   inheritAttrs: false,
 
   /******************
@@ -36,7 +61,7 @@ export default {
     /**
      * Whether the child slot is shown.
      */
-    show: {
+    isExpanded: {
       type: Boolean,
       default: null,
     },
@@ -58,36 +83,13 @@ export default {
     },
   },
 
-  /******************
-   *      DATA      *
-   ******************/
-  data () {
-    return {
-      initialized: !!this.show,
-    };
-  },
-
-  /******************
-   *      WATCH     *
-   ******************/
-  watch: {
-    show: function (newValue) {
-      if (!newValue || this.initialized) return;
-
-      this.initialized = true;
-    },
-  },
-
   methods: {
-    /**
-     * @param {HTMLElement} element
-     */
+
     beforeEnter (element) {
       requestAnimationFrame(() => {
         if (!element.style.height) {
           element.style.height = '0px';
         }
-
         element.style.display = null;
       });
     },

--- a/components/collapsible/collapsible_lazy_show.vue
+++ b/components/collapsible/collapsible_lazy_show.vue
@@ -5,7 +5,6 @@
     mode="out-in"
     enter-active-class="enter-active"
     leave-active-class="leave-active"
-    v-bind="$attrs"
     @before-enter="beforeEnter"
     @enter="enter"
     @after-enter="afterEnter"
@@ -32,7 +31,6 @@
       :is="elementType"
       v-if="(isExpanded && $slots.contentOnExpanded)"
       key="onOpen"
-      v-bind="$attrs"
     >
       <!-- @slot slot for Content when collapsible is expanded -->
       <slot name="contentOnExpanded" />
@@ -41,7 +39,6 @@
       :is="elementType"
       v-else-if="(!isExpanded && $slots.contentOnCollapsed)"
       key="onClose"
-      v-bind="$attrs"
     >
       <!-- @slot slot for Content when collapsible is collapsed -->
       <slot name="contentOnCollapsed" />
@@ -52,7 +49,7 @@
 <script>
 export default {
   name: 'DtCollapsibleLazyShow',
-  inheritAttrs: false,
+  inheritAttrs: true,
 
   /******************
    *     PROPS      *

--- a/components/collapsible/collapsible_variants.story.vue
+++ b/components/collapsible/collapsible_variants.story.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/no-v-model-argument -->
 <template>
-  <div class="d-d-flex ">
+  <div class="d-d-flex d-w100p d-ai-center d-jc-center d-h100p">
     <div>
       <p>Favorites Collapsible is open: {{ isFavoritesExpanded }}</p>
       <dt-collapsible
@@ -28,7 +28,7 @@
         </template>
       </dt-collapsible>
     </div>
-    <div class="d-ml8">
+    <div class="d-ml24">
       <dt-button @click="toggleRecentsCollapsible">
         Click to Toggle Recents Collapsible
       </dt-button>

--- a/components/collapsible/collapsible_variants.story.vue
+++ b/components/collapsible/collapsible_variants.story.vue
@@ -6,7 +6,6 @@
       <dt-collapsible
         v-model:open="isFavoritesExpanded"
         anchor-text="Favorites"
-        aria-label="Favorites, click to expand or collapse"
         content-element-type="ol"
         class="d-p0 d-w100p"
       >
@@ -35,7 +34,6 @@
       <dt-collapsible
         :open="isRecentsExpanded"
         anchor-text="Recents"
-        aria-label="Recents, click to expand or collapse"
         content-element-type="ol"
         class="d-p0 d-w100p"
       >

--- a/components/collapsible/collapsible_variants.story.vue
+++ b/components/collapsible/collapsible_variants.story.vue
@@ -1,0 +1,68 @@
+<!-- eslint-disable vue/no-v-model-argument -->
+<template>
+  <div>
+    <p>Collapsible is open: {{ isOpenLocal }}</p>
+    <dt-collapsible
+      v-model:open="isOpenLocal"
+      anchor-text="Favorites"
+      aria-label="Favorites, click to expand or collapse"
+      content-element-type="ol"
+      class="d-p0 d-w100p"
+    >
+      <template #contentOnExpanded>
+        <li
+          v-for="item in items"
+          :key="item.name"
+        >
+          {{ item.name }}
+        </li>
+      </template>
+      <template #contentOnCollapsed>
+        <li
+          v-for="item in unreadItems"
+          :key="item.name"
+        >
+          {{ item.name }}
+        </li>
+      </template>
+    </dt-collapsible>
+  </div>
+</template>
+
+<script>
+import DtCollapsible from './collapsible';
+
+export default {
+  name: 'DtCollapsibleVariantsStory',
+
+  components: {
+    DtCollapsible,
+  },
+
+  data () {
+    return {
+      isOpenLocal: true,
+      items: [
+        {
+          name: 'Item 1',
+          unread: false,
+        },
+        {
+          name: 'Item 2',
+          unread: false,
+        },
+        {
+          name: 'Unread Item 3',
+          unread: true,
+        },
+      ],
+    };
+  },
+
+  computed: {
+    unreadItems () {
+      return this.items.filter(item => item.unread);
+    },
+  },
+};
+</script>

--- a/components/collapsible/collapsible_variants.story.vue
+++ b/components/collapsible/collapsible_variants.story.vue
@@ -1,47 +1,80 @@
 <!-- eslint-disable vue/no-v-model-argument -->
 <template>
-  <div>
-    <p>Collapsible is open: {{ isOpenLocal }}</p>
-    <dt-collapsible
-      v-model:open="isOpenLocal"
-      anchor-text="Favorites"
-      aria-label="Favorites, click to expand or collapse"
-      content-element-type="ol"
-      class="d-p0 d-w100p"
-    >
-      <template #contentOnExpanded>
-        <li
-          v-for="item in items"
-          :key="item.name"
-        >
-          {{ item.name }}
-        </li>
-      </template>
-      <template #contentOnCollapsed>
-        <li
-          v-for="item in unreadItems"
-          :key="item.name"
-        >
-          {{ item.name }}
-        </li>
-      </template>
-    </dt-collapsible>
+  <div class="d-d-flex ">
+    <div>
+      <p>Favorites Collapsible is open: {{ isFavoritesExpanded }}</p>
+      <dt-collapsible
+        v-model:open="isFavoritesExpanded"
+        anchor-text="Favorites"
+        aria-label="Favorites, click to expand or collapse"
+        content-element-type="ol"
+        class="d-p0 d-w100p"
+      >
+        <template #contentOnExpanded>
+          <li
+            v-for="item in items"
+            :key="item.name"
+          >
+            {{ item.name }}
+          </li>
+        </template>
+        <template #contentOnCollapsed>
+          <li
+            v-for="item in unreadItems"
+            :key="item.name"
+          >
+            {{ item.name }}
+          </li>
+        </template>
+      </dt-collapsible>
+    </div>
+    <div class="d-ml8">
+      <dt-button @click="toggleRecentsCollapsible">
+        Click to Toggle Recents Collapsible
+      </dt-button>
+      <dt-collapsible
+        :open="isRecentsExpanded"
+        anchor-text="Recents"
+        aria-label="Recents, click to expand or collapse"
+        content-element-type="ol"
+        class="d-p0 d-w100p"
+      >
+        <template #contentOnExpanded>
+          <li
+            v-for="item in items"
+            :key="item.name"
+          >
+            {{ item.name }}
+          </li>
+        </template>
+        <template #contentOnCollapsed>
+          <li
+            v-for="item in unreadItems"
+            :key="item.name"
+          >
+            {{ item.name }}
+          </li>
+        </template>
+      </dt-collapsible>
+    </div>
   </div>
 </template>
 
 <script>
 import DtCollapsible from './collapsible';
-
+import { DtButton } from '../button';
 export default {
   name: 'DtCollapsibleVariantsStory',
 
   components: {
     DtCollapsible,
+    DtButton,
   },
 
   data () {
     return {
-      isOpenLocal: true,
+      isFavoritesExpanded: true,
+      isRecentsExpanded: true,
       items: [
         {
           name: 'Item 1',
@@ -62,6 +95,12 @@ export default {
   computed: {
     unreadItems () {
       return this.items.filter(item => item.unread);
+    },
+  },
+
+  methods: {
+    toggleRecentsCollapsible () {
+      this.isRecentsExpanded = !this.isRecentsExpanded;
     },
   },
 };


### PR DESCRIPTION
# Update Collapsible with recent changes to Vue3 branch

More info here: https://github.com/dialpad/dialtone-vue/pull/629

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Feature

## :book: Description

Note: this is breaking change since we change the slot name from content to contentOnExpanded to indicate clearly that this is content that is shown when expanded, as opposed to contentOnCollapsed which will be shown only when the content is collapsible is collapsed.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root
