### PR TITLE
feat(theme): update leftbar theme vars vue3 (redo)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "node": ">= 16"
       },
       "peerDependencies": {
-        "@dialpad/dialtone": ">=7.17",
+        "@dialpad/dialtone": ">=7.19",
         "vue": ">=3.2"
       }
     },

--- a/recipes/leftbar/contact_row/contact_row.stories.js
+++ b/recipes/leftbar/contact_row/contact_row.stories.js
@@ -60,7 +60,7 @@ export const argTypesData = {
 };
 
 const decorator = () => ({
-  template: '<div class="d-w512"><story /></div>',
+  template: '<div class="d-w264 d-theme-sidebar-bgc d-p8"><story /></div>',
 });
 
 // Story Collection

--- a/recipes/leftbar/contact_row/contact_row_variants.story.vue
+++ b/recipes/leftbar/contact_row/contact_row_variants.story.vue
@@ -1,71 +1,69 @@
 <template>
-  <div class="d-w464">
-    <dt-stack gap="600">
-      <div>
-        <h3>
-          With user status
-        </h3>
-        <dt-recipe-contact-row
-          name="Jaqueline Nackos"
-          :avatar-src="defaultImage"
-          user-status="Good Morning! :smile:"
-        />
-      </div>
-      <div>
-        <h3>
-          with away presence
-        </h3>
-        <dt-recipe-contact-row
-          name="Jaqueline Nackos"
-          avatar-presence="away"
-          presence-text="Away"
-          user-status="Out for a bit"
-          :avatar-src="defaultImage"
-        />
-      </div>
-      <div>
-        <h3>
-          with busy presence
-        </h3>
-        <dt-recipe-contact-row
-          name="Jaqueline Nackos"
-          avatar-presence="busy"
-          presence-text="In a meeting"
-          user-status="Meetings all day"
-          :avatar-src="defaultImage"
-        />
-      </div>
-      <div>
-        <h3>
-          With unread count
-        </h3>
-        <dt-recipe-contact-row
-          name="Jaqueline Nackos"
-          :avatar-src="defaultImage"
-          unread-count="5"
-          :has-unreads="true"
-        />
-      </div>
-      <div>
-        <h3>
-          Selected
-        </h3>
-        <dt-recipe-contact-row
-          name="Jaqueline Nackos"
-          :avatar-src="defaultImage"
-          :selected="true"
-        />
-      </div>
-      <div>
-        <h3>
-          With initial
-        </h3>
-        <dt-recipe-contact-row
-          name="Jaqueline Nackos"
-        />
-      </div>
-    </dt-stack>
-  </div>
+  <dt-stack gap="600">
+    <div>
+      <h3>
+        With user status
+      </h3>
+      <dt-recipe-contact-row
+        name="Jaqueline Nackos"
+        :avatar-src="defaultImage"
+        user-status="Good Morning! :smile:"
+      />
+    </div>
+    <div>
+      <h3>
+        with away presence
+      </h3>
+      <dt-recipe-contact-row
+        name="Jaqueline Nackos"
+        avatar-presence="away"
+        presence-text="Away"
+        user-status="Out for a bit"
+        :avatar-src="defaultImage"
+      />
+    </div>
+    <div>
+      <h3>
+        with busy presence
+      </h3>
+      <dt-recipe-contact-row
+        name="Jaqueline Nackos"
+        avatar-presence="busy"
+        presence-text="In a meeting"
+        user-status="Meetings all day"
+        :avatar-src="defaultImage"
+      />
+    </div>
+    <div>
+      <h3>
+        With unread count
+      </h3>
+      <dt-recipe-contact-row
+        name="Jaqueline Nackos"
+        :avatar-src="defaultImage"
+        unread-count="5"
+        :has-unreads="true"
+      />
+    </div>
+    <div>
+      <h3>
+        Selected
+      </h3>
+      <dt-recipe-contact-row
+        name="Jaqueline Nackos"
+        :avatar-src="defaultImage"
+        :selected="true"
+      />
+    </div>
+    <div>
+      <h3>
+        With initial
+      </h3>
+      <dt-recipe-contact-row
+        name="Jaqueline Nackos"
+      />
+    </div>
+  </dt-stack>
 </template>
 
 <script>

--- a/recipes/leftbar/general_row/general_row.stories.js
+++ b/recipes/leftbar/general_row/general_row.stories.js
@@ -73,7 +73,7 @@ export const argTypesData = {
 };
 
 const decorator = () => ({
-  template: '<div class="d-w512"><story /></div>',
+  template: '<div class="d-w264 d-theme-sidebar-bgc d-p8"><story /></div>',
 });
 
 // Story Collection

--- a/recipes/leftbar/general_row/general_row_variants.story.vue
+++ b/recipes/leftbar/general_row/general_row_variants.story.vue
@@ -9,8 +9,8 @@
         description="Channel name"
         unread-count="29"
       />
-      <div class="d-mt8">
-        Note: the unread count is not limited to 99 or any number so make sure to add the necessary
+      <div class="d-mt8 d-fc-secondary d-fs-100">
+        <strong>Note:</strong> the unread count is not limited to 99 or any number so make sure to add the necessary
         logic to limit the number of unread messages if needed.
       </div>
     </div>

--- a/recipes/leftbar/group_row/group_row.stories.js
+++ b/recipes/leftbar/group_row/group_row.stories.js
@@ -46,7 +46,7 @@ export const argTypesData = {
 };
 
 const decorator = () => ({
-  template: '<div class="d-w512"><story /></div>',
+  template: '<div class="d-w264 d-theme-sidebar-bgc d-p8"><story /></div>',
 });
 
 // Story Collection

--- a/recipes/leftbar/group_row/group_row_variants.story.vue
+++ b/recipes/leftbar/group_row/group_row_variants.story.vue
@@ -1,69 +1,63 @@
 <template>
-  <div class="d-w464">
-    <dt-stack gap="600">
-      <dt-stack gap="400">
-        <p class="d-fw-bold">
-          Default behavior
-        </p>
-        <dt-recipe-group-row
-          avatar-initials="JN"
-          :group-count="2"
-          names="Jaqueline Nackos, Lori Smith"
-          :avatar-src="defaultImage"
-        />
-      </dt-stack>
-
-      <dt-stack gap="400">
-        <p class="d-fw-bold">
-          Ellipsed names
-        </p>
-        <dt-recipe-group-row
-          avatar-initials="JN"
-          :group-count="4"
-          names="Jaqueline Nackos, Lori Smith, Jaqueline Nackos, Lori Smith"
-          :avatar-src="defaultImage"
-        />
-      </dt-stack>
-
-      <dt-stack gap="400">
-        <p class="d-fw-bold">
-          With unread count
-        </p>
-        <dt-recipe-group-row
-          avatar-initials="JN"
-          :group-count="2"
-          names="Jaqueline Nackos, Lori Smith"
-          :avatar-src="defaultImage"
-          unread-count="1"
-        />
-      </dt-stack>
-
-      <dt-stack gap="400">
-        <p class="d-fw-bold">
-          Selected
-        </p>
-        <dt-recipe-group-row
-          avatar-initials="JN"
-          :group-count="2"
-          names="Jaqueline Nackos, Lori Smith"
-          :avatar-src="defaultImage"
-          selected
-        />
-      </dt-stack>
-
-      <dt-stack gap="400">
-        <p class="d-fw-bold">
-          With Initial as fallback when avatar image src cannot be found.
-        </p>
-        <dt-recipe-group-row
-          avatar-initials="JN"
-          :group-count="2"
-          names="Jaqueline Nackos, Lori Smith"
-          avatar-src="/static/media/../components/avatar/404"
-        />
-      </dt-stack>
-    </dt-stack>
-  </div>
+  <dt-stack gap="600">
+    <div>
+      <h3>
+        Default behavior
+      </h3>
+      <dt-recipe-group-row
+        avatar-initials="JN"
+        :group-count="2"
+        names="Jaqueline Nackos, Lori Smith"
+        :avatar-src="defaultImage"
+      />
+    </div>
+    <div>
+      <h3>
+        Ellipsed names
+      </h3>
+      <dt-recipe-group-row
+        avatar-initials="JN"
+        :group-count="4"
+        names="Jaqueline Nackos, Lori Smith, Jaqueline Nackos, Lori Smith"
+        :avatar-src="defaultImage"
+      />
+    </div>
+    <div>
+      <h3>
+        With unread count
+      </h3>
+      <dt-recipe-group-row
+        avatar-initials="JN"
+        :group-count="2"
+        names="Jaqueline Nackos, Lori Smith"
+        :avatar-src="defaultImage"
+        unread-count="1"
+      />
+    </div>
+    <div>
+      <h3>
+        Selected
+      </h3>
+      <dt-recipe-group-row
+        avatar-initials="JN"
+        :group-count="2"
+        names="Jaqueline Nackos, Lori Smith"
+        :avatar-src="defaultImage"
+        selected
+      />
+    </div>
+    <div>
+      <h3>
+        With Initial as fallback when avatar image src cannot be found.
+      </h3>
+      <dt-recipe-group-row
+        avatar-initials="JN"
+        :group-count="2"
+        names="Jaqueline Nackos, Lori Smith"
+        avatar-src="/static/media/../components/avatar/404"
+      />
+    </div>
+  </dt-stack>
 </template>
 
 <script>

--- a/recipes/leftbar/style/leftbar_row.less
+++ b/recipes/leftbar/style/leftbar_row.less
@@ -8,7 +8,7 @@
   //  $   CSS CUSTOM PROPERTIES
   //  ----------------------------------------------------------------------------
   --leftbar-row-color-foreground: var(--theme-sidebar-color);
-  --leftbar-row-color-background: transparent;
+  --leftbar-row-color-background: var(--theme-sidebar-row-color-background);
   --leftbar-row-radius: 100em;
   --leftbar-row-opacity: 100%;
   --leftbar-row-alpha-color-foreground: var(--theme-sidebar-icon-color);
@@ -47,6 +47,15 @@
     --leftbar-row-omega-min-width: var(--leftbar-row-alpha-width);
   }
 
+  &:hover {
+    .d-presence {
+      --presence-color-border-base: var(--theme-sidebar-selected-row-color-background);
+    }
+    .d-avatar__count {
+      --avatar-count-color-shadow: var(--theme-sidebar-selected-row-color-background);
+    }
+  }
+
   &--has-unread {
     --leftbar-row-description-font-weight: var(--fw-bold);
     --leftbar-row-alpha-color-foreground: var(--leftbar-row-color-foreground);
@@ -61,10 +70,10 @@
   }
 
   &--selected {
-    --leftbar-row-color-background: var(--theme-sidebar-active-row-color-background);
-    --leftbar-row-color-foreground: var(--theme-sidebar-active-row-color);
+    --leftbar-row-color-background: var(--theme-sidebar-selected-row-color-background);
+    --leftbar-row-color-foreground: var(--theme-sidebar-selected-row-color);
     .d-avatar__count {
-      --avatar-count-color-shadow: var(--theme-sidebar-active-row-color-background);
+      --avatar-count-color-shadow: var(--theme-sidebar-selected-row-color-background);
     }
   }
 
@@ -111,7 +120,7 @@
     }
 
     &:active {
-      --leftbar-row-color-background: var(--theme-sidebar-active-row-color-background);
+      --leftbar-row-color-background: var(--theme-sidebar-row-color-background-active);
     }
 
     &:focus-visible {


### PR DESCRIPTION
# Update leftbar theme vars

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

* Leftbar theme variables were built up. This applies them to Leftbar Row Items.
* Placed example stories on a leftbar theme surface, `--theme-sidebar-color-background` for representative context.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [x] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

<img width="546" alt="image" src="https://user-images.githubusercontent.com/1165933/223264549-fa731717-d7df-49e6-8eb2-a13e8ff826b7.png">


## :link: Sources

* https://github.com/dialpad/dialtone/pull/839
* https://dialpad.design/design/colors/#theme

