### PR TITLE
fix(badge): export decoration modifiers

### DIFF
--- a/components/badge/index.js
+++ b/components/badge/index.js
@@ -1,2 +1,2 @@
 export { default as DtBadge } from './badge.vue';
-export { BADGE_TYPE_MODIFIERS, BADGE_KIND_MODIFIERS } from './badge_constants';
+export { BADGE_TYPE_MODIFIERS, BADGE_KIND_MODIFIERS, BADGE_DECORATION_MODIFIERS } from './badge_constants';


### PR DESCRIPTION
We missed exporting the badge decoration modifiers. This is needed in product to dynamically cycle through colors.