### PR TITLE
fix(recipe-grouped-chip): grouped chip width and content style fixes.

### DIFF
--- a/recipes/chips/grouped_chip/grouped_chip.stories.js
+++ b/recipes/chips/grouped_chip/grouped_chip.stories.js
@@ -103,7 +103,7 @@ export const Default = DefaultTemplate.bind({});
 Default.args = {
   leftIcon: 'clock',
   leftContent: `<div>
-    0.13
+    2:50:13
 </div>`,
   rightIcon: 'pause',
   rightContent: `<div>

--- a/recipes/chips/grouped_chip/grouped_chip.vue
+++ b/recipes/chips/grouped_chip/grouped_chip.vue
@@ -9,7 +9,7 @@
       content-class="d-fs100"
       size="xs"
       :grouped-chip="true"
-      class="d-blr-pill d-bgc-moderate-opaque d-w100p d-wmx64"
+      class="d-blr-pill d-bgc-moderate-opaque d-wmx84 dt-chip-content"
     >
       <template
         v-if="hasSlotContent($slots.leftIcon)"
@@ -41,7 +41,7 @@
       content-class="d-fs100"
       size="xs"
       :grouped-chip="true"
-      class="d-brr-pill d-bgc-purple-200 d-w100p d-wmx64"
+      class="d-brr-pill d-bgc-purple-200 d-wmx84 dt-chip-content"
     >
       <template #icon>
         <div
@@ -56,7 +56,6 @@
         <div
           v-if="hasSlotContent($slots.rightContent)"
           data-qa="right-grouped-chip-content"
-          class="d-wmx50p"
         >
           <!-- @slot Slot for right chip content information -->
           <slot name="rightContent" />
@@ -84,3 +83,9 @@ export default {
   },
 };
 </script>
+
+<style lang="less">
+.dt-chip-content {
+  font-variant-numeric: tabular-nums;
+}
+</style>


### PR DESCRIPTION
# PR Title

Update grouped chip styling


## :hammer_and_wrench: Type Of Change

- [ X] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Update chip width to use max width and add styling to prevents the calltimer chip from pulsing with constant time updates.

vue3 version of https://github.com/dialpad/dialtone-vue/pull/949

## :bulb: Context

Update chip width to use max width and add styling to prevents the calltimer chip from pulsing with constant time updates.

https://dialpad.atlassian.net/browse/DP-70140?focusedCommentId=691320

## :pencil: Checklist


- [ X] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root


## :camera: Screenshots / GIFs


<img width="161" alt="Screen Shot 2023-05-01 at 11 37 39 AM" src="https://user-images.githubusercontent.com/70488122/235541062-33d5dc8d-6a31-4fca-85e7-7a3798cc48b4.png">
