### PR TITLE
fix(combobox-multi-select): chips missalignment

### DIFF
--- a/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -112,7 +112,7 @@ import { validationMessageValidator } from '@/common/validators';
 import {
   MULTI_SELECT_SIZES,
   CHIP_SIZES,
-  CHIP_BOTTOM_POSITION,
+  CHIP_TOP_POSITION,
 } from './combobox_multi_select_story_constants';
 import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
 
@@ -500,8 +500,9 @@ export default {
     },
 
     setChipsPosition () {
+      const input = this.getInput().getBoundingClientRect();
       const chipsWrapper = this.$refs.chipsWrapper;
-      chipsWrapper.style.bottom = `${CHIP_BOTTOM_POSITION[this.size]}px`;
+      chipsWrapper.style.top = (input.top - CHIP_TOP_POSITION[this.size]) + 'px';
     },
 
     setInputPadding () {

--- a/recipes/comboboxes/combobox_multi_select/combobox_multi_select_story_constants.js
+++ b/recipes/comboboxes/combobox_multi_select/combobox_multi_select_story_constants.js
@@ -37,8 +37,8 @@ export const CHIP_SIZES = {
   md: 'sm',
 };
 
-export const CHIP_BOTTOM_POSITION = {
-  xs: 4,
-  sm: 5,
-  md: 5,
+export const CHIP_TOP_POSITION = {
+  xs: 11.1,
+  sm: 10.1,
+  md: 10.1,
 };


### PR DESCRIPTION
# Fix combobox multi-select chips missalignment with validation message.

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Fixed the issue by using the top position instead of the bottom and using the input position to calculate in a better way the position.

## :bulb: Context

When using a combobox multiselect with a validation message the chips were missaligned.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

<img width="737" alt="image" src="https://user-images.githubusercontent.com/87546543/216190893-45a617f8-39d0-49ed-ab92-c68768cc7c49.png">
