### PR TITLE
fix(recipe-callbar-btn): transparent background when btn is in disabled (vue3)

### DIFF
--- a/recipes/buttons/callbar_button/callbar_button.test.js
+++ b/recipes/buttons/callbar_button/callbar_button.test.js
@@ -93,6 +93,7 @@ describe('DtRecipeCallbarButton Tests', function () {
       it('Should display a disabled button when "disabled"', async function () {
         await wrapper.setProps({ disabled: true });
         assert.isTrue(button.classes().includes('d-btn--disabled'));
+        assert.isTrue(button.classes().includes('d-bgc-transparent'));
       });
     });
   });

--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -143,7 +143,7 @@ export default {
           'd-btn--icon-only': this.circle,
           'dt-recipe-callbar-button--active': this.active,
           'dt-recipe-callbar-button--danger': this.danger,
-          'd-btn--disabled': this.disabled,
+          'd-btn--disabled d-bgc-transparent': this.disabled,
           'd-fc-primary': !this.disabled,
         }];
     },


### PR DESCRIPTION
# PR Title

Show transparent background when btn is in disabled state
vue3 version of https://github.com/dialpad/dialtone-vue/pull/875

## :hammer_and_wrench: Type Of Change

- [X] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Show transparent background when btn is in disabled state

## :bulb: Context

Show transparent background when btn is in disabled state


## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [X] I have reviewed my changes
- [X] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root


## :camera: Screenshots / GIFs

Refer https://github.com/dialpad/dialtone-vue/pull/875
