### PR TITLE
fix: emoji size in leftbar item descriptions

### DIFF
--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -36,6 +36,7 @@
           <dt-emoji-text-wrapper
             class="dt-leftbar-row__description"
             data-qa="dt-leftbar-row-description"
+            size="200"
           >
             {{ description }}
           </dt-emoji-text-wrapper>


### PR DESCRIPTION
Vue 3 of https://github.com/dialpad/dialtone-vue/pull/918