### PR TITLE
fix(avatar): initials are not available until image loads

### DIFF
--- a/.esplint.rec.json
+++ b/.esplint.rec.json
@@ -8,6 +8,9 @@
     "common/mixins/modal.js": {
       "complexity": 1
     },
+    "components/avatar/avatar.vue": {
+      "complexity": 1
+    },
     "components/combobox/combobox.vue": {
       "complexity": 1
     },

--- a/common/utils.js
+++ b/common/utils.js
@@ -7,6 +7,7 @@ import Vue from 'vue';
 const seedrandom = require('seedrandom');
 
 let UNIQUE_ID_COUNTER = 0;
+let TIMER;
 
 // selector to find focusable not hidden inputs
 const FOCUSABLE_SELECTOR_NOT_HIDDEN = 'input:not([type=hidden]):not(:disabled)';
@@ -144,6 +145,16 @@ export const pascalCaseToKebabCase = (string) => {
     .replace(/^-/, '');
 };
 
+/*
+* Set's a global timer to debounce the execution of a function.
+* @param { object } func - the function that is going to be called after timeout
+* @param { number } [timeout=300] timeout
+* */
+export function debounce (func, timeout = 300) {
+  clearTimeout(TIMER);
+  TIMER = setTimeout(func, timeout);
+}
+
 export default {
   getUniqueString,
   getRandomElement,
@@ -154,4 +165,5 @@ export default {
   htmlFragment,
   flushPromises,
   kebabCaseToPascalCase,
+  debounce,
 };

--- a/common/utils.js
+++ b/common/utils.js
@@ -127,8 +127,7 @@ export const flushPromises = () => {
  * @returns {string}
  */
 export const kebabCaseToPascalCase = (string) => {
-  return string
-    .toLowerCase()
+  return string?.toLowerCase()
     .split('-')
     .map(word => word.charAt(0).toUpperCase() + word.slice(1))
     .join('');

--- a/components/avatar/avatar.stories.js
+++ b/components/avatar/avatar.stories.js
@@ -94,6 +94,7 @@ const defaultImage = require('./person.png');
 export const Default = DefaultTemplate.bind({});
 Default.args = {
   default: `<img data-qa="dt-avatar-image" src="${defaultImage}" alt="Person Avatar">`,
+  initials: 'PS',
 };
 
 // TO DO: figure out why Icon.argTypes is causing the controls to not show up in the Initials story when

--- a/components/avatar/avatar.test.js
+++ b/components/avatar/avatar.test.js
@@ -385,11 +385,12 @@ describe('DtAvatar Tests', function () {
 
       describe('When image alt attribute is not provided', function () {
         // Test Setup
-        beforeEach(function () {
+        beforeEach(async function () {
           const imageSlot = `<img src="${IMAGE_ATTRS.SRC}" data-qa="dt-avatar-image">`;
 
           slots = { default: imageSlot };
           _setWrappers();
+          await wrapper.vm.$nextTick();
         });
 
         itBehavesLikeRaisesSingleVueWarning(warningMessage);
@@ -397,11 +398,12 @@ describe('DtAvatar Tests', function () {
 
       describe('When image src attribute is not provided', function () {
         // Test Setup
-        beforeEach(function () {
+        beforeEach(async function () {
           const imageSlot = `<img alt="${IMAGE_ATTRS.ALT}" data-qa="dt-avatar-image">`;
 
           slots = { default: imageSlot };
           _setWrappers();
+          await wrapper.vm.$nextTick();
         });
 
         itBehavesLikeRaisesSingleVueWarning(warningMessage);

--- a/components/avatar/avatar.test.js
+++ b/components/avatar/avatar.test.js
@@ -71,9 +71,9 @@ describe('DtAvatar Tests', function () {
   describe('Presentation Tests', function () {
     describe('When the avatar renders', function () {
       // Test Setup
-      beforeEach(function () {
+      beforeEach(async function () {
         slots = { default: DEFAULT_SLOT };
-        _setWrappers();
+        await _setWrappers();
       });
 
       it('should exists', function () { assert.exists(wrapper); });
@@ -88,8 +88,6 @@ describe('DtAvatar Tests', function () {
       beforeEach(async function () {
         slots = { default: imageSlot };
         await _setWrappers();
-
-        _setChildWrappers();
       });
 
       it('image should exist', function () {
@@ -134,7 +132,7 @@ describe('DtAvatar Tests', function () {
         await _setWrappers();
       });
 
-      it('initial slot should exist', function () {
+      it('should display initials', function () {
         assert.strictEqual(wrapper.text(), initials);
       });
 
@@ -187,13 +185,13 @@ describe('DtAvatar Tests', function () {
       const size = 'lg';
 
       // Test Setup
-      beforeEach(function () {
+      beforeEach(async function () {
         propsData = {
           ...basePropsData,
           size,
         };
         slots = { default: DEFAULT_SLOT };
-        _setWrappers();
+        await _setWrappers();
       });
 
       it('should have size variant class on the avatar', function () {
@@ -206,13 +204,13 @@ describe('DtAvatar Tests', function () {
       const group = 25;
 
       // Test Setup
-      beforeEach(function () {
+      beforeEach(async function () {
         propsData = {
           ...basePropsData,
           group,
         };
         slots = { default: DEFAULT_SLOT };
-        _setWrappers();
+        await _setWrappers();
       });
 
       it('should have group count', function () {
@@ -241,13 +239,13 @@ describe('DtAvatar Tests', function () {
       const gradient = false;
 
       // Test Setup
-      beforeEach(function () {
+      beforeEach(async function () {
         propsData = {
           ...basePropsData,
           gradient,
         };
         slots = { default: DEFAULT_SLOT };
-        _setWrappers();
+        await _setWrappers();
       });
 
       it('should set the correct class', function () {
@@ -259,12 +257,12 @@ describe('DtAvatar Tests', function () {
       const initials = 'DP';
 
       // Test Setup
-      beforeEach(function () {
+      beforeEach(async function () {
         propsData = {
           ...basePropsData,
         };
         slots = { default: initials };
-        _setWrappers();
+        await _setWrappers();
       });
 
       it('should not render presence if presence prop is not defined', async function () {
@@ -362,11 +360,11 @@ describe('DtAvatar Tests', function () {
 
       describe('When image src and alt attributes are provided', function () {
         // Test Setup
-        beforeEach(function () {
+        beforeEach(async function () {
           const imageSlot = `<img src="${IMAGE_ATTRS.SRC}" alt="${IMAGE_ATTRS.ALT}" data-qa="dt-avatar-image">`;
 
           slots = { default: imageSlot };
-          _setWrappers();
+          await _setWrappers();
         });
 
         itBehavesLikeDoesNotRaiseAnyVueWarnings();
@@ -404,10 +402,10 @@ describe('DtAvatar Tests', function () {
     const customClass = 'my-custom-class';
 
     // Helpers
-    const _setupChildClassTest = (childClassName, selector) => {
+    const _setupChildClassTest = async (childClassName, selector) => {
       propsData[childClassName] = customClass;
       slots = { default: DEFAULT_SLOT };
-      _setWrappers();
+      await _setWrappers();
       element = wrapper.find(selector);
     };
 
@@ -420,7 +418,9 @@ describe('DtAvatar Tests', function () {
 
     describe('When an avatar class is provided', function () {
       // Test Setup
-      beforeEach(function () { _setupChildClassTest('avatarClass', '[data-qa="dt-avatar"]'); });
+      beforeEach(async function () {
+        await _setupChildClassTest('avatarClass', '[data-qa="dt-avatar"]');
+      });
 
       itBehavesLikeAppliesClassToChildLocal();
     });

--- a/components/avatar/avatar.test.js
+++ b/components/avatar/avatar.test.js
@@ -27,7 +27,6 @@ const baseAttrs = {};
 describe('DtAvatar Tests', function () {
   // Wrappers
   let wrapper;
-  let avatar;
   let image;
   let count;
   let presence;
@@ -39,19 +38,19 @@ describe('DtAvatar Tests', function () {
 
   // Helpers
   const _setChildWrappers = () => {
-    avatar = wrapper.find('[data-qa="dt-avatar"]');
     image = wrapper.find('[data-qa="dt-avatar-image"]');
     count = wrapper.find('[data-qa="dt-avatar-count"]');
     presence = wrapper.find('[data-qa="dt-presence"]');
   };
 
-  const _setWrappers = () => {
+  const _setWrappers = async () => {
     wrapper = shallowMount(DtAvatar, {
       propsData,
       attrs,
       slots,
       localVue: this.localVue,
     });
+    await wrapper.vm.$nextTick();
     _setChildWrappers();
   };
 
@@ -78,7 +77,7 @@ describe('DtAvatar Tests', function () {
       });
 
       it('should exists', function () { assert.exists(wrapper); });
-      it('should render the avatar', function () { assert.isTrue(avatar.exists()); });
+      it('should render the avatar', function () { assert.isTrue(wrapper.exists()); });
     });
 
     describe('When the avatar renders image via slot', function () {
@@ -88,8 +87,8 @@ describe('DtAvatar Tests', function () {
       // Test Setup
       beforeEach(async function () {
         slots = { default: imageSlot };
-        _setWrappers();
-        await wrapper.vm.$nextTick();
+        await _setWrappers();
+
         _setChildWrappers();
       });
 
@@ -112,17 +111,16 @@ describe('DtAvatar Tests', function () {
 
       // Test Setup
       beforeEach(async function () {
-        propsData = { ...basePropsData };
         slots = { default: icon };
-        _setWrappers();
+        await _setWrappers();
       });
 
       it('icon slot should exist', function () {
-        assert.exists(avatar.find('svg'));
+        assert.exists(wrapper.find('svg'));
       });
 
       it('should have correct class', function () {
-        itBehavesLikeHasCorrectClass(avatar.find('svg'), AVATAR_KIND_MODIFIERS.icon);
+        itBehavesLikeHasCorrectClass(wrapper.find('svg'), AVATAR_KIND_MODIFIERS.icon);
       });
     });
 
@@ -132,17 +130,12 @@ describe('DtAvatar Tests', function () {
 
       // Test Setup
       beforeEach(async function () {
-        propsData = {
-          ...basePropsData,
-        };
         slots = { default: initials };
-        _setWrappers();
-        await wrapper.vm.$nextTick();
-        _setChildWrappers();
+        await _setWrappers();
       });
 
       it('initial slot should exist', function () {
-        assert.strictEqual(avatar.text(), initials);
+        assert.strictEqual(wrapper.text(), initials);
       });
 
       it('should have correct class', function () {
@@ -156,19 +149,17 @@ describe('DtAvatar Tests', function () {
       const initials = 'DP';
 
       // Test Setup
-      beforeEach(function () {
+      beforeEach(async function () {
         propsData = {
           ...basePropsData,
+          size: 'sm',
         };
         slots = { default: initials };
-        _setWrappers();
+        await _setWrappers();
       });
 
-      it(' shows a single character', async function () {
-        await wrapper.setProps({
-          size: 'sm',
-        });
-        assert.strictEqual(avatar.text(), initials[0]);
+      it('shows a single character', async function () {
+        assert.strictEqual(wrapper.text(), initials[0]);
       });
     });
 
@@ -177,19 +168,17 @@ describe('DtAvatar Tests', function () {
       const initials = 'DP';
 
       // Test Setup
-      beforeEach(function () {
+      beforeEach(async function () {
         propsData = {
           ...basePropsData,
+          size: 'xs',
         };
         slots = { default: initials };
-        _setWrappers();
+        await _setWrappers();
       });
 
-      it('has no initials', async function () {
-        await wrapper.setProps({
-          size: 'xs',
-        });
-        assert.strictEqual(avatar.text(), '');
+      it('has no initials', function () {
+        assert.strictEqual(wrapper.text(), '');
       });
     });
 
@@ -208,7 +197,7 @@ describe('DtAvatar Tests', function () {
       });
 
       it('should have size variant class on the avatar', function () {
-        assert.isTrue(avatar.classes(AVATAR_SIZE_MODIFIERS[size]));
+        assert.isTrue(wrapper.classes(AVATAR_SIZE_MODIFIERS[size]));
       });
     });
 
@@ -227,7 +216,7 @@ describe('DtAvatar Tests', function () {
       });
 
       it('should have group count', function () {
-        assert.isTrue(count.exists());
+        assert.exists(count);
       });
 
       it('should have the correct group number', function () {
@@ -262,7 +251,7 @@ describe('DtAvatar Tests', function () {
       });
 
       it('should set the correct class', function () {
-        assert.isTrue(avatar.classes('d-avatar--no-gradient'));
+        assert.isTrue(wrapper.classes('d-avatar--no-gradient'));
       });
     });
 
@@ -389,8 +378,7 @@ describe('DtAvatar Tests', function () {
           const imageSlot = `<img src="${IMAGE_ATTRS.SRC}" data-qa="dt-avatar-image">`;
 
           slots = { default: imageSlot };
-          _setWrappers();
-          await wrapper.vm.$nextTick();
+          await _setWrappers();
         });
 
         itBehavesLikeRaisesSingleVueWarning(warningMessage);
@@ -402,8 +390,7 @@ describe('DtAvatar Tests', function () {
           const imageSlot = `<img alt="${IMAGE_ATTRS.ALT}" data-qa="dt-avatar-image">`;
 
           slots = { default: imageSlot };
-          _setWrappers();
-          await wrapper.vm.$nextTick();
+          await _setWrappers();
         });
 
         itBehavesLikeRaisesSingleVueWarning(warningMessage);

--- a/components/avatar/avatar.vue
+++ b/components/avatar/avatar.vue
@@ -12,6 +12,7 @@
       <!-- @slot Slot for avatar content -->
       <slot v-if="showDefaultSlot" />
       <span
+        v-if="showInitials"
         class="d-ps-absolute d-zi-base"
         :class="AVATAR_KIND_MODIFIERS.initials"
       >
@@ -148,7 +149,7 @@ export default {
   data () {
     return {
       // initials, image or icon
-      kind: 'image',
+      kind: 'initials',
       AVATAR_SIZE_MODIFIERS,
       AVATAR_KIND_MODIFIERS,
       AVATAR_PRESENCE_SIZE_MODIFIERS,
@@ -177,7 +178,7 @@ export default {
     },
 
     showInitials () {
-      return this.kind === 'initials' || this.initials;
+      return this.kind === 'initials' || (this.initials && this.kind !== 'icon');
     },
 
     showGroup () {
@@ -215,7 +216,7 @@ export default {
   },
 
   updated () {
-    this.defaultSlotContent = this.$slots.default ? this.$slots.default[0] : null;
+    this.defaultSlotContent = this.$slots.default?.[0] ?? null;
     this.imageLoadedSuccessfully = this.defaultSlotContent?.elm?.complete;
   },
 
@@ -290,11 +291,13 @@ export default {
     },
 
     isIconType (element) {
-      return element?.componentOptions?.tag === 'dt-icon' || element?.tagName?.toUpperCase() === 'SVG';
+      return element?.componentOptions?.tag === 'dt-icon' ||
+          element?.tagName?.toUpperCase() === 'SVG' ||
+          element?.tag === 'svg';
     },
 
     isImageType (element) {
-      return element?.tagName?.toUpperCase() === 'IMG';
+      return element?.tag === 'img' || element?.tagName?.toUpperCase() === 'IMG';
     },
 
     randomizeGradientAngle () {
@@ -324,8 +327,8 @@ export default {
     },
 
     validateImageAttrsPresence () {
-      const isSrcMissing = !this.$slots.default[0].elm.getAttribute('src');
-      const isAltMissing = !this.$slots.default[0].elm.getAttribute('alt');
+      const isSrcMissing = !this.defaultSlotContent.elm.getAttribute('src');
+      const isAltMissing = !this.defaultSlotContent.elm.getAttribute('alt');
 
       if (isSrcMissing || isAltMissing) {
         Vue.util.warn('src and alt attributes are required for image avatars', this);


### PR DESCRIPTION
# Fix (Avatar): Initials are not available until image loads

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Changed the behavior to have the initials always displayed and put the image over so when the image is loading, initials are shown.

Fixed behavior on storybook, vue 2 version didn't detected the slot changes properly.

## :bulb: Context

Even after passing the initials, initials are not shown untill the image loads, this is replicable on storybook.

## :pencil: Checklist

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have considered the performance impact of my change

## :camera: Screenshots / GIFs


Uploading Screen Recording 2023-03-07 at 9.10.59 p.m..mov…