### PR TITLE
fix(popover): refactor wheel event

### DIFF
--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -5,7 +5,6 @@
         class="d-modal--transparent"
         :aria-hidden="modal && isOpen ? 'false' : 'true'"
         @click.prevent.stop
-        @wheel.prevent.stop
       />
     </portal>
     <component
@@ -55,7 +54,6 @@
         :tabindex="contentTabindex"
         appear
         v-on="popoverListeners"
-        @wheel="(e) => (isOpen && modal) && e.preventDefault()"
       >
         <popover-header-footer
           v-if="$slots.headerContent || showCloseButton"
@@ -580,6 +578,7 @@ export default {
 
     isOpen (isOpen, isPrev) {
       if (isOpen) {
+        window.addEventListener('wheel', this.preventScrolling, { passive: false });
         this.tip.setProps({
           zIndex: this.modal ? 650 : this.calculateAnchorZindex(),
         });
@@ -588,6 +587,7 @@ export default {
       } else if (!isOpen && isPrev !== isOpen) {
         this.removeClosePopoverEventListener();
         this.tip.hide();
+        window.removeEventListener('wheel', this.preventScrolling, { passive: false });
       }
     },
   },
@@ -716,6 +716,14 @@ export default {
 
     closePopover () {
       this.isOpen = false;
+    },
+
+    /*
+    * Prevents scrolling only when the popover is set to modal
+    **/
+    preventScrolling (e) {
+      if (!this.modal) return;
+      e.preventDefault();
     },
 
     removeReferences () {


### PR DESCRIPTION
# Refactored wheel event

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Removed wheel event from the popover instances, added a `window.addEventListener` to prevent scrolling only when the popover is modal and open. This should be the right behavior and fix the issues with scrolling.

## :bulb: Context

After merging #683 Found that the event was still having issues, so found a different and better way to solve this scrolling issues with popover. The listener should only be added when the popover is opened.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Remove the ability to scroll through the page with arrow-keys, the scrolling is blocked now, but arrow keys still can be used to move the content of the page.