### PR TITLE
fix(group-row): change group row avatar to 'users' icon

### DIFF
--- a/recipes/leftbar/group_row/group_row.mdx
+++ b/recipes/leftbar/group_row/group_row.mdx
@@ -35,10 +35,7 @@ import { DtRecipeGroupRow } from '@dialpad/dialtone-vue';
 
 ```html
 <dt-recipe-group-row
-  avatar-initials="JN"
-  :group-count="2"
   names="Jaqueline Nackos, Lori Smith"
-  avatar-src="/static/media/../components/avatar/person.png"
 />
 ```
 
@@ -46,10 +43,7 @@ import { DtRecipeGroupRow } from '@dialpad/dialtone-vue';
 
 ```html
 <dt-recipe-group-row
-  avatar-initials="JN"
-  :group-count="2"
   names="Jaqueline Nackos, Lori Smith"
-  avatar-src="/static/media/../components/avatar/person.png"
   :selected="true"
 />
 ```
@@ -58,10 +52,7 @@ import { DtRecipeGroupRow } from '@dialpad/dialtone-vue';
 
 ```html
 <dt-recipe-group-row
-  avatar-initials="JN"
-  :group-count="2"
   names="Jaqueline Nackos, Lori Smith"
-  avatar-src="/static/media/../components/avatar/person.png"
   :unread-count="10"
 />
 ```

--- a/recipes/leftbar/group_row/group_row.stories.js
+++ b/recipes/leftbar/group_row/group_row.stories.js
@@ -4,7 +4,6 @@ import DtRecipeGroupRow from './group_row';
 import DtRecipeGroupRowMdx from './group_row.mdx';
 import DtRecipeGroupRowDefaultTemplate from './group_row_default.story.vue';
 import DtRecipeGroupRowVariantsTemplate from './group_row_variants.story.vue';
-const defaultImage = require('@/components/avatar/person.png');
 
 // Default Prop Values
 export const argsData = {
@@ -12,21 +11,8 @@ export const argsData = {
 };
 
 export const argTypesData = {
-  // Props
-  groupCount: {
-    defaultValue: 8,
-  },
-
   names: {
     defaultValue: 'Jaqueline Nackos, Lori Smith',
-  },
-
-  avatarInitials: {
-    defaultValue: 'JN',
-  },
-
-  avatarSrc: {
-    defaultValue: defaultImage,
   },
 
   // Slots

--- a/recipes/leftbar/group_row/group_row.test.js
+++ b/recipes/leftbar/group_row/group_row.test.js
@@ -13,8 +13,6 @@ const basePropsData = {
 describe('DtRecipeGroupRow Tests', function () {
   // Wrappers
   let wrapper;
-  let avatarImage;
-  let avatarGroupCount;
   let description;
   let unreadBadge;
 
@@ -26,8 +24,6 @@ describe('DtRecipeGroupRow Tests', function () {
 
   // Helpers
   const _setChildWrappers = () => {
-    avatarImage = wrapper.find('[data-qa="dt-avatar-image"]');
-    avatarGroupCount = wrapper.find('[data-qa="dt-avatar-count"]');
     description = wrapper.find('.dt-leftbar-row__description');
     unreadBadge = wrapper.find('[data-qa="dt-leftbar-row-unread-badge"]');
   };
@@ -70,16 +66,8 @@ describe('DtRecipeGroupRow Tests', function () {
 
       it('should exist', function () { assert.exists(wrapper); });
 
-      it('should render the avatar', function () {
-        assert.isTrue(avatarImage.exists());
-      });
-
       it('should render the description', function () {
         assert.strictEqual(description.text(), basePropsData.names);
-      });
-
-      it('should render the group count', function () {
-        assert.strictEqual(+avatarGroupCount.text(), basePropsData.groupCount);
       });
     });
 

--- a/recipes/leftbar/group_row/group_row.vue
+++ b/recipes/leftbar/group_row/group_row.vue
@@ -11,77 +11,29 @@
     v-on="$listeners"
   >
     <template #left>
-      <dt-avatar
-        :initials="avatarInitials"
-        :seed="avatarSeed"
-        :group="groupCount"
-      >
-        <!-- No alt needed as the name is already mentioned in the description
-          https://dequeuniversity.com/rules/axe/4.4/image-redundant-alt?application=axe-puppeteer -->
-        <img
-          v-if="avatarSrc"
-          data-qa="dt-avatar-image"
-          :src="avatarSrc"
-          alt=""
-        >
-        <template v-else>
-          {{ avatarInitials }}
-        </template>
-      </dt-avatar>
+      <dt-icon
+        name="users"
+        size="300"
+      />
     </template>
   </dt-recipe-general-row>
 </template>
 
 <script>
 import { DtRecipeGeneralRow } from '@/recipes/leftbar/general_row';
-import DtAvatar from '@/components/avatar/avatar.vue';
+import DtIcon from '@/components/icon/icon.vue';
 
 export default {
   name: 'DtRecipeGroupRow',
 
   components: {
-    DtAvatar,
+    DtIcon,
     DtRecipeGeneralRow,
   },
 
   inheritAttrs: false,
 
   props: {
-    /**
-     * Optional avatar image url.
-     * if provided, it's also required to provide a value in the `avatarInitials` prop to use
-     * in the alt attribute of the avatar.
-     */
-    avatarSrc: {
-      type: String,
-      default: '',
-    },
-
-    /**
-     * Initials to display on the avatar if avatarSrc is not provided or
-     * alt attr if avatarSrc is provided.
-     */
-    avatarInitials: {
-      type: String,
-      default: '',
-      required: true,
-    },
-
-    /**
-     * Avatar seed, set this to the user's ID to get the same avatar background gradient each time it is displayed.
-     */
-    avatarSeed: {
-      type: String,
-      default: null,
-    },
-
-    /**
-     * Number displayed in avatar to count group members
-     */
-    groupCount: {
-      type: Number,
-      required: true,
-    },
 
     /**
      * Screen reader will read out the number of users in the group using this text. Ex: "2 users"

--- a/recipes/leftbar/group_row/group_row_default.story.vue
+++ b/recipes/leftbar/group_row/group_row_default.story.vue
@@ -1,11 +1,7 @@
 <template>
   <dt-recipe-group-row
-    :avatar-initials="avatarInitials"
-    :group-count="groupCount"
     :group-count-text="groupCountText"
     :names="names"
-    :avatar-src="avatarSrc"
-    :avatar-seed="avatarSeed"
     :unread-count="unreadCount"
     :unread-count-tooltip="unreadCountTooltip"
     :has-unreads="hasUnreads"

--- a/recipes/leftbar/group_row/group_row_variants.story.vue
+++ b/recipes/leftbar/group_row/group_row_variants.story.vue
@@ -5,11 +5,8 @@
         Default behavior
       </h3>
       <dt-recipe-group-row
-        avatar-initials="JN"
-        :group-count="2"
         group-count-text="2 users"
         names="Jaqueline Nackos, Lori Smith"
-        :avatar-src="defaultImage"
       />
     </div>
     <div>
@@ -17,11 +14,8 @@
         Ellipsed names
       </h3>
       <dt-recipe-group-row
-        avatar-initials="JN"
-        :group-count="4"
         group-count-text="4 users"
         names="Jaqueline Nackos, Lori Smith, Jaqueline Nackos, Lori Smith"
-        :avatar-src="defaultImage"
       />
     </div>
     <div>
@@ -29,13 +23,9 @@
         With unread count
       </h3>
       <dt-recipe-group-row
-        avatar-initials="JN"
-        :group-count="2"
         group-count-text="2 users"
         names="Jaqueline Nackos, Lori Smith"
-        :avatar-src="defaultImage"
         :has-unreads="true"
-        unread-count="1"
         unread-count-tooltip="1 unread message"
       />
     </div>
@@ -44,24 +34,9 @@
         Selected
       </h3>
       <dt-recipe-group-row
-        avatar-initials="JN"
-        :group-count="2"
         group-count-text="2 users"
         names="Jaqueline Nackos, Lori Smith"
-        :avatar-src="defaultImage"
         selected
-      />
-    </div>
-    <div>
-      <h3>
-        With Initial as fallback when avatar image src cannot be found.
-      </h3>
-      <dt-recipe-group-row
-        avatar-initials="JN"
-        :group-count="2"
-        group-count-text="2 users"
-        names="Jaqueline Nackos, Lori Smith"
-        avatar-src="/static/media/../components/avatar/404"
       />
     </div>
   </dt-stack>


### PR DESCRIPTION
# fix(group-row): change group row avatar to 'users' icon

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Changing group row to a users icon instead of avatar

## :bulb: Context

Unfortunately due to some limitations of the back end we can't display the first users avatar. Updating to just show the "users" icon for now until the back end gets updated and we can do what we ultimately need.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Add into product

## :camera: Screenshots / GIFs

![Screenshot 2023-03-27 at 3 26 39 PM](https://user-images.githubusercontent.com/64808812/228080817-e27bd9eb-27ec-45fc-8a13-e5a795fe4d81.png)