### PR TITLE
fix: remove dialtone-icons from externals

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -12,7 +12,6 @@ module.exports = defineConfig({
     },
     externals: [
       '@dialpad/dialtone',
-      '@dialpad/dialtone-icons',
     ],
     externalsType: 'commonjs',
   },


### PR DESCRIPTION
remove dialtone-icons from externals so it does not have to be installed independently by the consumer