### PR TITLE
fix: dialtone-icons version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.68.0",
       "license": "MIT",
       "dependencies": {
-        "@dialpad/dialtone-icons": "latest",
+        "@dialpad/dialtone-icons": "0.0.21",
         "@linusborg/vue-simple-portal": "^0.1.5",
         "emoji-regex": "^10.2.1",
         "emoji-toolkit": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "node": "16"
   },
   "dependencies": {
-    "@dialpad/dialtone-icons": "latest",
+    "@dialpad/dialtone-icons": "0.0.21",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "emoji-regex": "^10.2.1",
     "emoji-toolkit": "^6.6.0",


### PR DESCRIPTION
# Fix Dialtone-icons version

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Changed the version tag from 'latest' to the exact latest version so the client get the version matching.

## :bulb: Context

Clients needed to install the latest dialtone-icons version to prevent errors.

## :pencil: Checklist

- [x] I have reviewed my changes