### PR TITLE
fix(recipe-callbar-btn): transparent background when btn is in disabl…

### DIFF
--- a/recipes/buttons/callbar_button/callbar_button.test.js
+++ b/recipes/buttons/callbar_button/callbar_button.test.js
@@ -98,6 +98,7 @@ describe('DtRecipeCallbarButton Tests', function () {
       it('Should display a disabled button when "disabled"', async function () {
         await wrapper.setProps({ disabled: true });
         assert.isTrue(button.classes().includes('d-btn--disabled'));
+        assert.isTrue(button.classes().includes('d-bgc-transparent'));
       });
     });
   });

--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -132,17 +132,6 @@ export default {
       default: 'xl',
       validator: size => VALID_WIDTH_SIZE.includes(size),
     },
-
-    /**
-     * Whether to show the tooltip text. Sometimes we want to show it when the button is disabled.
-     * @values true, false
-     * @see https://dialpad.design/components/button.html#disabled
-     */
-    showTooltip: {
-      type: Boolean,
-      default: false,
-    },
-
   },
 
   emits: [
@@ -165,7 +154,7 @@ export default {
           'dt-recipe-callbar-button--circle': this.circle,
           'dt-recipe-callbar-button--active': this.active,
           'dt-recipe-callbar-button--danger': this.danger,
-          'd-btn--disabled': this.disabled,
+          'd-btn--disabled d-bgc-transparent': this.disabled,
           'd-fc-primary': !this.disabled,
         }];
     },


### PR DESCRIPTION
…ed state

# PR Title

Show transparent background when btn is in disabled state

## :hammer_and_wrench: Type Of Change

- [X] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Show transparent background when btn is in disabled state

## :bulb: Context

Show transparent background when btn is in disabled state


## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [X] I have reviewed my changes
- [X] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root


## :camera: Screenshots / GIFs
<img width="126" alt="Screen Shot 2023-03-30 at 4 50 30 PM" src="https://user-images.githubusercontent.com/70488122/228989713-5fadf2cd-27a1-477b-b9ae-9109a9a6e82e.png">

Right AI icon show how it currently looks. But it needs to be transparent as seen in the left share screen icon 
<img width="518" alt="Screen Shot 2023-03-30 at 4 42 18 PM" src="https://user-images.githubusercontent.com/70488122/228989733-2f470009-8387-4192-b715-6f8f029d1efc.png">


