### PR TITLE
fix(leftbar_row): animation speed to 1.5s

### DIFF
--- a/recipes/leftbar/style/leftbar_row.less
+++ b/recipes/leftbar/style/leftbar_row.less
@@ -104,11 +104,11 @@
     padding: 0;
     opacity: 0.3;
     border-radius: var(--br-pill);
-    animation: wave var(--td150) ease infinite;
+    animation: wave 1.5s ease infinite;
   }
 
   &__is-typing span:nth-child(1){
-      animation-delay: 0;
+      animation-delay: 0ms;
   }
   &__is-typing span:nth-child(2){
     animation-delay: var(--td100);


### PR DESCRIPTION
# fix(leftbar_row): animation speed to 1.5s

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

isTyping animation was erroneously changed and going hyperspeed. This is the fix.
