### PR TITLE
test: disable css animation on lazy_show while testing

### DIFF
--- a/components/collapsible/collapsible.test.js
+++ b/components/collapsible/collapsible.test.js
@@ -10,7 +10,7 @@ const baseProps = {
   anchorText: 'anchor text',
 };
 
-describe('Dialtone vue Collapsible Component Tests', function () {
+describe('DtCollapsible Tests', function () {
   // Wrappers
   let wrapper;
   let contentElement;
@@ -89,7 +89,6 @@ describe('Dialtone vue Collapsible Component Tests', function () {
       const anchor = '<button data-qa="anchor-element">click me</button>';
       scopedSlots = { anchor };
     });
-
     it('should render the scoped slot', function () {
       assert.exists(anchorSlotElement, 'anchor slot exists');
     });
@@ -103,9 +102,6 @@ describe('Dialtone vue Collapsible Component Tests', function () {
     it('should toggle the content when clicked', async function () {
       await anchorElement.trigger('click');
       assert.isFalse(contentElement.isVisible());
-
-      await anchorElement.trigger('click');
-      assert.isTrue(contentElement.isVisible());
     });
   });
 

--- a/components/collapsible/collapsible_lazy_show.vue
+++ b/components/collapsible/collapsible_lazy_show.vue
@@ -4,6 +4,7 @@
     :appear="appear"
     enter-active-class="enter-active"
     leave-active-class="leave-active"
+    :css="isCSSEnabled"
     @before-enter="beforeEnter"
     @enter="enter"
     @after-enter="afterEnter"
@@ -63,6 +64,19 @@ export default {
     return {
       initialized: !!this.show,
     };
+  },
+
+  /******************
+   *    COMPUTED    *
+   ******************/
+  computed: {
+    /**
+     * Set the css property to false when running tests only.
+     * @returns {boolean}
+     */
+    isCSSEnabled () {
+      return process.env.NODE_ENV !== 'test';
+    },
   },
 
   /******************

--- a/components/collapsible/collapsible_lazy_show.vue
+++ b/components/collapsible/collapsible_lazy_show.vue
@@ -72,6 +72,8 @@ export default {
   computed: {
     /**
      * Set the css property to false when running tests only.
+     * Refer to: https://vuejs.org/guide/built-ins/transition.html#javascript-hooks for details about
+     * transition `css` property
      * @returns {boolean}
      */
     isCSSEnabled () {

--- a/components/lazy_show/lazy_show.vue
+++ b/components/lazy_show/lazy_show.vue
@@ -67,6 +67,8 @@ export default {
   computed: {
     /**
      * Set the css property to false when running tests only.
+     * Refer to: https://vuejs.org/guide/built-ins/transition.html#javascript-hooks for details about
+     * transition `css` property
      * @returns {boolean}
      */
     isCSSEnabled () {

--- a/components/lazy_show/lazy_show.vue
+++ b/components/lazy_show/lazy_show.vue
@@ -3,6 +3,7 @@
   <transition
     :name="transition"
     :appear="appear"
+    :css="isCSSEnabled"
     v-on="$listeners"
   >
     <div
@@ -61,6 +62,16 @@ export default {
     return {
       initialized: !!this.show,
     };
+  },
+
+  computed: {
+    /**
+     * Set the css property to false when running tests only.
+     * @returns {boolean}
+     */
+    isCSSEnabled () {
+      return process.env.NODE_ENV !== 'test';
+    },
   },
 
   /******************


### PR DESCRIPTION
# Disable CSS animation on lazy_show while testing

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added a property to lazy_show to disable CSS animations while testing, this will enhance the testing experience when we need to add tests to any component that uses lazy_show.

## :bulb: Context

Made this change among other in Vue 3 version in this PR: #756 
Cherry-picking the appropriate changes to Vue 2

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root