### PR TITLE
fix(root-layout): sidebar independently scrollable

### DIFF
--- a/components/root_layout/root_layout_body.vue
+++ b/components/root_layout/root_layout_body.vue
@@ -1,14 +1,15 @@
 <template>
   <div
     ref="root-layout-body"
-    :class="['root-layout__body', 'd-fl-grow1', bodyClasses]"
+    :class="['root-layout__body', { 'd-of-y-auto': isInMobileMode }, 'd-fl-grow1', bodyClasses]"
+    :style="{ 'height': isInMobileMode ? mainHeight : null }"
     data-qa="root-layout-body"
   >
     <aside
       v-if="$slots.sidebar"
       ref="root-layout-sidebar"
-      :class="['root-layout__sidebar', sidebarClass]"
-      :style="{ 'flex-basis': sidebarWidth }"
+      :class="['root-layout__sidebar', { 'd-of-y-auto': !isInMobileMode }, sidebarClass]"
+      :style="{ 'flex-basis': sidebarWidth, 'height': !isInMobileMode ? mainHeight : null }"
       data-qa="root-layout-sidebar"
     >
       <!-- @slot Slot for the sidebar -->
@@ -17,8 +18,8 @@
     <main
       v-if="$slots.content"
       ref="root-layout-content"
-      :class="['root-layout__content', contentClass]"
-      :style="{ 'min-inline-size': contentWrapWidthPercent, 'height': mainHeight }"
+      :class="['root-layout__content', { 'd-of-y-auto': !isInMobileMode }, contentClass]"
+      :style="{ 'min-inline-size': contentWrapWidthPercent, 'height': !isInMobileMode ? mainHeight : null }"
       data-qa="root-layout-content"
     >
       <!-- @slot Slot for the main content -->
@@ -120,20 +121,19 @@ export default {
 
     mainHeight () {
       if (this.fixed) {
-        return `calc(${this.documentHeight}
-          - (${this.headerHeight} + ${this.extraSidebarHeight} + ${this.footerHeight}))`;
+        return `calc(${this.documentHeight} - (${this.headerHeight} + ${this.footerHeight}))`;
       }
       return null;
     },
 
-    // When the sidebar is above the header due to contentWrapWidthPercent, it needs to be excluded
-    // in the main content height calculation. Otherwise it is 0 since it is at equal height with the main content.
-    extraSidebarHeight () {
+    // When the sidebar is above the header due to contentWrapWidthPercent it is considered to be in mobile mode.
+    isInMobileMode () {
       if (this.contentTop > this.sidebarTop) {
-        return this.$refs['root-layout-sidebar'].offsetHeight + 'px';
+        return true;
       }
-      return '0px';
+      return false;
     },
+
   },
 
   mounted () {
@@ -182,6 +182,5 @@ export default {
 .root-layout__content {
   flex-basis: 0;
   flex-grow: 999;
-  overflow-y: auto;
 }
 </style>


### PR DESCRIPTION
# fix(root-layout): sidebar independently scrollable

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Got a report that while the main content was scrollable on overflow, the sidebar was not. Added overflow y auto to the sidebar and also made the entire main content section (sidebar + content) scrollable when at mobile width, as this makes more sense than what we were doing before.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes

## :crystal_ball: Next Steps

Test in DP 2.0
