### PR TITLE
fix: bundle in vue

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -16,12 +16,7 @@ export default defineConfig({
       },
     },
     rollupOptions: {
-      external: ['vue', '@dialpad/dialtone'],
-      output: {
-        globals: {
-          vue: 'Vue',
-        },
-      },
+      external: ['@dialpad/dialtone'],
     },
   },
   plugins: [vue()],


### PR DESCRIPTION
# fix: bundle in vue

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

No idea why this keeps expecting vue to have a default export when externalized and I have wasted enough time on it. I am just going to bundle in vue for now. Should fix it for the short term at least