### PR TITLE
fix(recipe-grouped-chip): update to use fixed width

### DIFF
--- a/recipes/chips/grouped_chip/grouped_chip.vue
+++ b/recipes/chips/grouped_chip/grouped_chip.vue
@@ -9,7 +9,7 @@
       content-class="d-fs100"
       size="xs"
       :grouped-chip="true"
-      class="d-blr-pill d-bgc-moderate-opaque d-w100p d-wmx64"
+      class="d-blr-pill d-bgc-moderate-opaque d-w72"
     >
       <template
         v-if="$slots.leftIcon"
@@ -41,7 +41,7 @@
       content-class="d-fs100"
       size="xs"
       :grouped-chip="true"
-      class="d-brr-pill d-bgc-purple-200 d-w100p d-wmx64"
+      class="d-brr-pill d-bgc-purple-200 d-w72"
     >
       <template #icon>
         <div
@@ -56,7 +56,6 @@
         <div
           v-if="$slots.rightContent"
           data-qa="right-grouped-chip-content"
-          class="d-wmx50p"
         >
           <!-- @slot Slot for right chip content information -->
           <slot name="rightContent" />


### PR DESCRIPTION
# PR Title

Update chip width to fixed size.

## :hammer_and_wrench: Type Of Change

- [X] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Update chip width to fixed size.

## :bulb: Context

Update chip width to fixed size. This prevents the calltimer chip from pulsing with constant time updates.

## :pencil: Checklist

- [X] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps
N/A 

## :camera: Screenshots / GIFs
<img width="181" alt="Screen Shot 2023-04-28 at 9 54 54 AM" src="https://user-images.githubusercontent.com/70488122/235222751-956ddfd3-f86d-4a1e-9825-700bc3cd3fe4.png">


