### PR TITLE
fix(root-layout): full height support

### DIFF
--- a/components/root_layout/root_layout.vue
+++ b/components/root_layout/root_layout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="root-layout">
+  <div class="root-layout d-d-flex d-fd-column d-h100vh">
     <header
       v-if="$slots.header"
       :class="['root-layout__header', headerClass, { 'root-layout__header--sticky': headerSticky }]"

--- a/components/root_layout/root_layout_body.vue
+++ b/components/root_layout/root_layout_body.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="['root-layout__body', bodyClasses]"
+    :class="['root-layout__body', 'd-fl-grow1', bodyClasses]"
     data-qa="root-layout-body"
   >
     <aside


### PR DESCRIPTION
# fix(root-layout): full height support

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Been getting some requests for this so decided to fix it right now since it was pretty low effort. 

Root layout component was not taking up the full viewport by default and consumers were having to pass in a bunch of utility classes to fix issues that this component should already handle. Added some flexbox classes to handle the sizing of the main content pane and render at full viewport height.

## :bulb: Context

This component should have taken up the full viewport from the start, since it's only meant to be used at the root. Decided to implement it directly instead of making it a prop.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes

## :crystal_ball: Next Steps

release for implementation in web-clients
