### PR TITLE
fix(general_row): show dnd alongside unreadCount

### DIFF
--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -60,7 +60,7 @@
           </template>
         </dt-tooltip>
         <div
-          v-else-if="activeVoiceChat"
+          v-if="activeVoiceChat"
           class="dt-leftbar-row__active-voice"
         >
           <dt-icon
@@ -238,8 +238,8 @@ export default {
     },
 
     /**
-     * Acronym used to represent "Do not Disturb" state. If entered will display the entered text over
-     * unreadCount and activeVoiceChat.
+     * Acronym used to represent "Do not Disturb" state. If entered will display the entered text alongside
+     * unreadCount.
      */
     dndText: {
       type: String,


### PR DESCRIPTION
# fix(general_row): show dnd alongside unreadCount

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Fixes bug where DND would hide the unread count. It now displays beside.

https://dialpad.atlassian.net/browse/DT-1163

## :bulb: Context

Reported bug by customer
