### PR TITLE
feat(semantic-release): add vue3 releases to GitHub releases

### DIFF
--- a/release-ci.config.js
+++ b/release-ci.config.js
@@ -1,7 +1,10 @@
 module.exports = {
   branches: [
-    'production',
-    'vue3',
+    {
+      name: 'vue3',
+      channel: 'vue3',
+    },
+    'staging-vue3',
     {
       name: 'beta',
       prerelease: true,

--- a/release-local.config.js
+++ b/release-local.config.js
@@ -1,7 +1,10 @@
 /* eslint-disable no-template-curly-in-string */
 module.exports = {
   branches: [
-    'staging',
+    {
+      name: 'vue3',
+      channel: 'vue3',
+    },
     'staging-vue3',
     {
       name: 'beta',


### PR DESCRIPTION
# add vue3 releases to GitHub releases

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Adding the channel for `vue3` branch will make semantic release GH plugin takes the last release and add in the GH releases.
Tested in a forked dialtone-vue repo https://github.com/josedialpad/dialtone-vue/releases

## :bulb: Context

https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#channel

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
