### PR TITLE
fix(collapsible): fix validation of anchor-related prop and slot

### DIFF
--- a/components/collapsible/collapsible.stories.js
+++ b/components/collapsible/collapsible.stories.js
@@ -9,7 +9,6 @@ const argTypesData = {
   // Slots
   anchor: {
     control: 'text',
-    defaultValue: 'Click me to toggle Content',
     table: {
       type: {
         summary: 'VNode',
@@ -28,7 +27,7 @@ const argTypesData = {
   // Props
   anchorText: {
     description: 'Text on the anchor if slot is unused.',
-    defaultValue: null,
+    defaultValue: 'Click me to toggle Content',
     table: {
       type: { summary: 'string' },
     },

--- a/components/collapsible/collapsible.stories.js
+++ b/components/collapsible/collapsible.stories.js
@@ -9,6 +9,7 @@ const argTypesData = {
   // Slots
   anchor: {
     control: 'text',
+    defaultValue: 'Click me to toggle Content',
     table: {
       type: {
         summary: 'VNode',
@@ -27,7 +28,7 @@ const argTypesData = {
   // Props
   anchorText: {
     description: 'Text on the anchor if slot is unused.',
-    defaultValue: 'Click me to toggle Content',
+    defaultValue: null,
     table: {
       type: { summary: 'string' },
     },

--- a/components/collapsible/collapsible.vue
+++ b/components/collapsible/collapsible.vue
@@ -236,10 +236,6 @@ export default {
     },
   },
 
-  created () {
-    this.validateProperAnchor();
-  },
-
   mounted () {
     this.validateProperAnchor();
   },

--- a/components/collapsible/collapsible.vue
+++ b/components/collapsible/collapsible.vue
@@ -240,6 +240,10 @@ export default {
     this.validateProperAnchor();
   },
 
+  mounted () {
+    this.validateProperAnchor();
+  },
+
   methods: {
     onLeaveTransitionComplete () {
       this.$emit('opened', false);
@@ -269,6 +273,7 @@ export default {
       if (!this.anchorText && !this.$scopedSlots.anchor) {
         console.error('anchor text and anchor slot content cannot both be falsy');
       }
+      debugger;
     },
   },
 };

--- a/components/collapsible/collapsible.vue
+++ b/components/collapsible/collapsible.vue
@@ -273,7 +273,6 @@ export default {
       if (!this.anchorText && !this.$scopedSlots.anchor) {
         console.error('anchor text and anchor slot content cannot both be falsy');
       }
-      debugger;
     },
   },
 };


### PR DESCRIPTION
# fix validation of anchor-related prop and slot

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Moved validation to `mounted` hook to make it backward compatible with Vue 2.6 as this major version has a bug getting `scopedSlots` in the `created` hook.
It can be tested in dialtone-vue v2.49.1-alpha.1 that [has the validation in the mounted too](https://github.com/dialpad/dialtone-vue/commit/8791df703fcdb23c69951e795c22562b5a1b104b). So, when testing in the product (vue 2.6), it only outputs the error from the created and not in the mounted hook.

## :bulb: Context

https://dialpad.atlassian.net/browse/DT-889

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
