### PR TITLE
feat(toggle): add toggleOnClick prop

### DIFF
--- a/components/toggle/toggle.stories.js
+++ b/components/toggle/toggle.stories.js
@@ -33,6 +33,7 @@ export const argTypesData = {
       type: 'select',
       options: TOGGLE_CHECKED_VALUES,
     },
+    defaultValue: false,
     table: {
       category: 'props',
       type: {

--- a/components/toggle/toggle.vue
+++ b/components/toggle/toggle.vue
@@ -80,6 +80,16 @@ export default {
     },
 
     /**
+     * Whether the component toggles on click. If you set this to false it means you will handle the toggling manually
+     * via the checked prop or v-model. Change events will still be triggered.
+     * @values true, false
+     */
+    toggleOnClick: {
+      type: Boolean,
+      default: true,
+    },
+
+    /**
      * The size of the toggle.
      * @values sm, md
      */
@@ -173,8 +183,11 @@ export default {
 
   methods: {
     toggleCheckedValue () {
-      this.internalChecked = !this.internalChecked;
-      this.$emit('change', this.internalChecked);
+      this.$emit('change', !this.internalChecked);
+
+      if (this.toggleOnClick) {
+        this.internalChecked = !this.internalChecked;
+      }
     },
 
     hasSlotLabel () {

--- a/components/toggle/toggle_default.story.vue
+++ b/components/toggle/toggle_default.story.vue
@@ -6,6 +6,7 @@
     :show-icon="showIcon"
     :label-class="labelClass"
     :label-child-props="labelChildProps"
+    :toggle-on-click="toggleOnClick"
     @change="onChange"
   >
     <span


### PR DESCRIPTION
# feat(toggle): add toggleOnClick prop

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added toggleOnClick prop to give users the option to disable the default internal toggle when clicked behaviour.

## :bulb: Context

They were having an issue in Dialpad Meetings where a user clicks a toggle and it pops up a disclaimer in a modal they have to accept before proceeding. If they accept the toggle gets set to true, if they do not it is set to false. Without this prop set, the toggle would immediately go to true as soon as they clicked it. By setting this to false it allows them to handle the state of the toggle programatically.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added all relevant documentation

## :crystal_ball: Next Steps

Confirm that this fixes the reporters issue.
