### PR TITLE
fix(avatar): image size and z-index issues

### DIFF
--- a/components/avatar/avatar.stories.js
+++ b/components/avatar/avatar.stories.js
@@ -96,6 +96,9 @@ const defaultImage = require('./person.png');
 
 // Stories
 export const Default = DefaultTemplate.bind({});
+Default.decorators = [() => ({
+  template: `<div class="d-d-flex"><story /></div>`,
+})];
 Default.args = {
   default: `<img data-qa="dt-avatar-image" src="${defaultImage}" alt="Person Avatar">`,
   initials: 'PS',

--- a/components/avatar/avatar.vue
+++ b/components/avatar/avatar.vue
@@ -38,13 +38,13 @@
     </div>
     <span
       v-if="showGroup"
-      class="d-avatar__count d-zi-base1"
+      class="d-avatar__count d-zi-base"
       data-qa="dt-avatar-count"
     >{{ formattedGroup }}</span>
     <dt-presence
       v-if="presence && !showGroup"
       :presence="presence"
-      class="d-zi-base1"
+      class="d-zi-base"
       :class="[
         'd-avatar__presence',
         AVATAR_PRESENCE_SIZE_MODIFIERS[size],
@@ -221,11 +221,13 @@ export default {
     },
 
     showDefaultSlot () {
-      return this.kind !== 'initials' || (this.kind === 'image' && this.imageLoadedSuccessfully === true);
+      return this.kind !== 'initials' ||
+      (this.kind === 'image' && this.imageLoadedSuccessfully === true);
     },
 
     showInitials () {
-      return this.kind === 'initials' || (this.kind === 'image' && this.initials);
+      return this.kind === 'initials' ||
+      (this.kind === 'image' && this.initials && this.imageLoadedSuccessfully !== true);
     },
 
     showGroup () {
@@ -276,12 +278,11 @@ export default {
       this.initializing = false;
     },
 
+    // eslint-disable-next-line complexity
     kindHandler (el) {
       switch (this.kind) {
         case 'image':
-          if (this.showInitials) {
-            el.classList.add('d-avatar__image', 'd-zi-base1');
-          }
+          el.classList.add('d-avatar__image');
           this.validateImageAttrsPresence();
           this.setImageListeners(el);
           break;


### PR DESCRIPTION
# Fix avatar - image size and z-index issues

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

- Fixed z-index issues caused by displaying both `initials` and `image`, changed back to `d-zi-base`.
- Removed logic that was preventing `d-avatar__image` class being added to avatar.
- Added a decorator to `avatar.stories.js` to contain the avatar.

## :bulb: Context

- Logic preventing `d-avatar__image` class being added #901
- `d-avatar` class recently changed `display: inline-flex` to `display: flex` and it was causing issues on avatar's presence positioning. https://github.com/dialpad/dialtone/pull/852

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Update #906 with this changes.