### PR TITLE
fix(popover, tooltip): support shadow dom

### DIFF
--- a/components/dropdown/dropdown.stories.js
+++ b/components/dropdown/dropdown.stories.js
@@ -76,6 +76,14 @@ export const argTypesData = {
       },
     },
   },
+  appendTo: {
+    defaultValue: 'body',
+    table: {
+      defaultValue: {
+        summary: 'body',
+      },
+    },
+  },
   padding: {
     defaultValue: 'none',
     control: {

--- a/components/dropdown/dropdown.vue
+++ b/components/dropdown/dropdown.vue
@@ -8,6 +8,7 @@
     :fallback-placements="fallbackPlacements"
     padding="none"
     role="menu"
+    :append-to="appendTo"
     :modal="modal"
     :max-height="maxHeight"
     :max-width="maxWidth"
@@ -57,6 +58,9 @@ import { LIST_ITEM_NAVIGATION_TYPES } from '../list_item/list_item_constants';
 import {
   DROPDOWN_PADDING_CLASSES,
 } from './dropdown_constants';
+import {
+  POPOVER_APPEND_TO_VALUES,
+} from '@/components/popover/popover_constants';
 import { getUniqueString } from '@/common/utils';
 import { EVENT_KEYNAMES } from '@/common/constants';
 import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
@@ -214,6 +218,20 @@ export default {
     listClass: {
       type: [String, Array, Object],
       default: '',
+    },
+
+    /**
+     * Sets the element to which the popover is going to append to.
+     * 'body' will append to the nearest body (supports shadow DOM).
+     * @values 'body', 'parent', HTMLElement,
+     */
+    appendTo: {
+      type: [HTMLElement, String],
+      default: 'body',
+      validator: appendTo => {
+        return POPOVER_APPEND_TO_VALUES.includes(appendTo) ||
+            (appendTo instanceof HTMLElement);
+      },
     },
   },
 

--- a/components/popover/popover.stories.js
+++ b/components/popover/popover.stories.js
@@ -130,10 +130,10 @@ export const argTypesData = {
     defaultValue: [0, 4],
   },
   appendTo: {
-    defaultValue: document.body,
+    defaultValue: 'body',
     table: {
       defaultValue: {
-        summary: 'document.body',
+        summary: 'body',
       },
     },
   },

--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -455,11 +455,12 @@ export default {
 
     /**
      * Sets the element to which the popover is going to append to.
-     * @values 'parent', HTMLElement,
+     * 'body' will append to the nearest body (supports shadow DOM).
+     * @values 'body', 'parent', HTMLElement,
      */
     appendTo: {
       type: [HTMLElement, String],
-      default: () => document.body,
+      default: 'body',
       validator: appendTo => {
         return POPOVER_APPEND_TO_VALUES.includes(appendTo) ||
             (appendTo instanceof HTMLElement);
@@ -588,7 +589,9 @@ export default {
   },
 
   mounted () {
-    const externalAnchorEl = document.getElementById(this.externalAnchor);
+    const externalAnchorEl = this.externalAnchor
+      ? this.$refs.anchor.getRootNode().querySelector(`#${this.externalAnchor}`)
+      : null;
     this.anchorEl = externalAnchorEl ?? this.$refs.anchor.children[0];
     this.popoverContentEl = this.$refs.content.$el;
 
@@ -624,7 +627,11 @@ export default {
 
     calculateAnchorZindex () {
       // if a modal is currently active render at modal-element z-index, otherwise at popover z-index
-      if (document.querySelector('.d-modal[aria-hidden="false"], .d-modal--transparent[aria-hidden="false"]')) {
+      if (this.$el.getRootNode()
+        .querySelector('.d-modal[aria-hidden="false"], .d-modal--transparent[aria-hidden="false"]') ||
+        // Special case because we don't have any dialtone drawer component yet. Render at 650 when
+        // anchor of popover is within a drawer.
+        this.anchorEl.closest('.d-zi-drawer')) {
         return 650;
       } else {
         return 300;
@@ -841,7 +848,7 @@ export default {
         placement: this.placement,
         offset: this.offset,
         sticky: this.sticky,
-        appendTo: this.appendTo,
+        appendTo: this.appendTo === 'body' ? this.anchorEl?.getRootNode()?.querySelector('body') : this.appendTo,
         interactive: true,
         trigger: 'manual',
         // We have to manage hideOnClick functionality manually to handle

--- a/components/popover/popover_constants.js
+++ b/components/popover/popover_constants.js
@@ -15,7 +15,7 @@ export const POPOVER_HEADER_FOOTER_PADDING_CLASSES = {
 export const POPOVER_ROLES = ['dialog', 'menu', 'listbox', 'tree', 'grid'];
 export const POPOVER_CONTENT_WIDTHS = [null, 'anchor'];
 export const POPOVER_INITIAL_FOCUS_STRINGS = ['none', 'dialog', 'first'];
-export const POPOVER_APPEND_TO_VALUES = ['parent'];
+export const POPOVER_APPEND_TO_VALUES = ['parent', 'body'];
 export const POPOVER_STICKY_VALUES = [
   ...TIPPY_STICKY_VALUES,
 ];

--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -234,7 +234,7 @@ export default {
     tippyProps () {
       return {
         offset: this.offset,
-        appendTo: document.body,
+        appendTo: this.anchorEl?.getRootNode()?.querySelector('body'),
         interactive: false,
         trigger: 'manual',
         placement: this.placement,
@@ -300,7 +300,11 @@ export default {
   methods: {
     calculateAnchorZindex () {
       // if a modal is currently active render at modal-element z-index, otherwise at tooltip z-index
-      if (document.querySelector('.d-modal[aria-hidden="false"], .d-modal--transparent[aria-hidden="false"]')) {
+      if (this.$el.getRootNode()
+        .querySelector('.d-modal[aria-hidden="false"], .d-modal--transparent[aria-hidden="false"]') ||
+        // Special case because we don't have any dialtone drawer component yet. Render at 650 when
+        // anchor of popover is within a drawer.
+        this.anchorEl.closest('.d-zi-drawer')) {
         return 651;
       } else {
         return 400;

--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -302,9 +302,9 @@ export default {
       // if a modal is currently active render at modal-element z-index, otherwise at tooltip z-index
       if (this.$el.getRootNode()
         .querySelector('.d-modal[aria-hidden="false"], .d-modal--transparent[aria-hidden="false"]') ||
-        // Special case because we don't have any dialtone drawer component yet. Render at 650 when
+        // Special case because we don't have any dialtone drawer component yet. Render at 651 when
         // anchor of popover is within a drawer.
-        this.anchorEl.closest('.d-zi-drawer')) {
+        this.$el.closest('.d-zi-drawer')) {
         return 651;
       } else {
         return 400;

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.test.js
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.test.js
@@ -46,6 +46,7 @@ describe('DtRecipeCallbarButtonWithPopover Tests', function () {
       slots,
       provide,
       listeners,
+      attachTo: document.body,
       localVue: this.localVue,
     });
     _setChildWrappers();

--- a/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
+++ b/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
@@ -90,10 +90,10 @@ export const argTypesData = {
     defaultValue: true,
   },
   appendTo: {
-    defaultValue: document.body,
+    defaultValue: 'body',
     table: {
       defaultValue: {
-        summary: 'document.body',
+        summary: 'body',
       },
     },
   },

--- a/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -273,11 +273,12 @@ export default {
 
     /**
      * Sets the element to which the popover is going to append to.
-     * @values 'parent', HTMLElement,
+     * 'body' will append to the nearest body (supports shadow DOM).
+     * @values 'body', 'parent', HTMLElement,
      */
     appendTo: {
       type: [HTMLElement, String],
-      default: () => document.body,
+      default: 'body',
       validator: appendTo => {
         return POPOVER_APPEND_TO_VALUES.includes(appendTo) ||
             (appendTo instanceof HTMLElement);

--- a/recipes/comboboxes/combobox_with_popover/combobox_with_popover.stories.js
+++ b/recipes/comboboxes/combobox_with_popover/combobox_with_popover.stories.js
@@ -114,10 +114,10 @@ export const argTypesData = {
     },
   },
   appendTo: {
-    defaultValue: document.body,
+    defaultValue: 'body',
     table: {
       defaultValue: {
-        summary: 'document.body',
+        summary: 'body',
       },
     },
   },

--- a/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue
+++ b/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue
@@ -311,11 +311,12 @@ export default {
 
     /**
      * Sets the element to which the popover is going to append to.
-     * @values 'parent', HTMLElement,
+     * 'body' will append to the nearest body (supports shadow DOM).
+     * @values 'body', 'parent', HTMLElement,
      */
     appendTo: {
       type: [HTMLElement, String],
-      default: () => document.body,
+      default: 'body',
       validator: appendTo => {
         return POPOVER_APPEND_TO_VALUES.includes(appendTo) ||
             (appendTo instanceof HTMLElement);


### PR DESCRIPTION
# fix(popover, tooltip): support shadow dom

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Had this change released on beta for Kare team a while back. Integrating it into the main release now since it seems to be working for them. 

Use [getRootNode](https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode) instead of `document.body` to reference the body. Changed default appendTo prop to be string 'body' which causes `getRootNode` to be used to get the "nearest" body.

Added appendTo to dropdown as well for consistency

## :bulb: Context

Because we were appending to `document.body` it was causing a number of issues in the kare shadow dom containers with popovers/tooltips rendering at the app body rather than shadow dom body. Errors being caused by looking for components in `document.body`.



## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
