### PR TITLE
fix(popover): protect against an undefined focus element

### DIFF
--- a/common/mixins/modal.js
+++ b/common/mixins/modal.js
@@ -69,6 +69,7 @@ export default {
      * @param {bool} includeNegativeTabIndex - will include tabindex="-1" in the list of focusable elements.
      */
     _getFocusableElements (el = this.$el, includeNegativeTabIndex = false) {
+      if (!el) return [];
       const focusableContent = [...el.querySelectorAll(focusableElementsList)];
       return focusableContent.filter((fc) => {
         const style = window.getComputedStyle(fc);


### PR DESCRIPTION
# fix(popover): protect against an undefined focus element

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Fix for error mentioned in
https://dialpad.atlassian.net/browse/DT-1013

Do not cause error if focus element no longer exists.

## :bulb: Context

If navigating to a new page after clicking something in a popover it will error out because it tries to focus an element that no longer exists. This will cause an error to no longer happen in that case.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added all relevant documentation

## :crystal_ball: Next Steps

Verify with Yusef the fix works.
