### PR TITLE
fix: null protection on some refs

### DIFF
--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -825,7 +825,7 @@ export default {
         console.warn('Could not find the element specified in dt-popover prop "initialFocusElement". ' +
           'Defaulting to focusing the dialog.');
       }
-      result ? result.focus() : this.$refs.content.$el.focus();
+      result ? result.focus() : this.$refs.content?.$el.focus();
     },
 
     onResize () {
@@ -865,7 +865,7 @@ export default {
         this.$refs.popover__header?.focusCloseButton();
       } else {
         // if there are no focusable elements at all focus the dialog itself
-        this.$refs.content.$el.focus();
+        this.$refs.content?.$el.focus();
       }
     },
 

--- a/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -435,7 +435,7 @@ export default {
   methods: {
     onChipRemove (item) {
       this.$emit('remove', item);
-      this.$refs.input.focus();
+      this.$refs.input?.focus();
     },
 
     onComboboxSelect (i) {
@@ -445,12 +445,12 @@ export default {
 
     showComboboxList () {
       if (this.showList != null) { return; }
-      this.$refs.comboboxWithPopover.showComboboxList();
+      this.$refs.comboboxWithPopover?.showComboboxList();
     },
 
     closeComboboxList () {
       if (this.showList != null) { return; }
-      this.$refs.comboboxWithPopover.closeComboboxList();
+      this.$refs.comboboxWithPopover?.closeComboboxList();
     },
 
     getChipButtons () {
@@ -506,20 +506,20 @@ export default {
 
     moveFromInputToChip () {
       this.getLastChipButton().focus();
-      this.$refs.input.blur();
+      this.$refs.input?.blur();
       this.closeComboboxList();
     },
 
     moveFromChipToInput () {
       this.getLastChipButton().blur();
-      this.$refs.input.focus();
+      this.$refs.input?.focus();
       this.showComboboxList();
     },
 
     navigateBetweenChips (target, toLeft) {
       const from = this.getChipButtons().indexOf(target);
       const to = toLeft ? from - 1 : from + 1;
-      if (to < 0 || to >= this.$refs.chips.length) {
+      if (to < 0 || to >= this.$refs.chips?.length) {
         return;
       }
       this.getChipButtons()[from].blur();

--- a/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue
+++ b/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue
@@ -454,7 +454,7 @@ export default {
     },
 
     onFocusIn (e) {
-      if (this.hasSuggestionList && e && this.$refs.input.querySelector('input') === e.target) {
+      if (this.hasSuggestionList && e && this.$refs.input?.querySelector('input') === e.target) {
         // only trigger if we show suggestion list when focused, and
         // it's the input specifically that was focused
         this.showComboboxList();
@@ -463,7 +463,7 @@ export default {
 
     onFocusOut (e) {
       // Check if the focus change was to another target within the combobox component
-      const popoverEl = this.$refs.popover.tip?.popper;
+      const popoverEl = this.$refs.popover?.tip?.popper;
       const comboboxEl = this.$refs.input;
 
       if (e.composedPath()?.some(el => [popoverEl, comboboxEl].includes(el))) return;


### PR DESCRIPTION
Some additional null protection on some refs fields, since these seem to be triggering errors in a lot of cases likely because the ref element no longer exists.