### PR TITLE
fix(popover): losing focus

### DIFF
--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -732,8 +732,7 @@ export default {
     *   - when anchor is within another popover: set the popover dialog container to it's non-modal z-index
     *     since it is no longer the active modal. This puts it underneath the overlay and prevents scrolling.
     **/
-    async preventScrolling () {
-      await this.$nextTick();
+    preventScrolling () {
       if (this.modal) {
         const element = this.anchorEl.closest('body, .tippy-box');
         if (element.tagName.toLowerCase() === 'body') {
@@ -748,17 +747,14 @@ export default {
     /*
     * Resets the prevent scrolling properties set in preventScrolling() back to normal.
     **/
-    async enableScrolling () {
-      await this.$nextTick();
-      if (this.modal) {
-        const element = this.anchorEl.closest('body, .tippy-box');
-        if (!element) return;
-        if (element.tagName?.toLowerCase() === 'body') {
-          element.classList.remove('d-of-hidden');
-          this.tip.setProps({ offset: this.offset });
-        } else {
-          element.classList.remove('d-zi-popover');
-        }
+    enableScrolling () {
+      const element = this.anchorEl.closest('body, .tippy-box');
+      if (!element) return;
+      if (element.tagName?.toLowerCase() === 'body') {
+        element.classList.remove('d-of-hidden');
+        this.tip.setProps({ offset: this.offset });
+      } else {
+        element.classList.remove('d-zi-popover');
       }
     },
 
@@ -783,8 +779,10 @@ export default {
     async onLeaveTransitionComplete () {
       if (this.modal) {
         await this.focusFirstElement(this.$refs.anchor);
+        // await next tick in case the user wants to change focus themselves.
+        await this.$nextTick();
+        this.enableScrolling();
       }
-      await this.enableScrolling();
       this.tip?.unmount();
       this.$emit('opened', false);
       if (this.open !== null) {
@@ -794,7 +792,9 @@ export default {
 
     async onEnterTransitionComplete () {
       this.focusInitialElement();
-      await this.preventScrolling();
+      // await next tick in case the user wants to change focus themselves.
+      await this.$nextTick();
+      this.preventScrolling();
       this.$emit('opened', true, this.$refs.popover__content);
       if (this.open !== null) {
         this.$emit('update:open', true);

--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -783,11 +783,9 @@ export default {
     async onLeaveTransitionComplete () {
       if (this.modal) {
         await this.focusFirstElement(this.$refs.anchor);
-        // await next tick in case the user wants to change focus themselves.
-        await this.$nextTick();
       }
-      this.tip?.unmount();
       await this.enableScrolling();
+      this.tip?.unmount();
       this.$emit('opened', false);
       if (this.open !== null) {
         this.$emit('update:open', false);
@@ -797,8 +795,6 @@ export default {
     async onEnterTransitionComplete () {
       this.focusInitialElement();
       await this.preventScrolling();
-      // await next tick in case the user wants to change focus themselves.
-      await this.$nextTick();
       this.$emit('opened', true, this.$refs.popover__content);
       if (this.open !== null) {
         this.$emit('update:open', true);


### PR DESCRIPTION
# Fix popover losing focus

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Removed `this.$nextTick()` as we are already waiting for the nextTick on `preventScrolling`.

## :bulb: Context

This behavior was firing the 'opened' event until 2 ticks, so if the client was depending on this to keep the anchor visible, it will hide and close the popover immediately.

## :pencil: Checklist

- [x] I have reviewed my changes