### PR TITLE
feat: enable shadowMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ import { getEmojiData } from '@dialpad/dialtone-vue/emoji'
 const emojiData = getEmojiData();
 ```
 
+## Shadow DOM
+
+If you are using Dialtone Vue within a shadow DOM set the `shadowRoot: YOUR_ELEMENT` option on your vue instance and the styles will be isolated to that element rather than rendered at the root.
+
 ## Contributing
 
 If you would like to contribute to Dialtone Vue the first step is to get the project running locally. Follow the below quickstart to do so.

--- a/vue.config.js
+++ b/vue.config.js
@@ -30,7 +30,8 @@ function enableShadowCss (config) {
     config.module.rule('stylus').oneOf('normal').use('vue-style-loader'),
   ];
   configs.forEach(c => c.tap(options => {
-    options.shadowMode = true;
+    // disable shadowMode for test environment.
+    options.shadowMode = process.env.NODE_ENV !== 'test';
     return options;
   }));
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,9 +1,46 @@
 const path = require('path');
 const { defineConfig } = require('@vue/cli-service');
 
+function enableShadowCss (config) {
+  const configs = [
+    config.module.rule('vue').use('vue-loader'),
+    config.module.rule('css').oneOf('vue-modules').use('vue-style-loader'),
+    config.module.rule('css').oneOf('vue').use('vue-style-loader'),
+    config.module.rule('css').oneOf('normal-modules').use('vue-style-loader'),
+    config.module.rule('css').oneOf('normal').use('vue-style-loader'),
+    config.module.rule('postcss').oneOf('vue-modules').use('vue-style-loader'),
+    config.module.rule('postcss').oneOf('vue').use('vue-style-loader'),
+    config.module.rule('postcss').oneOf('normal-modules').use('vue-style-loader'),
+    config.module.rule('postcss').oneOf('normal').use('vue-style-loader'),
+    config.module.rule('scss').oneOf('vue-modules').use('vue-style-loader'),
+    config.module.rule('scss').oneOf('vue').use('vue-style-loader'),
+    config.module.rule('scss').oneOf('normal-modules').use('vue-style-loader'),
+    config.module.rule('scss').oneOf('normal').use('vue-style-loader'),
+    config.module.rule('sass').oneOf('vue-modules').use('vue-style-loader'),
+    config.module.rule('sass').oneOf('vue').use('vue-style-loader'),
+    config.module.rule('sass').oneOf('normal-modules').use('vue-style-loader'),
+    config.module.rule('sass').oneOf('normal').use('vue-style-loader'),
+    config.module.rule('less').oneOf('vue-modules').use('vue-style-loader'),
+    config.module.rule('less').oneOf('vue').use('vue-style-loader'),
+    config.module.rule('less').oneOf('normal-modules').use('vue-style-loader'),
+    config.module.rule('less').oneOf('normal').use('vue-style-loader'),
+    config.module.rule('stylus').oneOf('vue-modules').use('vue-style-loader'),
+    config.module.rule('stylus').oneOf('vue').use('vue-style-loader'),
+    config.module.rule('stylus').oneOf('normal-modules').use('vue-style-loader'),
+    config.module.rule('stylus').oneOf('normal').use('vue-style-loader'),
+  ];
+  configs.forEach(c => c.tap(options => {
+    options.shadowMode = true;
+    return options;
+  }));
+}
+
 module.exports = defineConfig({
   lintOnSave: false,
   css: { extract: false },
+  chainWebpack: config => {
+    enableShadowCss(config);
+  },
   configureWebpack: {
     resolve: {
       alias: {


### PR DESCRIPTION
# feat: enable shadowMode 

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Related to https://dialpad.atlassian.net/browse/DP-63528

Added support for `shadowMode` which allows css classes in the library to be rendered within a shadow dom rather than always at the root.

The way to enable this is a bit cumbersome as vue.config.js doesn't really have a built in option to change this directly for all instance, so you have to go through the vue-cli generated config and manually set it on each rule. After searching a bunch this appears to be the best way available.

The consumer must set the `shadowRoot: element` as an option on the vue instance where element is the element where the styles should be rendered.

Joao has tested this change on the kare agent assist widget and has confirmed it fixes the issue.

## :bulb: Context

The Kare agent assist widget renders in a shadow dom within firespotter, however any styles from dialtone vue were being rendered at the root rather than within the shadow dom. This was overriding dialtone classes already in the project with older versions. The css needs to be isolated within the shadow dom.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added all relevant documentation
- [x] I have checked that my change did not significantly increase bundle size

## :crystal_ball: Next Steps

Joao to update to the new release in agent assist widget

## :link: Sources

https://vue-loader.vuejs.org/options.html#shadowmode
https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM
