### PR TITLE
chore: update dialtone-icons and extract into constant

### DIFF
--- a/components/icon/icon.vue
+++ b/components/icon/icon.vue
@@ -9,9 +9,8 @@
 </template>
 
 <script>
-import { ICON_SIZE_MODIFIERS } from './icon_constants';
+import { ICON_SIZE_MODIFIERS, DIALTONE_ICONS } from './icon_constants';
 import { kebabCaseToPascalCase } from '@/common/utils';
-import * as dialtoneIcons from '@dialpad/dialtone-icons';
 
 /**
  * The Icon component provides a set of glyphs and sizes to provide context your application.
@@ -48,12 +47,6 @@ export default {
     },
   },
 
-  data () {
-    return {
-      dialtoneIcons,
-    };
-  },
-
   computed: {
     iconSize () {
       return ICON_SIZE_MODIFIERS[this.size];
@@ -64,7 +57,7 @@ export default {
     },
 
     currentIcon () {
-      return this.dialtoneIcons[this.iconName];
+      return DIALTONE_ICONS[this.iconName];
     },
   },
 };

--- a/components/icon/icon_constants.js
+++ b/components/icon/icon_constants.js
@@ -1,3 +1,4 @@
+import * as dialtoneIcons from '@dialpad/dialtone-icons';
 export const ICON_SIZE_MODIFIERS = {
   100: 'd-icon--size-100',
   200: 'd-icon--size-200',
@@ -8,7 +9,9 @@ export const ICON_SIZE_MODIFIERS = {
   700: 'd-icon--size-700',
   800: 'd-icon--size-800',
 };
+export const DIALTONE_ICONS = dialtoneIcons;
 
 export default {
   ICON_SIZE_MODIFIERS,
+  DIALTONE_ICONS,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.56.1",
       "license": "MIT",
       "dependencies": {
-        "@dialpad/dialtone-icons": "0.0.17",
+        "@dialpad/dialtone-icons": "0.0.18",
         "@linusborg/vue-simple-portal": "^0.1.5",
         "emoji-regex": "^10.2.1",
         "emoji-toolkit": "^6.6.0",
@@ -2716,9 +2716,9 @@
       }
     },
     "node_modules/@dialpad/dialtone-icons": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.17.tgz",
-      "integrity": "sha512-wymQ+Eg5A3QpXJAFOx31Zr8W52tzTfpOLpZA56XhmpE+nIm9t3JaOeQM3xtuzBEje6XxwCQohMKi48W9d4s8eQ==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.18.tgz",
+      "integrity": "sha512-yeJ6Be0CQ8HfWIfH/HxmKs96CLxNjIrt3VF+gHO/YCN7cpt6agGlOdO4qVHTWAo/ro2GNDdMVJ2oxCmrcvzQSA==",
       "dependencies": {
         "core-js": "^3.8.3",
         "vue": ">=2.6"
@@ -32972,9 +32972,9 @@
       }
     },
     "@dialpad/dialtone-icons": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.17.tgz",
-      "integrity": "sha512-wymQ+Eg5A3QpXJAFOx31Zr8W52tzTfpOLpZA56XhmpE+nIm9t3JaOeQM3xtuzBEje6XxwCQohMKi48W9d4s8eQ==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.18.tgz",
+      "integrity": "sha512-yeJ6Be0CQ8HfWIfH/HxmKs96CLxNjIrt3VF+gHO/YCN7cpt6agGlOdO4qVHTWAo/ro2GNDdMVJ2oxCmrcvzQSA==",
       "requires": {
         "core-js": "^3.8.3",
         "vue": ">=2.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.56.1",
       "license": "MIT",
       "dependencies": {
-        "@dialpad/dialtone-icons": "0.0.18",
+        "@dialpad/dialtone-icons": "latest",
         "@linusborg/vue-simple-portal": "^0.1.5",
         "emoji-regex": "^10.2.1",
         "emoji-toolkit": "^6.6.0",
@@ -20,7 +20,7 @@
         "@commitlint/cli": "^17.4.2",
         "@commitlint/config-conventional": "^17.4.2",
         "@dialpad/conventional-changelog-angular": "^1.1.1",
-        "@dialpad/dialtone": "^7.16.0",
+        "@dialpad/dialtone": "^7.16.1",
         "@dialpad/semantic-release-changelog-json": "^1.0.0",
         "@percy/cli": "1.18.0",
         "@percy/storybook": "4.3.4",
@@ -2703,9 +2703,9 @@
       }
     },
     "node_modules/@dialpad/dialtone": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.16.0.tgz",
-      "integrity": "sha512-NcWH1jH27XKMkHgOFb4r0jeKmXUOJ6NhRR1LaWN/uKw1vW0/ml/C3onTTdwPzpw+hhM0dAEx8N9dOx0WaZUtrA==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.16.1.tgz",
+      "integrity": "sha512-1ljutBwzIpdpIw1gaaxgaq0HriyNp3vO2lMyffQdh6e8FpWD8kKTgpFKVr8jEDvIkPZt/ehehJG/TWv9thxGEg==",
       "dev": true,
       "dependencies": {
         "docopt": "^0.6.2",
@@ -2716,15 +2716,11 @@
       }
     },
     "node_modules/@dialpad/dialtone-icons": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.18.tgz",
-      "integrity": "sha512-yeJ6Be0CQ8HfWIfH/HxmKs96CLxNjIrt3VF+gHO/YCN7cpt6agGlOdO4qVHTWAo/ro2GNDdMVJ2oxCmrcvzQSA==",
-      "dependencies": {
-        "core-js": "^3.8.3",
-        "vue": ">=2.6"
-      },
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.20.tgz",
+      "integrity": "sha512-YYNPqmBIW4TDIdeF/B6LFyoxMGsySbjySE4A27B9U3tw06aIFAhIDibsNjs/cDe8Y3Zx1v44OUYfT6BXiRdwMQ==",
       "peerDependencies": {
-        "vue": ">=2.6"
+        "vue": "v2-latest"
       }
     },
     "node_modules/@dialpad/semantic-release-changelog-json": {
@@ -9324,6 +9320,7 @@
       "version": "3.21.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
       "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
+      "dev": true,
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -32962,9 +32959,9 @@
       }
     },
     "@dialpad/dialtone": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.16.0.tgz",
-      "integrity": "sha512-NcWH1jH27XKMkHgOFb4r0jeKmXUOJ6NhRR1LaWN/uKw1vW0/ml/C3onTTdwPzpw+hhM0dAEx8N9dOx0WaZUtrA==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.16.1.tgz",
+      "integrity": "sha512-1ljutBwzIpdpIw1gaaxgaq0HriyNp3vO2lMyffQdh6e8FpWD8kKTgpFKVr8jEDvIkPZt/ehehJG/TWv9thxGEg==",
       "dev": true,
       "requires": {
         "docopt": "^0.6.2",
@@ -32972,13 +32969,10 @@
       }
     },
     "@dialpad/dialtone-icons": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.18.tgz",
-      "integrity": "sha512-yeJ6Be0CQ8HfWIfH/HxmKs96CLxNjIrt3VF+gHO/YCN7cpt6agGlOdO4qVHTWAo/ro2GNDdMVJ2oxCmrcvzQSA==",
-      "requires": {
-        "core-js": "^3.8.3",
-        "vue": ">=2.6"
-      }
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.20.tgz",
+      "integrity": "sha512-YYNPqmBIW4TDIdeF/B6LFyoxMGsySbjySE4A27B9U3tw06aIFAhIDibsNjs/cDe8Y3Zx1v44OUYfT6BXiRdwMQ==",
+      "requires": {}
     },
     "@dialpad/semantic-release-changelog-json": {
       "version": "1.0.0",
@@ -37925,7 +37919,8 @@
     "core-js": {
       "version": "3.21.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
-      "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig=="
+      "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.25.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "node": "16"
   },
   "dependencies": {
-    "@dialpad/dialtone-icons": "0.0.18",
+    "@dialpad/dialtone-icons": "latest",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "emoji-regex": "^10.2.1",
     "emoji-toolkit": "^6.6.0",
@@ -98,7 +98,7 @@
     "@commitlint/cli": "^17.4.2",
     "@commitlint/config-conventional": "^17.4.2",
     "@dialpad/conventional-changelog-angular": "^1.1.1",
-    "@dialpad/dialtone": "^7.16.0",
+    "@dialpad/dialtone": "^7.16.1",
     "@dialpad/semantic-release-changelog-json": "^1.0.0",
     "@percy/cli": "1.18.0",
     "@percy/storybook": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "node": "16"
   },
   "dependencies": {
-    "@dialpad/dialtone-icons": "0.0.17",
+    "@dialpad/dialtone-icons": "0.0.18",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "emoji-regex": "^10.2.1",
     "emoji-toolkit": "^6.6.0",


### PR DESCRIPTION
# Update dialtone-icons dependency

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Updated dialtone-icons to latest.

## :bulb: Context

The newest version of dialtone-icons includes a fix to an error happening due to duplicated `clip-path` id's.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root