### PR TITLE
fix(root-layout): detect empty slot

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -3,7 +3,11 @@ import {
   DEFAULT_VALIDATION_MESSAGE_TYPE,
   VALIDATION_MESSAGE_TYPES,
 } from './constants';
-import { h } from 'vue';
+import {
+  h,
+  Comment,
+  Text,
+} from 'vue';
 const seedrandom = require('seedrandom');
 
 let UNIQUE_ID_COUNTER = 0;
@@ -110,6 +114,27 @@ export const flushPromises = () => {
     scheduler(resolve);
   });
 };
+
+/*
+  It is very cumbersome to check if a slot is empty in vue 3. Copied this method from the following thread
+  https://github.com/vuejs/core/issues/4733. There is an RFC to fix this but not yet being worked on.
+  https://github.com/vuejs/rfcs/discussions/453
+*/
+export function hasSlotContent (slot, slotProps = {}) {
+  if (!slot) return false;
+
+  // eslint-disable-next-line complexity
+  return slot(slotProps).some((vnode) => {
+    if (vnode.type === Comment) return false;
+
+    if (Array.isArray(vnode.children) && !vnode.children.length) return false;
+
+    return (
+      vnode.type !== Text ||
+      (typeof vnode.children === 'string' && vnode.children.trim() !== '')
+    );
+  });
+}
 
 /**
  * Transform a string from kebab-case to PascalCase

--- a/components/root_layout/root_layout.vue
+++ b/components/root_layout/root_layout.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="root-layout d-d-flex d-fd-column d-h100vh">
     <header
-      v-if="$slots.header"
+      v-if="hasSlotContent($slots.header)"
       :class="['root-layout__header', headerClass, { 'root-layout__header--sticky': headerSticky }]"
       :style="{ 'height': headerHeight }"
       data-qa="root-layout-header"
@@ -18,14 +18,14 @@
       :sidebar-position="sidebarPosition"
     >
       <template
-        v-if="$slots.sidebar"
+        v-if="hasSlotContent($slots.sidebar)"
         #sidebar
       >
         <!-- @slot Slot for the sidebar -->
         <slot name="sidebar" />
       </template>
       <template
-        v-if="$slots.default"
+        v-if="hasSlotContent($slots.default)"
         #content
       >
         <!-- @slot Slot for main content -->
@@ -33,7 +33,7 @@
       </template>
     </dt-root-layout-body>
     <footer
-      v-if="$slots.footer"
+      v-if="hasSlotContent($slots.footer)"
       :class="['root-layout__footer', footerClass]"
       :style="{ 'height': footerHeight }"
       data-qa="root-layout-footer"
@@ -47,6 +47,7 @@
 <script>
 import DtRootLayoutBody from './root_layout_body';
 import { ROOT_LAYOUT_SIDEBAR_POSITIONS } from './root_layout_constants';
+import { hasSlotContent } from '@/common/utils';
 
 /**
  * A root layout provides a standardized group of containers to display content at the root level.
@@ -156,6 +157,12 @@ export default {
       type: String,
       default: '64px',
     },
+  },
+
+  data () {
+    return {
+      hasSlotContent,
+    };
   },
 };
 </script>

--- a/components/root_layout/root_layout_default.story.vue
+++ b/components/root_layout/root_layout_default.story.vue
@@ -13,25 +13,32 @@
     :footer-height="$attrs.footerHeight"
   >
     <template
-      v-if="$attrs.header"
       #header
     >
-      <v-html :html="$attrs.header" />
+      <v-html
+        v-if="$attrs.header"
+        :html="$attrs.header"
+      />
     </template>
     <template
-      v-if="$attrs.sidebar"
       #sidebar
     >
-      <v-html :html="$attrs.sidebar" />
+      <v-html
+        v-if="$attrs.sidebar"
+        :html="$attrs.sidebar"
+      />
     </template>
-    <template v-if="defaultSlot">
-      <v-html :html="defaultSlot" />
-    </template>
+    <v-html
+      v-if="$attrs.default"
+      :html="defaultSlot"
+    />
     <template
-      v-if="$attrs.footer"
       #footer
     >
-      <v-html :html="$attrs.footer" />
+      <v-html
+        v-if="$attrs.footer"
+        :html="$attrs.footer"
+      />
     </template>
   </dt-root-layout>
 </template>

--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -17,7 +17,7 @@
     <dt-lazy-show
       :id="id"
       ref="content"
-      :show="isShown && (!!message.trim() || !defaultSlotIsEmpty)"
+      :show="isShown && (!!message.trim() || hasSlotContent($slots.default))"
       role="tooltip"
       aria-hidden="false"
       data-qa="dt-tooltip"
@@ -49,7 +49,7 @@ import {
   TOOLTIP_DIRECTIONS,
   TOOLTIP_STICKY_VALUES,
 } from './tooltip_constants';
-import { getUniqueString } from '@/common/utils';
+import { getUniqueString, hasSlotContent } from '@/common/utils';
 import DtLazyShow from '../lazy_show/lazy_show';
 import {
   createTippy,
@@ -210,6 +210,7 @@ export default {
   data () {
     return {
       TOOLTIP_KIND_MODIFIERS,
+      hasSlotContent,
       tip: null,
 
       // Internal state for whether the tooltip is shown. Changing the prop
@@ -250,20 +251,6 @@ export default {
           onChangePlacement: this.onChangePlacement,
         }),
       };
-    },
-
-    defaultSlotIsEmpty () {
-      const defaultSlotContents = this.$slots?.default();
-      const slotItemCount = defaultSlotContents?.length;
-
-      const slotIsEmpty = slotItemCount === 1 &&
-        (defaultSlotContents[0].type.toString() === 'Symbol(Comment)' ||
-        (
-          defaultSlotContents[0].type.toString() === 'Symbol(Fragment)' &&
-          defaultSlotContents[0].children.length === 0)
-        );
-
-      return !slotItemCount || slotIsEmpty;
     },
   },
 


### PR DESCRIPTION
# fix(root-layout): detect empty slot

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Using `$slots.footer` to detect a slot is empty no longer works correctly in vue 3. In fact it is very cumbersome to simply detect whether a slot is empty. Copied the method posted by andrey-hohlov in [this thread](https://github.com/vuejs/core/issues/4733). There is an RFC to fix this in vue, but has not been worked on yet.

## :bulb: Context

Root layout was still taking up space for the footer even when it was empty, the v-if on the slot wrapper was not working correctly in Vue 3

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added all relevant documentation

## :crystal_ball: Next Steps

Inform DP 2.0 of this change.
