### PR TITLE
fix: adjust callbar button width for size

### DIFF
--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -137,9 +137,8 @@ export default {
     buttonWidth () {
       switch (this.buttonWidthSize) {
         case 'sm':
-        case 'md':
           return '4.5rem';
-        case 'lg':
+        case 'md':
           return '6rem';
         default:
           return '8.4rem';

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -259,7 +259,7 @@ export default {
     },
 
     isCompactMode () {
-      return this.buttonWidthSize === 'sm' || this.buttonWidthSize === 'md';
+      return this.buttonWidthSize === 'sm';
     },
   },
 


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

In my integration test, I notice that the realize actual button size should be 4.5 for `sm` and 6 for `md`. This pull request fix that.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps
 
No need to release.

## :link: Sources

Figma: https://www.figma.com/file/lGKE93k5Ydn16NF6fLe5r9/%E2%9C%A8-%5BDP-39438-EPIC%5D-Call-Workflow-Stakeholder-Presentations?node-id=7192%3A277451&t=SK42Y7G2peUvu2xA-0
Vue2: https://github.com/dialpad/dialtone-vue/pull/794