### PR TITLE
fix: showing both image and initials issue

### DIFF
--- a/components/avatar/avatar.vue
+++ b/components/avatar/avatar.vue
@@ -279,6 +279,9 @@ export default {
     kindHandler (el) {
       switch (this.kind) {
         case 'image':
+          if (this.showInitials) {
+            el.classList.add('d-avatar__image', 'd-zi-base1');
+          }
           this.validateImageAttrsPresence();
           this.setImageListeners(el);
           break;


### PR DESCRIPTION
# PR Title

<!--- Feel free to remove any unused sections -->

DT-1119 Fix bug that showing both image and initials

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

<!--- Describe the changes -->

There is image overlap issue for multiple avatars feature since we set `z-index`.
<img width="393" alt="Screen Shot 2023-04-10 at 9 11 25 AM" src="https://user-images.githubusercontent.com/86271164/230943224-60db61c0-caf8-431b-945f-d53dae91f505.png">

To fix this issue, I removed `z-index` at [here](https://github.com/dialpad/dialtone-vue/pull/881/files#diff-90b30c664802d78094183e71b1acbb8385122479a20e6052588cd5a6d422dff0L248):
<img width="634" alt="Screen Shot 2023-04-10 at 9 14 40 AM" src="https://user-images.githubusercontent.com/86271164/230943725-4a3ced68-f9ab-4554-b50f-46372a9325d2.png">

However, this will make both image and initials showing if both values are set. So revert `z-index` for DPM case. For `DtRecipeContactInfo` component, we have already handled value input that won't set both image and initials.

<img width="397" alt="Screen Shot 2023-04-10 at 9 25 24 AM" src="https://user-images.githubusercontent.com/86271164/230945726-835dbe40-9f60-40af-9c8c-314592b09f8f.png">


## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have validated components with a screen reader
- [x] I have considered the performance impact of my change

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->

JIra: https://dialpad.atlassian.net/browse/DT-1119
