### PR TITLE
refactor(popover): tippy instance

### DIFF
--- a/.esplint.rec.json
+++ b/.esplint.rec.json
@@ -26,6 +26,9 @@
     },
     "recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue": {
       "max-lines": 1
+    },
+    "recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue": {
+      "max-lines": 1
     }
   }
 }

--- a/components/chip/chip.vue
+++ b/components/chip/chip.vue
@@ -1,5 +1,5 @@
 <template>
-  <span :class="['d-chip', parentClass]">
+  <span class="d-chip">
     <component
       :is="interactive ? 'button' : 'span'"
       :id="id"

--- a/components/dropdown/dropdown.test.js
+++ b/components/dropdown/dropdown.test.js
@@ -26,6 +26,10 @@ const baseSlots = {
   </ul>`,
 };
 
+const baseScopedSlots = {
+  anchor: `<template #anchor="{ attrs }"><a href="#" id="anchor" v-bind="attrs">Link</a></template>`,
+};
+
 describe('DtDropdown Tests', function () {
   // Wrappers
   let wrapper;
@@ -35,7 +39,7 @@ describe('DtDropdown Tests', function () {
   // Environment
   let propsData = basePropsData;
   let slots = baseSlots;
-  let scopedSlots = {};
+  let scopedSlots = baseScopedSlots;
   let listeners;
   let highlightStub;
 
@@ -79,7 +83,7 @@ describe('DtDropdown Tests', function () {
   afterEach(function () {
     propsData = basePropsData;
     slots = baseSlots;
-    scopedSlots = {};
+    scopedSlots = baseScopedSlots;
     listeners = {};
     wrapper.destroy();
   });
@@ -151,9 +155,6 @@ describe('DtDropdown Tests', function () {
     describe('When the dropdown is open', function () {
       // Test setup
       beforeEach(function () {
-        scopedSlots = {
-          anchor: `<template #anchor="{ attrs }"><a href="#" id="anchor" v-bind="attrs">Link</a></template>`,
-        };
         _setWrappers();
         wrapper.vm.$nextTick();
       });

--- a/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue
+++ b/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue
@@ -23,7 +23,6 @@
         :id="externalAnchor"
         ref="input"
         @focusin="onFocusIn"
-        @focusout="onFocusOut"
         @keydown.up="openOnArrowKeyPress($event)"
         @keydown.down="openOnArrowKeyPress($event)"
       >
@@ -60,7 +59,6 @@
           <div
             v-if="$slots.header"
             ref="header"
-            @focusout="onFocusOut"
           >
             <slot name="header" />
           </div>
@@ -71,7 +69,7 @@
             ref="listWrapper"
             :class="[DROPDOWN_PADDING_CLASSES[padding], listClass]"
             @mouseleave="clearHighlightIndex"
-            @focusout="clearHighlightIndex; onFocusOut;"
+            @focusout="clearHighlightIndex"
           >
             <combobox-loading-list
               v-if="loading"
@@ -94,7 +92,6 @@
           <div
             v-if="$slots.footer"
             ref="footer"
-            @focusout="onFocusOut"
           >
             <slot name="footer" />
           </div>
@@ -376,6 +373,11 @@ export default {
     },
 
     isListShown (val) {
+      if (val) {
+        window.addEventListener('mousedown', this.onFocusOut);
+      } else {
+        window.removeEventListener('mousedown', this.onFocusOut);
+      }
       this.onOpened(val);
     },
   },
@@ -430,14 +432,12 @@ export default {
     },
 
     onFocusOut (e) {
-      const comboboxRefs = ['input', 'header', 'footer', 'listWrapper'];
       // Check if the focus change was to another target within the combobox component
-      const isComboboxStillFocused = e.relatedTarget === null || comboboxRefs.some((ref) => {
-        return this.$refs[ref]?.contains(e.relatedTarget);
-      }) || this.visuallyHiddenClose;
+      const isComboboxStillFocused = this.$refs?.combobox?.$el.contains(e.target);
+      if (isComboboxStillFocused) return;
 
       // If outside the combobox then close
-      if (!isComboboxStillFocused) { this.closeComboboxList(); }
+      this.closeComboboxList();
     },
 
     openOnArrowKeyPress () {

--- a/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue
+++ b/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue
@@ -37,7 +37,7 @@
       <dt-popover
         ref="popover"
         :open.sync="isListShown"
-        :hide-on-click="showList === null"
+        :hide-on-click="false"
         :max-height="maxHeight"
         :max-width="maxWidth"
         :offset="popoverOffset"
@@ -433,7 +433,10 @@ export default {
 
     onFocusOut (e) {
       // Check if the focus change was to another target within the combobox component
-      const isComboboxStillFocused = this.$refs?.combobox?.$el.contains(e.target);
+      const isComboboxStillFocused = Object.keys(this.$refs).some(refName => {
+        const ref = this.$refs[refName];
+        return ref.$el ? ref.$el.contains(e.target) : ref.contains(e.target);
+      });
       if (isComboboxStillFocused) return;
 
       // If outside the combobox then close

--- a/recipes/comboboxes/combobox_with_popover/combobox_with_popover_default.story.vue
+++ b/recipes/comboboxes/combobox_with_popover/combobox_with_popover_default.story.vue
@@ -12,6 +12,7 @@
     :padding="padding"
     :list-id="listId"
     :empty-list="emptyList"
+    :visually-hidden-close="visuallyHiddenClose"
     :visually-hidden-close-label="visuallyHiddenCloseLabel"
     @escape="onComboboxEscape"
     @highlight="onHighlight"


### PR DESCRIPTION
# Refactor popover's tippy instance

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [ ] Feature
- [x] Refactoring
- [ ] Documentation

## :book: Description

Moved the tippy instance on popover to be initialized when open and not on mounted to improve performance.

## :bulb: Context

We had a lot of performance issues while implementing a page with 400+ popovers, found out that was due to the fact that popover's tippy instance where initialized on mounted, so we decided to move the initialization on open to prevent a lot of tippy instances unused.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Refactor tooltip and any other component that uses tippy on its core to do this too.