### PR TITLE
fix: configure passthrough attrs in leftbar components

### DIFF
--- a/recipes/leftbar/contact_row/contact_row.vue
+++ b/recipes/leftbar/contact_row/contact_row.vue
@@ -9,6 +9,7 @@
     :is-typing="isTyping"
     :call-button-tooltip="callButtonTooltip"
     :unread-count-tooltip="unreadCountTooltip"
+    v-bind="$attrs"
     v-on="$listeners"
   >
     <template #left>
@@ -81,6 +82,8 @@ export default {
     DtRecipeGeneralRow,
     DtEmojiTextWrapper,
   },
+
+  inheritAttrs: false,
 
   props: {
     /**

--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -5,7 +5,7 @@
   >
     <button
       class="dt-leftbar-row__primary"
-      data-qa="dt-leftbar-row-link"
+      :data-qa="'data-qa' in $attrs ? $attrs['data-qa'] : 'dt-leftbar-row-link'"
       :aria-label="getAriaLabel"
       :title="description"
       v-bind="$attrs"

--- a/recipes/leftbar/group_row/group_row.vue
+++ b/recipes/leftbar/group_row/group_row.vue
@@ -7,6 +7,7 @@
     :unread-count-tooltip="unreadCountTooltip"
     :selected="selected"
     :is-typing="isTyping"
+    v-bind="$attrs"
     v-on="$listeners"
   >
     <template #left>
@@ -37,6 +38,8 @@ export default {
     DtAvatar,
     DtRecipeGeneralRow,
   },
+
+  inheritAttrs: false,
 
   props: {
     /**


### PR DESCRIPTION
# fix: configure passthrough attrs in leftbar components

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Passing in data-qa was not overriding the existing data-qa on the element. Made a change so it will now do this and added  passthrough props to group / contact rows as well. Needed to fix failing tests on master
