### PR TITLE
refactor: modify dt-recipe-callbar component to have common styles baked in (vue3)

### DIFF
--- a/recipes/buttons/callbar_button/callbar_button.stories.js
+++ b/recipes/buttons/callbar_button/callbar_button.stories.js
@@ -40,6 +40,15 @@ export const argTypesData = {
         summary: ['string', 'array', 'object'],
       },
     },
+    control: 'text',
+  },
+  textClass: {
+    table: {
+      type: {
+        summary: ['string', 'array', 'object'],
+      },
+    },
+    control: 'text',
   },
   buttonWidthSize: {
     defaultValue: 'xl',

--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -10,7 +10,7 @@
         icon-position="top"
         :disabled="disabled"
         :aria-label="ariaLabel"
-        label-class="d-fs-100"
+        :label-class="callbarButtonTextClass"
         :width="buttonWidth"
         :class="callbarButtonClass"
       >
@@ -110,6 +110,14 @@ export default {
       default: '',
     },
 
+    /**
+     * Additional class name for the button text.
+     */
+    textClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+
     /*
      * Width size. Valid values are: 'xl', 'lg', 'md' and 'sm'.
      */
@@ -126,12 +134,20 @@ export default {
         this.buttonClass,
         'dt-recipe-callbar-button',
         'd-px0',
+        'd-fc-black-900',
         {
           'dt-recipe-callbar-button--circle': this.circle,
           'd-btn--icon-only': this.circle,
           'dt-recipe-callbar-button--active': this.active,
           'dt-recipe-callbar-button--danger': this.danger,
         }];
+    },
+
+    callbarButtonTextClass () {
+      return [
+        'd-fs-100 lg:d-d-none md:d-d-none sm:d-d-none',
+        this.textClass,
+      ];
     },
 
     buttonWidth () {

--- a/recipes/buttons/callbar_button/callbar_button_default.story.vue
+++ b/recipes/buttons/callbar_button/callbar_button_default.story.vue
@@ -7,6 +7,7 @@
     :disabled="$attrs.disabled"
     :danger="$attrs.danger"
     :button-class="$attrs.buttonClass"
+    :text-class="$attrs.textClass"
     :button-width-size="$attrs.buttonWidthSize"
     @click="$attrs.onClick"
   >

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
@@ -80,6 +80,20 @@ export const argTypesData = {
       options: VALID_WIDTH_SIZE,
     },
   },
+  textClass: {
+    table: {
+      type: {
+        summary: ['string', 'array', 'object'],
+      },
+    },
+  },
+  iconClass: {
+    table: {
+      type: {
+        summary: ['string', 'array', 'object'],
+      },
+    },
+  },
   contentClass: {
     table: {
       type: {

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
@@ -72,6 +72,7 @@ export const argTypesData = {
         summary: ['string', 'array', 'object'],
       },
     },
+    control: 'text',
   },
   buttonWidthSize: {
     defaultValue: 'xl',
@@ -86,13 +87,7 @@ export const argTypesData = {
         summary: ['string', 'array', 'object'],
       },
     },
-  },
-  iconClass: {
-    table: {
-      type: {
-        summary: ['string', 'array', 'object'],
-      },
-    },
+    control: 'text',
   },
   contentClass: {
     table: {
@@ -100,6 +95,7 @@ export const argTypesData = {
         summary: ['string', 'array', 'object'],
       },
     },
+    control: 'text',
   },
 
   // Popover slots

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -9,6 +9,8 @@
       :danger="danger"
       :button-class="buttonClass"
       :button-width-size="buttonWidthSize"
+      :text-class="textClass"
+      :icon-class="iconClass"
       class="dt-recipe--callbar-button-with-popover--main-button"
       @click="buttonClick"
     >
@@ -210,6 +212,22 @@ export default {
      * Additional class name for the button wrapper element.
      */
     buttonClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+
+    /**
+     * Additional class name for the button text.
+     */
+    textClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+
+    /**
+     * Additional class name for the icon of button.
+     */
+    iconClass: {
       type: [String, Array, Object],
       default: '',
     },

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -10,7 +10,6 @@
       :button-class="buttonClass"
       :button-width-size="buttonWidthSize"
       :text-class="textClass"
-      :icon-class="iconClass"
       class="dt-recipe--callbar-button-with-popover--main-button"
       @click="buttonClick"
     >
@@ -220,14 +219,6 @@ export default {
      * Additional class name for the button text.
      */
     textClass: {
-      type: [String, Array, Object],
-      default: '',
-    },
-
-    /**
-     * Additional class name for the icon of button.
-     */
-    iconClass: {
       type: [String, Array, Object],
       default: '',
     },

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_default.story.vue
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_default.story.vue
@@ -12,6 +12,7 @@
     :danger="$attrs.danger"
     :button-class="$attrs.buttonClass"
     :button-width-size="$attrs.buttonWidthSize"
+    :text-class="$attrs.textClass"
     :content-class="$attrs.contentClass"
     @arrow-click="$attrs.onClick"
     @click="$attrs.onClick"


### PR DESCRIPTION
# PR Title

Modify DtRecipeCallbar component to have common styles baked in

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [ ] Feature
- [X] Refactoring
- [ ] Documentation

## :book: Description

Currently, we have repeated stylings across callbar buttons like `d-fs-100`, `importance="clear"`, and `d-svg--size24`. Instead, we should modify the DtRecipeCallbar component to have these styles baked in. Also modify color to Black 900.

In Application UI PR https://github.com/dialpad/firespotter/pull/27776, we'll remove the styling from each of the call bar buttons since they will be part of the recipe.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [X] I have reviewed my changes
- [X] I have validated components with a screen reader
- [X] I have validated components keyboard navigation
- [X] I have considered the performance impact of my change
- [X] I have checked that my change did not significantly increase bundle size

## :crystal_ball: Next Steps

Update Application UI (PR https://github.com/dialpad/firespotter/pull/27776) and merge to master.

## :camera: Screenshots / GIFs

<img width="1274" alt="Screen Shot 2023-03-14 at 2 56 38 PM" src="https://user-images.githubusercontent.com/86271164/225149532-b9312ce8-f6e2-46c0-8116-aa0d01bcba53.png">

Jira: [DP-66177](https://dialpad.atlassian.net/browse/DP-66177)
Vue 2 PR: https://github.com/dialpad/dialtone-vue/pull/811

[DP-66177]: https://dialpad.atlassian.net/browse/DP-66177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ