### PR TITLE
fix(collapsible): correct anchor slot check

### DIFF
--- a/components/collapsible/collapsible.vue
+++ b/components/collapsible/collapsible.vue
@@ -79,7 +79,7 @@
 </template>
 
 <script>
-import { getUniqueString } from '@/common/utils';
+import { getUniqueString, hasSlotContent } from '@/common/utils';
 import DtCollapsibleLazyShow from './collapsible_lazy_show';
 import { DtButton } from '../button';
 import { DtLazyShow } from '../lazy_show';
@@ -273,7 +273,7 @@ export default {
     },
 
     validateProperAnchor () {
-      if (!this.anchorText && !this.$slots.$anchor) {
+      if (!this.anchorText && !hasSlotContent(this.$slots.anchor)) {
         console.error('anchor text and anchor slot content cannot both be falsy');
       }
     },


### PR DESCRIPTION
# fix(collapsible): correct anchor slot check

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Code was using `this.$slots.$anchor` which is incorrect it should be `this.$slots.anchor`. Also updated to use our new `hasSlotContent` function to get around the slot content issues in vue 3.

This is a vue 3 only issue.

## :link: Sources

https://dialpad.atlassian.net/browse/DP-64811
