### PR TITLE
feat: css as separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Dialtone Vue components can be imported directly from the package. Some componen
 import { DtInput, VALIDATION_MESSAGE_TYPES } from '@dialpad/dialtone-vue';
 ```
 
+If you are using the Vue 3 version of Dialtone, you must also import the css:
+
+```js
+import '@dialpad/dialtone-vue/css';
+```
+
 Projects using Dialtone Vue should be aware of the requirements:
 
 - Dialtone classes must be made available globally (to avoid duplication, Dialtone Vue does not do this for you).
@@ -45,6 +51,12 @@ import { setEmojiAssetUrlSmall, setEmojiAssetUrlLarge } from '@dialpad/dialtone-
 setEmojiAssetUrlSmall('https://my.example.website.com/joypixels/svg/unicode/32/', '.png')
 // larger than 16px
 setEmojiAssetUrlLarge('https://my.example.website.com/joypixels/svg/unicode/', '.svg')
+```
+
+If you are using the Vue 3 version of Dialtone emoji, you must import the css:
+
+```js
+import '@dialpad/dialtone-vue/emoji/css';
 ```
 
 You may access the emoji.json data for all emojis Dialtone Vue supports via executing the following function

--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ import { getEmojiData } from '@dialpad/dialtone-vue/emoji'
 const emojiData = getEmojiData();
 ```
 
-## Shadow DOM
-
-If you are using Dialtone Vue within a shadow DOM set the `shadowRoot: YOUR_ELEMENT` option on your vue instance and the styles will be isolated to that element rather than rendered at the root.
-
 ## Contributing
 
 If you would like to contribute to Dialtone Vue the first step is to get the project running locally. Follow the below quickstart to do so.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   ],
   "files": [
     "dist/*.js",
+    "dist/*.css",
     "dist/component-documentation.json",
     "CHANGELOG.md",
     "CHANGELOG.json"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,9 @@
   },
   "exports": {
     ".": "./dist/dialtone-vue.common.js",
-    "./emoji": "./dist/emoji.common.js"
+    "./emoji": "./dist/emoji.common.js",
+    "./css": "./dist/dialtone-vue.css",
+    "./emoji/css": "./dist/emoji.css"
   },
   "gitHooks": {
     "pre-commit": "lint-staged",

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,46 +1,8 @@
 const path = require('path');
 const { defineConfig } = require('@vue/cli-service');
 
-function enableShadowCss (config) {
-  const configs = [
-    config.module.rule('vue').use('vue-loader'),
-    config.module.rule('css').oneOf('vue-modules').use('vue-style-loader'),
-    config.module.rule('css').oneOf('vue').use('vue-style-loader'),
-    config.module.rule('css').oneOf('normal-modules').use('vue-style-loader'),
-    config.module.rule('css').oneOf('normal').use('vue-style-loader'),
-    config.module.rule('postcss').oneOf('vue-modules').use('vue-style-loader'),
-    config.module.rule('postcss').oneOf('vue').use('vue-style-loader'),
-    config.module.rule('postcss').oneOf('normal-modules').use('vue-style-loader'),
-    config.module.rule('postcss').oneOf('normal').use('vue-style-loader'),
-    config.module.rule('scss').oneOf('vue-modules').use('vue-style-loader'),
-    config.module.rule('scss').oneOf('vue').use('vue-style-loader'),
-    config.module.rule('scss').oneOf('normal-modules').use('vue-style-loader'),
-    config.module.rule('scss').oneOf('normal').use('vue-style-loader'),
-    config.module.rule('sass').oneOf('vue-modules').use('vue-style-loader'),
-    config.module.rule('sass').oneOf('vue').use('vue-style-loader'),
-    config.module.rule('sass').oneOf('normal-modules').use('vue-style-loader'),
-    config.module.rule('sass').oneOf('normal').use('vue-style-loader'),
-    config.module.rule('less').oneOf('vue-modules').use('vue-style-loader'),
-    config.module.rule('less').oneOf('vue').use('vue-style-loader'),
-    config.module.rule('less').oneOf('normal-modules').use('vue-style-loader'),
-    config.module.rule('less').oneOf('normal').use('vue-style-loader'),
-    config.module.rule('stylus').oneOf('vue-modules').use('vue-style-loader'),
-    config.module.rule('stylus').oneOf('vue').use('vue-style-loader'),
-    config.module.rule('stylus').oneOf('normal-modules').use('vue-style-loader'),
-    config.module.rule('stylus').oneOf('normal').use('vue-style-loader'),
-  ];
-  configs.forEach(c => c.tap(options => {
-    options.shadowMode = true;
-    return options;
-  }));
-}
-
 module.exports = defineConfig({
   lintOnSave: false,
-  css: { extract: false },
-  chainWebpack: config => {
-    enableShadowCss(config);
-  },
   configureWebpack: {
     resolve: {
       alias: {


### PR DESCRIPTION
# feat: css as separate file

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Instead of using js to inject css, store it in a separate file and allow the consumer to import it manually.

## :bulb: Context

Fixes the issue from the following slack thread: https://dialpad.slack.com/archives/C03EAH70A5P/p1674006782305509

Css classes from Dialtone Vue in Dialpad 2.0 were being completely ignored.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added all relevant documentation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size

## :crystal_ball: Next Steps

- Communicate this to teams using Dialtone Vue 3 since it is a breaking change.
- Move the new addition to the readme file over to the main staging branch.
