### PR TITLE
fix(popover): blocking wheel event

### DIFF
--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -5,6 +5,7 @@
         class="d-modal--transparent"
         :aria-hidden="modal && isOpen ? 'false' : 'true'"
         @click.prevent.stop
+        @wheel="(e) => (isOpen && modal) && e.preventDefault()"
       />
     </portal>
     <component
@@ -23,7 +24,6 @@
         @contextmenu="onContext"
         @keydown.up.prevent="onArrowKeyPress"
         @keydown.down.prevent="onArrowKeyPress"
-        @wheel="(e) => (isOpen && modal) && e.preventDefault()"
         @keydown.escape.capture="closePopover"
       >
         <!-- @slot Anchor element that activates the popover. Usually a button. -->
@@ -55,6 +55,7 @@
         :tabindex="contentTabindex"
         appear
         v-on="popoverListeners"
+        @wheel="(e) => (isOpen && modal) && e.preventDefault()"
       >
         <popover-header-footer
           v-if="$slots.headerContent || showCloseButton"
@@ -822,6 +823,11 @@ export default {
         // if there are no focusable elements at all focus the dialog itself
         this.$refs.content.$el.focus();
       }
+    },
+
+    handleWheel (e) {
+      e.preventDefault();
+      console.log(e);
     },
   },
 };

--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -824,11 +824,6 @@ export default {
         this.$refs.content.$el.focus();
       }
     },
-
-    handleWheel (e) {
-      e.preventDefault();
-      console.log(e);
-    },
   },
 };
 </script>

--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -5,7 +5,7 @@
         class="d-modal--transparent"
         :aria-hidden="modal && isOpen ? 'false' : 'true'"
         @click.prevent.stop
-        @wheel="(e) => (isOpen && modal) && e.preventDefault()"
+        @wheel.prevent.stop
       />
     </portal>
     <component


### PR DESCRIPTION
# Fix blocking wheel event on popover

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Moved @wheel event to popover's *transparent overlay* and *lazy-show content* to avoid filling the window with events when there's too many popovers.

This also fixes the wheel event behavior, when modal, it shouldn't let the user to scroll, with this fix it actually prevents the user from scrolling when popover open.

## :bulb: Context

Found a warning while working with a lot of popovers on a single page (422), the browser throws a warning and the page remains blocked until all the popovers get rendered.

Example error, limited to 4 popovers for readability.
![Screenshot 2023-01-06 at 5 31 08 p m](https://user-images.githubusercontent.com/87546543/211116742-4675be06-2196-42cf-8c5c-fe104b2431ea.png)

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root