### PR TITLE
feat(leftbar): update text-overflow style

### DIFF
--- a/recipes/leftbar/style/leftbar_row.less
+++ b/recipes/leftbar/style/leftbar_row.less
@@ -13,7 +13,7 @@
   --leftbar-row-alpha-color-foreground: var(--fc-secondary);
   --leftbar-row-alpha-width: calc(var(--size-300) * 10);
   --leftbar-row-alpha-height: calc(var(--size-300) * 9);
-  --leftbar-row-omega-min-width: var(--leftbar-row-alpha-width);
+  --leftbar-row-omega-min-width: 0;
   --leftbar-row-omega-height: var(--leftbar-row-alpha-height);
   --leftbar-row-omega-visibility: visible;
   --leftbar-row-description-font-weight: var(--fw-normal);
@@ -40,6 +40,10 @@
   //    ...
   //  </div>
   //
+  &:not(.dt-leftbar-row--no-action):hover {
+    --leftbar-row-omega-min-width: var(--leftbar-row-alpha-width);
+  }
+
   &--has-unread {
     --leftbar-row-description-font-weight: var(--fw-bold);
     --leftbar-row-alpha-color-foreground: var(--leftbar-row-color-foreground);


### PR DESCRIPTION
# Leftbar text-overflow style update

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Updated style to ensure that the description content extends the full available width by default, but if it does have an action (i.e. Call button) it will hold that space **beneath** the call button.

The `class="dt-leftbar-row__action"` slot hasn't been implemented yet, so this also sets up the style for it in [DT-959](https://dialpad.atlassian.net/browse/DT-959). 

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

https://user-images.githubusercontent.com/1165933/222193308-d2557354-f7e5-437e-be27-0c4424127821.mov

## :link: Sources

<!--- Add any links to external reference material -->


[DT-959]: https://dialpad.atlassian.net/browse/DT-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ