### PR TITLE
fix(tab): fix focus management with focusable elements inside the panel

### DIFF
--- a/common/mixins/modal.js
+++ b/common/mixins/modal.js
@@ -20,14 +20,23 @@ const focusableElementsList = `button,[href],input,select,textarea,details,[tabi
 export default {
   methods: {
     /**
+     * get the first focusable element in your component, includes tabindex="-1".
+     * @param {object} el - optional - ref of dom element to trap focus on.
+     *  will default to the root node of the vue component
+     */
+    async getFirstFocusableElement (el) {
+      await this.$nextTick();
+      const focusableElements = this._getFocusableElements(el, true);
+      return this._getFirstFocusElement(focusableElements);
+    },
+
+    /**
      * set focus to the first focusable element in your component, includes tabindex="-1".
      * @param {object} el - optional - ref of dom element to trap focus on.
      *  will default to the root node of the vue component
      */
     async focusFirstElement (el) {
-      await this.$nextTick();
-      const focusableElements = this._getFocusableElements(el, true);
-      const elToFocus = this._getFirstFocusElement(focusableElements);
+      const elToFocus = await this.getFirstFocusableElement(el);
       elToFocus?.focus({ preventScroll: true });
     },
 

--- a/components/tabs/tab_panel.test.js
+++ b/components/tabs/tab_panel.test.js
@@ -1,12 +1,14 @@
 import { assert } from 'chai';
-import { shallowMount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import DtTabPanel from './tab_panel.vue';
+import { flushPromises } from '@/common/utils';
 
 describe('DtTabPanel Tests', function () {
   // Wrappers
   let wrapper;
   let tabPanel;
   const defaultSlot = 'Panel Slot';
+  const focusableSlot = '<button>Focusable Slot</button>';
 
   const slots = { default: defaultSlot };
   const groupContext = {
@@ -22,7 +24,7 @@ describe('DtTabPanel Tests', function () {
   };
 
   const _mountWrapper = () => {
-    wrapper = shallowMount(DtTabPanel, {
+    wrapper = mount(DtTabPanel, {
       slots,
       propsData,
       global: {
@@ -31,6 +33,7 @@ describe('DtTabPanel Tests', function () {
         },
       },
     });
+
     _setWrappers();
   };
 
@@ -117,8 +120,21 @@ describe('DtTabPanel Tests', function () {
         assert.strictEqual(tabPanel.attributes('role'), 'tabpanel');
       });
 
-      it('tabindex should be "0"', function () {
+      it('tabindex should be "0" if the first element is not focusable', function () {
         assert.strictEqual(tabPanel.attributes('tabindex'), '0');
+      });
+    });
+
+    describe('Focus management with tabindex', function () {
+      beforeEach(async function () {
+        slots.default = focusableSlot;
+        await _mountWrapper();
+        await flushPromises();
+        _setWrappers();
+      });
+
+      it('tabindex should be "-1" if the first element is focusable', function () {
+        assert.strictEqual(tabPanel.attributes('tabindex'), '-1');
       });
     });
   });

--- a/components/tabs/tab_panel.vue
+++ b/components/tabs/tab_panel.vue
@@ -3,7 +3,7 @@
     v-show="!hidden"
     :id="`dt-panel-${id}`"
     role="tabpanel"
-    tabindex="0"
+    :tabindex="isFirstElementFocusable ? -1 : 0"
     :aria-labelledby="`dt-tab-${tabId}`"
     :aria-hidden="`${hidePanel}`"
     :class="[
@@ -20,12 +20,16 @@
 </template>
 
 <script>
+import Modal from '@/common/mixins/modal.js';
+
 /**
  * Tabs allow users to navigation between grouped content in different views while within the same page context.
  * @see https://dialpad.design/components/tabs.html
  */
 export default {
   name: 'DtTabPanel',
+
+  mixins: [Modal],
 
   inject: ['groupContext'],
 
@@ -64,10 +68,20 @@ export default {
     },
   },
 
+  data () {
+    return {
+      isFirstElementFocusable: false,
+    };
+  },
+
   computed: {
     hidePanel () {
       return this.groupContext.selected !== this.id || this.hidden;
     },
+  },
+
+  async mounted () {
+    this.isFirstElementFocusable = !!(await this.getFirstFocusableElement(this.$el));
   },
 };
 </script>


### PR DESCRIPTION
# fix focus management with focusable elements inside the panel

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Vue3 version of https://github.com/dialpad/dialtone-vue/pull/717 with the fix https://github.com/dialpad/dialtone-vue/pull/720 applied

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
