### PR TITLE
fix(tab): fix tabindex value tied to the first element in the panel

### DIFF
--- a/components/tabs/tab_panel.test.js
+++ b/components/tabs/tab_panel.test.js
@@ -8,7 +8,6 @@ describe('DtTabPanel Tests', function () {
   let wrapper;
   let tabPanel;
   const defaultSlot = 'Panel Slot';
-  const focusableSlot = '<button>Focusable Slot</button>';
 
   const slots = { default: defaultSlot };
   const groupContext = {
@@ -124,16 +123,29 @@ describe('DtTabPanel Tests', function () {
       });
     });
 
-    describe('Focus management with tabindex', function () {
+    describe('When the first element is focusable', function () {
       beforeEach(async function () {
-        slots.default = focusableSlot;
+        slots.default = '<div><button>Focusable Slot</button></div>';
         await _mountWrapper();
         await flushPromises();
         _setWrappers();
       });
 
-      it('tabindex should be "-1" if the first element is focusable', function () {
+      it('tabindex should be "-1"', function () {
         assert.strictEqual(tabPanel.attributes('tabindex'), '-1');
+      });
+    });
+
+    describe(`When there is a focusable element but it isn't the first element`, function () {
+      beforeEach(async function () {
+        slots.default = '<h1>Content</h1><div><button>Focusable Slot</button></div>';
+        await _mountWrapper();
+        await flushPromises();
+        _setWrappers();
+      });
+
+      it('tabindex should be "0"', function () {
+        assert.strictEqual(tabPanel.attributes('tabindex'), '0');
       });
     });
   });

--- a/components/tabs/tab_panel.vue
+++ b/components/tabs/tab_panel.vue
@@ -85,7 +85,9 @@ export default {
     if (!firstFocusableElement) {
       this.isFirstElementFocusable = false;
     } else {
-      // If the first focusable element isn't the first element, then we need to set the panel tabindex to 0
+      // If the first focusable element isn't the first element in the panel,
+      // then we need to set the panel tabindex to 0.
+      // See notes in https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
       this.isFirstElementFocusable = this.isFirstElementOfPanel(firstFocusableElement);
     }
   },
@@ -93,14 +95,14 @@ export default {
   methods: {
     isFirstElementOfPanel (element) {
       let current = element;
-      let isFirstElement = false;
+      let isFirstElement = true;
 
       while (current) {
-        if (current.previousElementSibling === null && current.parentNode === this.$el) {
-          isFirstElement = true;
+        if (current.previousElementSibling !== null) {
+          isFirstElement = false;
           break;
         }
-        current = current.previousElementSibling;
+        current = current.parentNode !== this.$el ? current.parentNode : null;
       }
 
       return isFirstElement;

--- a/components/tabs/tab_panel.vue
+++ b/components/tabs/tab_panel.vue
@@ -80,7 +80,31 @@ export default {
   },
 
   async mounted () {
-    this.isFirstElementFocusable = !!(await this.getFirstFocusableElement(this.$el));
+    const firstFocusableElement = await this.getFirstFocusableElement(this.$el);
+
+    if (!firstFocusableElement) {
+      this.isFirstElementFocusable = false;
+    } else {
+      // If the first focusable element isn't the first element, then we need to set the panel tabindex to 0
+      this.isFirstElementFocusable = this.isFirstElementOfPanel(firstFocusableElement);
+    }
+  },
+
+  methods: {
+    isFirstElementOfPanel (element) {
+      let current = element;
+      let isFirstElement = false;
+
+      while (current) {
+        if (current.previousElementSibling === null && current.parentNode === this.$el) {
+          isFirstElement = true;
+          break;
+        }
+        current = current.previousElementSibling;
+      }
+
+      return isFirstElement;
+    },
   },
 };
 </script>


### PR DESCRIPTION
# fix tabindex value tied to the first element in the panel

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Updated the `tabindex` logic regarding the first element in the panel described in the notes (4) in https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/.
This PR adds the validation when the first element with content is not focusable, the tabpanel should set `tabindex="0"`.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

![2023-01-30 at 12 13 00@2x](https://user-images.githubusercontent.com/83774467/215519768-2c592ddf-90c8-418b-a5b6-cb496bbc9f55.png)

<img width="710" alt="2023-01-30 at 12 16 15@2x" src="https://user-images.githubusercontent.com/83774467/215519742-f971215c-f8a7-4963-a3af-d64f4382dfba.png">

## :link: Sources

- https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
- https://www.w3.org/WAI/ARIA/apg/example-index/tabs/tabs-manual.html
