### PR TITLE
fix(notice): incorrect validation

### DIFF
--- a/components/notice/notice.stories.js
+++ b/components/notice/notice.stories.js
@@ -67,6 +67,11 @@ export const argTypesData = {
       options: NOTICE_ROLES,
     },
   },
+  show: {
+    table: {
+      disable: true,
+    },
+  },
 
   // Action Event Handlers
   onClick: {

--- a/components/notice/notice_action.test.js
+++ b/components/notice/notice_action.test.js
@@ -4,7 +4,6 @@ import { createLocalVue, mount } from '@vue/test-utils';
 import DtNoticeAction from './notice_action';
 import DtButton from '../button/button';
 import SrOnlyCloseButton from '../../common/sr_only_close_button';
-import sinon from 'sinon';
 import { cleanSpy, initializeSpy } from '@/tests/shared_examples/validation';
 import { itBehavesLikeVisuallyHiddenCloseLabelIsNull } from '@/tests/shared_examples/sr_only_close_button';
 
@@ -79,28 +78,14 @@ describe('DtNoticeAction tests', function () {
     });
 
     describe('When hideClose is true', function () {
-      let consoleErrorSpy;
-
       beforeEach(async function () {
         _setWrappers();
-        consoleErrorSpy = sinon.spy(console, 'error');
         await wrapper.setProps({ hideClose: true });
         _setChildWrappers();
       });
 
-      afterEach(function () {
-        consoleErrorSpy = null;
-        console.error.restore();
-      });
-
       it('Close button is not displayed', function () {
         assert.isFalse(closeButton.exists());
-      });
-
-      it('should output error message', function () {
-        assert.isTrue(consoleErrorSpy.calledWith('If hideClose prop is true, visuallyHiddenClose' +
-            ' and visuallyHiddenCloseLabel props need to be set so the component' +
-            ' always includes a close button'));
       });
     });
 

--- a/components/notice/notice_action.vue
+++ b/components/notice/notice_action.vue
@@ -89,16 +89,6 @@ export default {
     },
   },
 
-  watch: {
-    $props: {
-      immediate: true,
-      deep: true,
-      handler () {
-        this.validateProps();
-      },
-    },
-  },
-
   created () {
     if (!this.hideClose && !this.closeButtonProps.ariaLabel) {
       console.error('Invalid props: you must pass in closeButtonProps.ariaLabel if the close button is displayed.');
@@ -118,13 +108,6 @@ export default {
   methods: {
     close () {
       this.$emit('close');
-    },
-
-    validateProps () {
-      if (this.hideClose && !this.visuallyHiddenClose) {
-        console.error('If hideClose prop is true, visuallyHiddenClose and visuallyHiddenCloseLabel props ' +
-          'need to be set so the component always includes a close button');
-      }
     },
   },
 };


### PR DESCRIPTION
# Fix incorrect validation on notice 

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Removed visuallyHiddenClose validation on `notice_action` which impacts banner, notice and toast components which don't really require a visually hidden close button due to they're being called programatically most of the times and the user doesn't really needs to interact with them.

## :bulb: Context

A bug has been reported regarding this validation
https://dialpad.atlassian.net/browse/DP-58852

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root