### PR TITLE
feat(tooltip): add contentAppear prop

### DIFF
--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -21,7 +21,7 @@
       role="tooltip"
       aria-hidden="false"
       data-qa="dt-tooltip"
-      appear
+      :appear="contentAppear"
       :transition="transition"
       :class="[
         'd-tooltip',
@@ -180,6 +180,14 @@ export default {
     transition: {
       type: String,
       default: 'fade',
+    },
+
+    /**
+     * Whether to apply transition on initial render in the content lazy show component.
+     */
+    contentAppear: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/components/tooltip/tooltip_default.story.vue
+++ b/components/tooltip/tooltip_default.story.vue
@@ -18,6 +18,7 @@
         :offset="$attrs.offset"
         :sticky="$attrs.sticky"
         :content-class="$attrs.contentClass"
+        :content-appear="$attrs.contentAppear"
         :transition="$attrs.transition"
         :show.sync="$attrs.show"
         @shown="$attrs.onShown"


### PR DESCRIPTION
# PR Title

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

This is to fix the exact same issue as https://github.com/dialpad/dialtone-vue/commit/edfcf270132d7a6d74c226c977a89271b0f36d71 where the popover was initially rendering as open. We are having the same problem with tooltip so fixed it in the same way. Vue 3 only issue.

## :crystal_ball: Next Steps

Test in web-clients
