### PR TITLE
fix(leftbar-group-row): add missing avatarSeed prop

### DIFF
--- a/recipes/leftbar/group_row/group_row.vue
+++ b/recipes/leftbar/group_row/group_row.vue
@@ -12,6 +12,7 @@
     <template #left>
       <dt-avatar
         :initials="avatarInitials"
+        :seed="avatarSeed"
         :group="groupCount"
       >
         <img
@@ -56,6 +57,14 @@ export default {
       type: String,
       default: '',
       required: true,
+    },
+
+    /**
+     * Avatar seed, set this to the user's ID to get the same avatar background gradient each time it is displayed.
+     */
+    avatarSeed: {
+      type: String,
+      default: null,
     },
 
     /**

--- a/recipes/leftbar/group_row/group_row_default.story.vue
+++ b/recipes/leftbar/group_row/group_row_default.story.vue
@@ -5,6 +5,7 @@
     :group-count-text="groupCountText"
     :names="names"
     :avatar-src="avatarSrc"
+    :avatar-seed="avatarSeed"
     :unread-count="unreadCount"
     :unread-count-tooltip="unreadCountTooltip"
     :has-unreads="hasUnreads"


### PR DESCRIPTION
# fix(leftbar-group-row): add missing avatarSeed prop

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Add missing avatarSeed prop to group row

## :bulb: Context

Need this to set consistent avatar graidents between different views

