### PR TITLE
fix(popover): blocking wheel event

### DIFF
--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -698,6 +698,11 @@ export default {
     **/
     preventScrolling (e) {
       if (!this.modal) return;
+      const isEventComingWithinPopover = Object.keys(this.$refs).some(refName => {
+        const ref = this.$refs[refName];
+        return ref.$el ? ref.$el.contains(e.target) : ref.contains(e.target);
+      });
+      if (isEventComingWithinPopover) return;
       e.preventDefault();
     },
 
@@ -832,7 +837,6 @@ export default {
       this.addEventListeners();
     },
   },
-
 };
 </script>
 

--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -697,12 +697,7 @@ export default {
     * Prevents scrolling only when the popover is set to modal
     **/
     preventScrolling (e) {
-      if (!this.modal) return;
-      const isEventComingWithinPopover = Object.keys(this.$refs).some(refName => {
-        const ref = this.$refs[refName];
-        return ref.$el ? ref.$el.contains(e.target) : ref.contains(e.target);
-      });
-      if (isEventComingWithinPopover) return;
+      if (!this.modal || this.$refs.content.$el.contains(e.target)) return;
       e.preventDefault();
     },
 


### PR DESCRIPTION
# Fix popover blocking wheel event

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Fixed the popover blocking wheel event by bypassing events comming from inside the popover.

This gives another issue that the popover might be scrolled out of window by scrolling inside of it with over a no scrollable element.

## :bulb: Context

https://dialpad.atlassian.net/browse/DT-910

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Capture the events that its target is not a scrollable element within the popover.