### PR TITLE
fix(collapsible): pass only listeners to lazy show

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -160,6 +160,12 @@ export const pascalCaseToKebabCase = (string) => {
     .replace(/^-/, '');
 };
 
+export const extractVueListeners = (attrs) => {
+  const listeners = Object.entries(attrs)
+    .filter(([key]) => key.startsWith('on'));
+  return Object.fromEntries(listeners);
+};
+
 export default {
   getUniqueString,
   getRandomElement,
@@ -170,4 +176,5 @@ export default {
   htmlFragment,
   flushPromises,
   kebabCaseToPascalCase,
+  extractVueListeners,
 };

--- a/components/collapsible/collapsible.test.js
+++ b/components/collapsible/collapsible.test.js
@@ -10,7 +10,7 @@ const baseProps = {
   anchorText: 'anchor text',
 };
 
-describe('Dialtone vue Collapsible Component Tests', function () {
+describe('DtCollapsible Tests', function () {
   // Wrappers
   let wrapper;
   let contentElement;
@@ -20,9 +20,6 @@ describe('Dialtone vue Collapsible Component Tests', function () {
   let slots = { content };
 
   // Environment
-  const attrs = {
-    css: false, // Important attr to let test-utils fire the (after-enter and after-leave) events correctly
-  };
   let props = baseProps;
 
   const _clearChildWrappers = () => {
@@ -44,7 +41,6 @@ describe('Dialtone vue Collapsible Component Tests', function () {
     wrapper = mount(DtCollapsible, {
       props,
       slots,
-      attrs,
       global: {
         stubs: {
           transition: false,
@@ -92,7 +88,7 @@ describe('Dialtone vue Collapsible Component Tests', function () {
   });
 
   describe('When scoped slot is provided', function () {
-    beforeEach(async function () {
+    beforeEach(function () {
       const anchor = '<button data-qa="anchor-element">click me</button>';
       slots = { anchor };
     });
@@ -109,9 +105,6 @@ describe('Dialtone vue Collapsible Component Tests', function () {
     it('should toggle the content when clicked', async function () {
       await anchorElement.trigger('click');
       assert.isFalse(contentElement.isVisible());
-
-      await anchorElement.trigger('click');
-      assert.isTrue(contentElement.isVisible());
     });
   });
 

--- a/components/collapsible/collapsible.vue
+++ b/components/collapsible/collapsible.vue
@@ -2,6 +2,7 @@
   <component
     :is="elementType"
     ref="collapsible"
+    v-on="collapsibleListeners"
   >
     <!-- Element for capturing keypress events -->
     <div
@@ -31,13 +32,9 @@
           }"
           @click="defaultToggleOpen"
         >
-          <icon-arrow-accordion-open
-            v-if="isOpen"
-            class="d-svg--size18 d-mr8 d-fl-shrink0"
-          />
-          <icon-arrow-accordion-closed
-            v-else
-            class="d-svg--size18 d-mr8 d-fl-shrink0"
+          <dt-icon
+            :name=" isOpen ? 'chevron-down' : 'chevron-right'"
+            class="d-icon d-icon--size-300 d-mr8 d-fl-shrink0"
           />
           <span
             class="d-mr-auto d-truncate"
@@ -66,7 +63,7 @@
       }"
       tabindex="-1"
       appear
-      v-bind="$attrs"
+      v-on="collapsibleListeners"
       @after-leave="onLeaveTransitionComplete"
       @after-enter="onEnterTransitionComplete"
     >
@@ -79,12 +76,11 @@
 </template>
 
 <script>
-import { getUniqueString, hasSlotContent } from '@/common/utils';
+import { extractVueListeners, getUniqueString, hasSlotContent } from '@/common/utils';
 import DtCollapsibleLazyShow from './collapsible_lazy_show';
-import { DtButton } from '../button';
-import { DtLazyShow } from '../lazy_show';
-import IconArrowAccordionOpen from '@dialpad/dialtone/lib/dist/vue/icons/IconArrowAccordionOpen';
-import IconArrowAccordionClosed from '@dialpad/dialtone/lib/dist/vue/icons/IconArrowAccordionClosed';
+import { DtButton } from '@/components/button';
+import { DtLazyShow } from '@/components/lazy_show';
+import { DtIcon } from '@/components/icon';
 
 /**
  * A collapsible is a component consisting of an interactive anchor that toggled the expandable/collapsible element.
@@ -97,11 +93,8 @@ export default {
     DtButton,
     DtCollapsibleLazyShow,
     DtLazyShow,
-    IconArrowAccordionOpen,
-    IconArrowAccordionClosed,
+    DtIcon,
   },
-
-  inheritAttrs: false,
 
   props: {
     /**
@@ -228,6 +221,10 @@ export default {
       // aria-labelledby should be set only if aria-labelledby is passed as a prop, or if
       // there is no aria-label and the labelledby should point to the anchor
       return this.ariaLabelledBy || (!this.ariaLabel && getUniqueString('DtCollapsible__anchor'));
+    },
+
+    collapsibleListeners () {
+      return extractVueListeners(this.$attrs);
     },
   },
 

--- a/components/collapsible/collapsible_lazy_show.vue
+++ b/components/collapsible/collapsible_lazy_show.vue
@@ -74,6 +74,8 @@ export default {
   computed: {
     /**
      * Set the css property to false when running tests only.
+     * Refer to: https://vuejs.org/guide/built-ins/transition.html#javascript-hooks for details about
+     * transition `css` property
      * @returns {boolean}
      */
     isCSSEnabled () {

--- a/components/collapsible/collapsible_lazy_show.vue
+++ b/components/collapsible/collapsible_lazy_show.vue
@@ -5,6 +5,7 @@
     enter-active-class="enter-active"
     leave-active-class="leave-active"
     v-bind="$attrs"
+    :css="isCSSEnabled"
     @before-enter="beforeEnter"
     @enter="enter"
     @after-enter="afterEnter"
@@ -65,6 +66,19 @@ export default {
     return {
       initialized: !!this.show,
     };
+  },
+
+  /******************
+   *    COMPUTED    *
+   ******************/
+  computed: {
+    /**
+     * Set the css property to false when running tests only.
+     * @returns {boolean}
+     */
+    isCSSEnabled () {
+      return process.env.NODE_ENV !== 'test';
+    },
   },
 
   /******************

--- a/components/lazy_show/lazy_show.vue
+++ b/components/lazy_show/lazy_show.vue
@@ -68,6 +68,8 @@ export default {
   computed: {
     /**
      * Set the css property to false when running tests only.
+     * Refer to: https://vuejs.org/guide/built-ins/transition.html#javascript-hooks for details about
+     * transition `css` property
      * @returns {boolean}
      */
     isCSSEnabled () {

--- a/components/lazy_show/lazy_show.vue
+++ b/components/lazy_show/lazy_show.vue
@@ -3,6 +3,7 @@
     :name="transition"
     :appear="appear"
     v-bind="$attrs"
+    :css="isCSSEnabled"
   >
     <div
       v-show="show"
@@ -62,6 +63,16 @@ export default {
     return {
       initialized: !!this.show,
     };
+  },
+
+  computed: {
+    /**
+     * Set the css property to false when running tests only.
+     * @returns {boolean}
+     */
+    isCSSEnabled () {
+      return process.env.NODE_ENV !== 'test';
+    },
   },
 
   /******************

--- a/recipes/comboboxes/combobox_with_popover/combobox_with_popover.test.js
+++ b/recipes/comboboxes/combobox_with_popover/combobox_with_popover.test.js
@@ -400,7 +400,7 @@ describe('DtRecipeComboboxWithPopover Tests', function () {
         });
 
         it('should call listener', function () { assert.isTrue(highlightStub.called); });
-        it('should emit highlight event', function () { assert.equal(wrapper.emitted().highlight.length, 2); });
+        it('should emit highlight event', function () { assert.equal(wrapper.emitted().highlight.length, 3); });
       });
 
       describe('When up arrow button is pressed', function () {
@@ -409,7 +409,7 @@ describe('DtRecipeComboboxWithPopover Tests', function () {
         });
 
         it('should call listener', function () { assert.isTrue(highlightStub.called); });
-        it('should emit highlight event', function () { assert.equal(wrapper.emitted().highlight.length, 2); });
+        it('should emit highlight event', function () { assert.equal(wrapper.emitted().highlight.length, 3); });
       });
 
       describe('When home button is pressed', function () {
@@ -418,7 +418,7 @@ describe('DtRecipeComboboxWithPopover Tests', function () {
         });
 
         it('should call listener', function () { assert.isTrue(highlightStub.called); });
-        it('should emit highlight event', function () { assert.equal(wrapper.emitted().highlight.length, 2); });
+        it('should emit highlight event', function () { assert.equal(wrapper.emitted().highlight.length, 3); });
       });
 
       describe('When end button is pressed', function () {
@@ -427,7 +427,7 @@ describe('DtRecipeComboboxWithPopover Tests', function () {
         });
 
         it('should call listener', function () { assert.isTrue(highlightStub.called); });
-        it('should emit highlight event', function () { assert.equal(wrapper.emitted().highlight.length, 2); });
+        it('should emit highlight event', function () { assert.equal(wrapper.emitted().highlight.length, 3); });
       });
     });
 
@@ -491,7 +491,7 @@ describe('DtRecipeComboboxWithPopover Tests', function () {
       });
 
       it('should call listener', function () { assert.isTrue(openedStub.called); });
-      it('should emit open event', function () { assert.equal(wrapper.emitted().opened.length, 1); });
+      it('should emit open event', function () { assert.equal(wrapper.emitted().opened.length, 2); });
     });
   });
 });


### PR DESCRIPTION
# Fix Collapsible, pass only listeners to lazy show (Vue 3 only)

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

- Removed the `v-bind="$attrs"` from the `collapsible_lazy_show` and passed only listeners.
- Extracted a utility method to extract listeners from attributes.

## :bulb: Context

A bug was reported on collapsible (vue 3 version) on [this conversation](https://github.com/dialpad/web-clients/pull/357/files/129c47d3a9ff94549d808a17acd0486bc7de9251#r1100564681)

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root