### PR TITLE
fix(recipe-callbar-btn): show tooltip when the callbar button is disa…

### DIFF
--- a/recipes/buttons/callbar_button/callbar_button.stories.js
+++ b/recipes/buttons/callbar_button/callbar_button.stories.js
@@ -33,6 +33,7 @@ export const argTypesData = {
   },
   disabled: {
     control: 'boolean',
+    description: 'Button is disabled, shows the tooltip',
   },
   buttonClass: {
     table: {

--- a/recipes/buttons/callbar_button/callbar_button.test.js
+++ b/recipes/buttons/callbar_button/callbar_button.test.js
@@ -92,7 +92,7 @@ describe('DtRecipeCallbarButton Tests', function () {
 
       it('Should display a disabled button when "disabled"', async function () {
         await wrapper.setProps({ disabled: true });
-        assert.isTrue(button.element.disabled);
+        assert.isTrue(button.classes().includes('d-btn--disabled'));
       });
     });
   });

--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -130,17 +130,6 @@ export default {
       default: 'xl',
       validator: size => VALID_WIDTH_SIZE.includes(size),
     },
-
-    /**
-     * Whether to show the tooltip text. Sometimes we want to show it when the button is disabled.
-     * @values true, false
-     * @see https://dialpad.design/components/button.html#disabled
-     */
-    showTooltip: {
-      type: Boolean,
-      default: false,
-    },
-
   },
 
   computed: {

--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -4,21 +4,25 @@
     :offset="[0, -12]"
   >
     <template #anchor>
-      <dt-button
-        :importance="circle ? 'outlined' : 'clear'"
-        kind="muted"
-        icon-position="top"
-        :disabled="disabled"
-        :aria-label="ariaLabel"
-        :label-class="callbarButtonTextClass"
-        :width="buttonWidth"
-        :class="callbarButtonClass"
+      <span
+        :class="{ 'd-c-not-allowed': disabled }"
       >
-        <slot />
-        <template #icon>
-          <slot name="icon" />
-        </template>
-      </dt-button>
+        <dt-button
+          :importance="circle ? 'outlined' : 'clear'"
+          kind="muted"
+          icon-position="top"
+          :aria-disabled="disabled"
+          :aria-label="ariaLabel"
+          :label-class="callbarButtonTextClass"
+          :width="buttonWidth"
+          :class="callbarButtonClass"
+        >
+          <slot />
+          <slot
+            name="icon"
+          />
+        </dt-button>
+      </span>
     </template>
     <slot name="tooltip" />
   </dt-tooltip>
@@ -126,6 +130,17 @@ export default {
       default: 'xl',
       validator: size => VALID_WIDTH_SIZE.includes(size),
     },
+
+    /**
+     * Whether to show the tooltip text. Sometimes we want to show it when the button is disabled.
+     * @values true, false
+     * @see https://dialpad.design/components/button.html#disabled
+     */
+    showTooltip: {
+      type: Boolean,
+      default: false,
+    },
+
   },
 
   computed: {
@@ -134,12 +149,13 @@ export default {
         this.buttonClass,
         'dt-recipe-callbar-button',
         'd-px0',
-        'd-fc-primary',
         {
           'dt-recipe-callbar-button--circle': this.circle,
           'd-btn--icon-only': this.circle,
           'dt-recipe-callbar-button--active': this.active,
           'dt-recipe-callbar-button--danger': this.danger,
+          'd-btn--disabled': this.disabled,
+          'd-fc-primary': !this.disabled,
         }];
     },
 


### PR DESCRIPTION
…bled

# PR Title

Show tooltip when the callbar button is disabled.
Vue-3 version of https://github.com/dialpad/dialtone-vue/pull/866

## :hammer_and_wrench: Type Of Change

- [X] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Options to show tooltip text when the callbar recipe button is disabled

## :bulb: Context

Options to show tooltip text when the callbar recipe button is disabled
Jira: https://dialpad.atlassian.net/browse/DP-60576

## :pencil: Checklist

- [X] I have reviewed my changes
- [X ] I have added tests
- [X] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root


