### PR TITLE
fix(root-layout): null protection on getElementTops

### DIFF
--- a/components/root_layout/root_layout_body.vue
+++ b/components/root_layout/root_layout_body.vue
@@ -154,8 +154,8 @@ export default {
     },
 
     getElementTops () {
-      this.sidebarTop = this.$refs['root-layout-sidebar'].offsetTop;
-      this.contentTop = this.$refs['root-layout-content'].offsetTop;
+      this.sidebarTop = this.$refs['root-layout-sidebar']?.offsetTop;
+      this.contentTop = this.$refs['root-layout-content']?.offsetTop;
     },
 
     getDocumentHeight () {


### PR DESCRIPTION
# fix(root-layout): null protection on getElementTops

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Fix error when there is no sidebar

## :bulb: Context

Error was occurring on the docsite when there was no sidebar
