### PR TITLE
fix: add dialtone-icons to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5736,21 +5736,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@vue/cli-plugin-unit-mocha/node_modules/mochapack/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@vue/cli-plugin-unit-mocha/node_modules/mochapack/node_modules/p-locate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
@@ -5761,15 +5746,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@vue/cli-plugin-unit-mocha/node_modules/mochapack/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@vue/cli-plugin-unit-mocha/node_modules/mochapack/node_modules/string-width": {
@@ -35307,15 +35283,6 @@
                 "path-exists": "^3.0.0"
               }
             },
-            "p-limit": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-              "dev": true,
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
             "p-locate": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
@@ -35324,12 +35291,6 @@
               "requires": {
                 "p-limit": "^2.0.0"
               }
-            },
-            "path-exists": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-              "dev": true
             },
             "string-width": {
               "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
   },
   "peerDependencies": {
     "@dialpad/dialtone": ">=7.19",
+    "@dialpad/dialtone-icons": "latest",
     "vue": ">=2.6"
   },
   "engineStrict": true,


### PR DESCRIPTION
# Add dialtone-icons to peerDependencies

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added dialtone-icons to peerDependencies

## :bulb: Context

Dialtone icons was not a part of peer dependencies so the Dialtone-vue users needed to install dialtone-icons in order to get the icon component working. This should fix the issue.

## :pencil: Checklist

- [x] I have reviewed my changes- [ ] I have added tests

## :crystal_ball: Next Steps

Remove dialtone-icons dependency from the products.