### PR TITLE
feat(input): add date and time types

### DIFF
--- a/components/input/input.stories.js
+++ b/components/input/input.stories.js
@@ -2,7 +2,7 @@
 import { action } from '@storybook/addon-actions';
 import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
 import DtInput from './input';
-import { INPUT_SIZES } from './input_constants';
+import { INPUT_SIZES, INPUT_TYPES } from './input_constants';
 import InputMdx from './input.mdx';
 import InputDefault from './input_default.story.vue';
 
@@ -61,7 +61,7 @@ export const argTypesData = {
     defaultValue: DtInput.props.type.default,
     control: {
       type: 'select',
-      options: ['text', 'textarea', 'password', 'email', 'number'],
+      options: [null, ...Object.values(INPUT_TYPES)],
     },
     table: {
       defaultValue: {

--- a/components/input/input.vue
+++ b/components/input/input.vue
@@ -147,9 +147,9 @@ export default {
     },
 
     /**
-     * Type of the input, one of: `text`, `password`, `email`, `number`, `textarea`.
+     * Type of the input, one of: `text`, `password`, `email`, `number`, `textarea`, 'date', 'time'.
      * When `textarea` a `<textarea>` element will be rendered instead of an `<input>` element.
-     * @values text, password, email, number, textarea.
+     * @values text, password, email, number, textarea, date, time
      */
     type: {
       type: String,

--- a/components/input/input_constants.js
+++ b/components/input/input_constants.js
@@ -6,6 +6,8 @@ export const INPUT_TYPES = {
   PASSWORD: 'password',
   EMAIL: 'email',
   NUMBER: 'number',
+  DATE: 'date',
+  TIME: 'time',
 };
 
 export const INPUT_SIZES = {


### PR DESCRIPTION
# feat(input): add date and time types

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Add support for "date" and "time" types in the input. 

## :bulb: Context

We currently have no datepicker solution in Dialtone which a team is currently asking for, so we are publishing this native datepicker for them to use temporarily until we release our Dialtone Datepicker component.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Communicate release to the team working on this.

## :camera: Screenshots / GIFs
![Screenshot 2023-03-29 at 2 30 26 PM](https://user-images.githubusercontent.com/64808812/228672218-db349025-3a6a-45b7-9f07-897393591513.png)


## :link: Sources

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date
