### PR TITLE
feat(modal): add closeOnClick prop

### DIFF
--- a/components/modal/modal.vue
+++ b/components/modal/modal.vue
@@ -290,6 +290,15 @@ export default {
     },
 
     /**
+     * Whether the modal will close when you click outside of the dialog on the overlay.
+     * @values true, false
+     */
+    closeOnClick: {
+      type: Boolean,
+      default: true,
+    },
+
+    /**
      * Scrollable modal that allows scroll the modal content keeping the header and footer fixed
      * @values true, false
      */
@@ -325,6 +334,7 @@ export default {
         ...this.$listeners,
 
         click: event => {
+          if (!this.closeOnClick) return;
           (event.target === event.currentTarget) && this.close();
           this.$emit('click', event);
         },

--- a/components/modal/modal.vue
+++ b/components/modal/modal.vue
@@ -1,3 +1,4 @@
+
 <template>
   <dt-lazy-show
     transition="d-zoom"
@@ -115,6 +116,7 @@
 </template>
 
 <script>
+/* eslint-disable max-lines */
 import { DtButton } from '@/components/button';
 import { DtIcon } from '@/components/icon';
 import Modal from '@/common/mixins/modal.js';

--- a/components/modal/modal.vue
+++ b/components/modal/modal.vue
@@ -1,4 +1,3 @@
-
 <template>
   <dt-lazy-show
     transition="d-zoom"

--- a/components/modal/modal_default.story.vue
+++ b/components/modal/modal_default.story.vue
@@ -18,6 +18,7 @@
       :fixed-header-footer="fixedHeaderFooter"
       :visually-hidden-close="visuallyHiddenClose"
       :visually-hidden-close-label="visuallyHiddenCloseLabel"
+      :close-on-click="closeOnClick"
       @update:show="close"
     >
       <template


### PR DESCRIPTION
# feat(modal): add closeOnClick prop

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

If this prop is false it will prevent closing the modal when the overlay is clicked on

## :bulb: Context

Requested by dev
