### PR TITLE
fix(combobox-multi-select): wrong chips position while on modal

### DIFF
--- a/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -359,7 +359,7 @@ export default {
       async handler () {
         await this.$nextTick();
         this.setInputPadding();
-        this.setChipsPosition();
+        this.setChipsTopPosition();
         this.setInputMinWidth();
         this.checkMaxSelected();
       },
@@ -368,13 +368,13 @@ export default {
     async label () {
       await this.$nextTick();
       // Adjust the chips position if label changed
-      this.setChipsPosition();
+      this.setChipsTopPosition();
     },
 
     async description () {
       await this.$nextTick();
       // Adjust the chips position if description changed
-      this.setChipsPosition();
+      this.setChipsTopPosition();
     },
 
     size: {
@@ -384,6 +384,7 @@ export default {
         this.revertInputPadding(input);
         this.originalInputSize = input.getBoundingClientRect().height;
         this.setInputPadding();
+        this.setChipsTopPosition();
       },
 
       immediate: true,
@@ -391,10 +392,9 @@ export default {
   },
 
   mounted () {
-    this.setChipsPosition();
     // Recalculate chip position and input padding when resizing window
-    this.resizeWindowObserver = new ResizeObserver(() => {
-      this.setChipsPosition();
+    this.resizeWindowObserver = new ResizeObserver(async () => {
+      this.setChipsTopPosition();
       this.setInputPadding();
     });
     this.resizeWindowObserver.observe(document.body);
@@ -499,10 +499,16 @@ export default {
       this.closeComboboxList();
     },
 
-    setChipsPosition () {
-      const input = this.getInput().getBoundingClientRect();
+    setChipsTopPosition () {
+      // To place the chips in the input box
+      // The chip "top" position should be the same line as the input box
+      const input = this.getInput();
+      if (!input) return;
+      const inputSlotWrapper = this.$refs.inputSlotWrapper;
+      const top = input.getBoundingClientRect().top -
+                  inputSlotWrapper.getBoundingClientRect().top;
       const chipsWrapper = this.$refs.chipsWrapper;
-      chipsWrapper.style.top = (input.top - CHIP_TOP_POSITION[this.size]) + 'px';
+      chipsWrapper.style.top = (top - CHIP_TOP_POSITION[this.size]) + 'px';
     },
 
     setInputPadding () {

--- a/recipes/comboboxes/combobox_multi_select/combobox_multi_select_story_constants.js
+++ b/recipes/comboboxes/combobox_multi_select/combobox_multi_select_story_constants.js
@@ -38,7 +38,7 @@ export const CHIP_SIZES = {
 };
 
 export const CHIP_TOP_POSITION = {
-  xs: 11.1,
-  sm: 10.1,
-  md: 10.1,
+  xs: 1.4,
+  sm: 0.4,
+  md: 0.2,
 };


### PR DESCRIPTION
# Fix combobox multi select chips position while on modal

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Reverted the setChipsTopPosition logic, the only change that we really needed was the chips size and the input padding.

Tested Default, with Max select validation and inside a modal, everything should be working fine now.

## :bulb: Context

A bug was introduced on #736 when changed the way we were calculating the chips position.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root