### PR TITLE
fix: emoji size in leftbar item descriptions

### DIFF
--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -37,6 +37,7 @@
           <dt-emoji-text-wrapper
             class="dt-leftbar-row__description"
             data-qa="dt-leftbar-row-description"
+            size="200"
           >
             {{ description }}
           </dt-emoji-text-wrapper>


### PR DESCRIPTION
# fix: emoji size in leftbar item descriptions

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Emoji size was too large and ruining the layout in general row and group row, contact row was okay.

