### PR TITLE
fix(leftbar-group-row): add conditional img render

### DIFF
--- a/recipes/leftbar/group_row/group_row.vue
+++ b/recipes/leftbar/group_row/group_row.vue
@@ -15,6 +15,7 @@
         :group="groupCount"
       >
         <img
+          v-if="avatarSrc"
           data-qa="dt-avatar-image"
           :src="avatarSrc"
           :alt="avatarInitials"


### PR DESCRIPTION
# fix(leftbar-group-row): add conditional img render

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Was causing an error when group row had a falsy avatarSrc. This should fix it.
