### PR TITLE
feat(tooltip): add 300ms default delay

### DIFF
--- a/components/tooltip/tooltip.test.js
+++ b/components/tooltip/tooltip.test.js
@@ -48,6 +48,9 @@ describe('DtTooltip tests', function () {
         // this gets around transition async problems. See https://v1.test-utils.vuejs.org/guides/common-tips.html
         transition: transitionStub(),
       },
+      propsData: {
+        delay: false,
+      },
       slots: {
         default: 'Test message',
       },
@@ -158,6 +161,7 @@ describe('DtTooltip tests', function () {
 
       describe('When mouseenter tooltip', function () {
         beforeEach(async function () {
+          await wrapper.setProps({ delay: false });
           await anchor.trigger('mouseenter');
         });
 

--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -50,6 +50,7 @@ import {
   TOOLTIP_KIND_MODIFIERS,
   TOOLTIP_DIRECTIONS,
   TOOLTIP_STICKY_VALUES,
+  TOOLTIP_DELAY_MS,
 } from './tooltip_constants';
 import { getUniqueString } from '@/common/utils';
 import DtLazyShow from '../lazy_show/lazy_show';
@@ -182,6 +183,15 @@ export default {
       type: String,
       default: 'fade',
     },
+
+    /**
+     * Whether the tooltip will have a delay when being focused or moused over.
+     * @values true, false
+     */
+    delay: {
+      type: Boolean,
+      default: true,
+    },
   },
 
   emits: [
@@ -205,6 +215,9 @@ export default {
     return {
       TOOLTIP_KIND_MODIFIERS,
       tip: null,
+
+      inTimer: null,
+      outTimer: null,
 
       // Internal state for whether the tooltip is shown. Changing the prop
       // will update this.
@@ -317,6 +330,17 @@ export default {
     },
 
     onEnterAnchor (e) {
+      if (this.delay) {
+        this.inTimer = setTimeout(function (event) {
+          return this.triggerShow(event);
+        }.bind(this, e), TOOLTIP_DELAY_MS);
+      } else {
+        return this.triggerShow(event);
+      }
+      clearTimeout(this.outTimer);
+    },
+
+    triggerShow (e) {
       if (e.type === 'focusin') {
         // only show tooltips on visible focus when triggered via focus.
         // when the user is using the mouse they only want tooltips to display
@@ -334,6 +358,15 @@ export default {
     },
 
     onLeaveAnchor () {
+      if (this.delay) {
+        this.outTimer = setTimeout(this.triggerHide, TOOLTIP_DELAY_MS);
+      } else {
+        return this.triggerHide();
+      }
+      clearTimeout(this.inTimer);
+    },
+
+    triggerHide () {
       if (this.show === null) this.isShown = false;
     },
 

--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -217,7 +217,6 @@ export default {
       tip: null,
 
       inTimer: null,
-      outTimer: null,
 
       // Internal state for whether the tooltip is shown. Changing the prop
       // will update this.
@@ -337,7 +336,6 @@ export default {
       } else {
         return this.triggerShow(e);
       }
-      clearTimeout(this.outTimer);
     },
 
     triggerShow (e) {
@@ -358,12 +356,8 @@ export default {
     },
 
     onLeaveAnchor () {
-      if (this.delay) {
-        this.outTimer = setTimeout(this.triggerHide, TOOLTIP_DELAY_MS);
-      } else {
-        return this.triggerHide();
-      }
       clearTimeout(this.inTimer);
+      return this.triggerHide();
     },
 
     triggerHide () {

--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -335,7 +335,7 @@ export default {
           return this.triggerShow(event);
         }.bind(this, e), TOOLTIP_DELAY_MS);
       } else {
-        return this.triggerShow(event);
+        return this.triggerShow(e);
       }
       clearTimeout(this.outTimer);
     },

--- a/components/tooltip/tooltip_constants.js
+++ b/components/tooltip/tooltip_constants.js
@@ -7,6 +7,8 @@ export const TOOLTIP_DIRECTIONS = [
   ...BASE_TIPPY_DIRECTIONS,
 ];
 
+export const TOOLTIP_DELAY_MS = 500;
+
 export const TOOLTIP_KIND_MODIFIERS = {
   hover: `d-tooltip--hover`,
   show: `d-tooltip--show`,

--- a/components/tooltip/tooltip_constants.js
+++ b/components/tooltip/tooltip_constants.js
@@ -7,7 +7,7 @@ export const TOOLTIP_DIRECTIONS = [
   ...BASE_TIPPY_DIRECTIONS,
 ];
 
-export const TOOLTIP_DELAY_MS = 500;
+export const TOOLTIP_DELAY_MS = 300;
 
 export const TOOLTIP_KIND_MODIFIERS = {
   hover: `d-tooltip--hover`,

--- a/components/tooltip/tooltip_default.story.vue
+++ b/components/tooltip/tooltip_default.story.vue
@@ -19,6 +19,7 @@
         :content-class="contentClass"
         :transition="transition"
         :show="showTooltip"
+        :delay="delay"
         @shown="onShown"
       >
         <template


### PR DESCRIPTION
# feat(tooltip): add 300ms default delay

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Set 500ms delay on tooltip and added delay prop to enable / disable delay. We are intentionally not allowing users to set an exact ms for delay. Had to code delay manually since we aren't using tippy for trigger events but it was simple enough 🤷‍♂️ .

## :bulb: Context

It was a design decision to make this change since the tooltips in product are displaying much too fast. It is still possible to set delay = false but that will not be the default going forward.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Test with designers to see if the delay feels reasonable.

## :link: Sources

https://www.nngroup.com/articles/timing-exposing-content/
