### PR TITLE
fix: dialtone-icons dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.74.2",
       "license": "MIT",
       "dependencies": {
-        "@dialpad/dialtone-icons": "0.3.1",
         "@linusborg/vue-simple-portal": "^0.1.5",
         "emoji-regex": "^10.2.1",
         "emoji-toolkit": "^6.6.0",
@@ -21,6 +20,7 @@
         "@commitlint/config-conventional": "^17.4.2",
         "@dialpad/conventional-changelog-angular": "^1.1.1",
         "@dialpad/dialtone": "^7.22.0",
+        "@dialpad/dialtone-icons": "0.3.1",
         "@dialpad/semantic-release-changelog-json": "^1.0.0",
         "@percy/cli": "^1.21.0",
         "@percy/storybook": "^4.3.5",
@@ -67,6 +67,7 @@
       },
       "peerDependencies": {
         "@dialpad/dialtone": ">=7.19",
+        "@dialpad/dialtone-icons": "0.3.1",
         "vue": ">=2.6"
       }
     },
@@ -2719,6 +2720,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.3.1.tgz",
       "integrity": "sha512-uPSgBd1rcf8Vxj9+SuwI8+Lj/WZUOs3+zWbZ410WDbCPpcMr+bAGfcNWnJGbr6zWQ43iu9S9Mwlg59p4IoXfjg==",
+      "dev": true,
       "peerDependencies": {
         "vue": ">=2.6"
       }
@@ -32948,6 +32950,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.3.1.tgz",
       "integrity": "sha512-uPSgBd1rcf8Vxj9+SuwI8+Lj/WZUOs3+zWbZ410WDbCPpcMr+bAGfcNWnJGbr6zWQ43iu9S9Mwlg59p4IoXfjg==",
+      "dev": true,
       "requires": {}
     },
     "@dialpad/semantic-release-changelog-json": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "node": "16"
   },
   "dependencies": {
-    "@dialpad/dialtone-icons": "0.3.1",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "emoji-regex": "^10.2.1",
     "emoji-toolkit": "^6.6.0",
@@ -94,6 +93,7 @@
     "@commitlint/config-conventional": "^17.4.2",
     "@dialpad/conventional-changelog-angular": "^1.1.1",
     "@dialpad/dialtone": "^7.22.0",
+    "@dialpad/dialtone-icons": "0.3.1",
     "@dialpad/semantic-release-changelog-json": "^1.0.0",
     "@percy/cli": "^1.21.0",
     "@percy/storybook": "^4.3.5",
@@ -137,6 +137,7 @@
   },
   "peerDependencies": {
     "@dialpad/dialtone": ">=7.19",
+    "@dialpad/dialtone-icons": "0.3.1",
     "vue": ">=2.6"
   },
   "engineStrict": true,


### PR DESCRIPTION
# Fix dialtone-icons dependency

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Removed dialtone-icons from dependencies and moved into devDependencies and peerDependencies.

## :bulb: Context

Errors are being reported around dialtone-icons not found on clients using dialtone-vue.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root