### PR TITLE
fix: component documentation link class

### DIFF
--- a/components/banner/banner.vue
+++ b/components/banner/banner.vue
@@ -175,7 +175,7 @@ export default {
 
     /**
      * Background image size, follows the background-size CSS property values
-     * <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/background-size" target="_blank">
+     * <a class="d-link" href="https://developer.mozilla.org/en-US/docs/Web/CSS/background-size" target="_blank">
      *   CSS background-sizes
      * </a>
      */

--- a/components/button/button.vue
+++ b/components/button/button.vue
@@ -94,7 +94,7 @@ export default {
     /**
      * Whether the button should be styled as a link or not.
      * @values true, false
-     * @see https://dialpad.design/components/link.html
+     * @see DtLink
      */
     link: {
       type: Boolean,
@@ -104,7 +104,7 @@ export default {
     /**
      * The color of the link and button if the button is styled as a link.
      * @values default, warning, danger, success, muted, inverted
-     * @see https://dialpad.design/components/link.html
+     * @see DtLink
      */
     linkKind: {
       type: String,
@@ -114,7 +114,11 @@ export default {
 
     /**
      * HTML button disabled attribute
-     * <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled" target="_blank">
+     * <a
+     *   class="d-link"
+     *   href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled"
+     *   target="_blank"
+     * >
      *   (Reference)
      * </a>
      * @values true, false
@@ -126,7 +130,11 @@ export default {
 
     /**
      * HTML button type attribute
-     * <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type" target="_blank">
+     * <a
+     *   class="d-link"
+     *   href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type"
+     *   target="_blank"
+     * >
      *   (Reference)
      * </a>
      * @values button, submit, reset
@@ -139,7 +147,7 @@ export default {
 
     /**
      * Button width, accepts
-     * <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/width" target="_blank">
+     * <a class="d-link" href="https://developer.mozilla.org/en-US/docs/Web/CSS/width" target="_blank">
      *   CSS width attribute
      * </a>
      * values

--- a/components/dropdown/dropdown.vue
+++ b/components/dropdown/dropdown.vue
@@ -248,7 +248,13 @@ export default {
     /**
      * If set to false the dialog will display over top of the anchor when there is insufficient space.
      * If set to true it will never move from its position relative to the anchor and will clip instead.
-     * See <a href="https://popper.js.org/docs/v2/modifiers/prevent-overflow/#tether" target="_blank">Popper.js docs</a>
+     * <a
+     *   class="d-link"
+     *   href="https://popper.js.org/docs/v2/modifiers/prevent-overflow/#tether"
+     *   target="_blank"
+     * >
+     *   Popper.js docs
+     * </a>
      * @values true, false
      */
     tether: {

--- a/components/emoji/emoji.vue
+++ b/components/emoji/emoji.vue
@@ -47,8 +47,8 @@ export default {
   props: {
     /**
      * Supports shortcode ex: :smile: or unicode ex: 😄. Will display the resulting emoji.
-     * See <a href="https://emojipedia.org/joypixels/" target="_blank">JoyPixels</a>
-     *  for all supported shortcode/unicode or the docs for setting up custom emojis.
+     * <a class="d-link" href="https://emojipedia.org/joypixels/" target="_blank">JoyPixels</a>
+     * for all supported shortcode/unicode or the docs for setting up custom emojis.
      */
     code: {
       type: String,
@@ -57,7 +57,7 @@ export default {
 
     /**
      * The size of the emoji. Can be any of the icon size utility classes from
-     * <a href="https://dialpad.design/components/icon.html" target="_blank"> Dialpad Icon Size</a>
+     * <a class="d-link" href="https://dialpad.design/components/icon.html" target="_blank"> Dialpad Icon Size</a>
      * @values 100, 200, 300, 400, 500, 600, 700, 800
      */
     size: {

--- a/components/popover/popover.vue
+++ b/components/popover/popover.vue
@@ -194,7 +194,7 @@ export default {
 
     /**
      * ARIA role for the content of the popover. Defaults to "dialog".
-     * <a href="https://www.w3.org/TR/wai-aria/#aria-haspopup" target="_blank">aria-haspopup</a>
+     * <a class="d-link" href="https://www.w3.org/TR/wai-aria/#aria-haspopup" target="_blank">aria-haspopup</a>
      */
     role: {
       type: String,
@@ -292,8 +292,14 @@ export default {
 
     /**
      *  Displaces the content box from its anchor element
-     *  by the specified number of pixels. See
-     *  <a href="https://atomiks.github.io/tippyjs/v6/all-props/#offset" target="_blank">Tippy.js docs</a>
+     *  by the specified number of pixels.
+     *  <a
+     *    class="d-link"
+     *    href="https://atomiks.github.io/tippyjs/v6/all-props/#offset"
+     *    target="_blank"
+     *  >
+     *    Tippy.js docs
+     *  </a>
      */
     offset: {
       type: Array,
@@ -302,7 +308,7 @@ export default {
 
     /**
      * Determines if the popover hides upon clicking the
-     * anchor or outside of the content box.
+     * anchor or outside the content box.
      * @values true, false
      */
     hideOnClick: {
@@ -322,8 +328,14 @@ export default {
 
     /**
      * If the popover does not fit in the direction described by "placement",
-     * it will attempt to change it's direction to the "fallbackPlacements".
-     * See <a href="https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements" target="_blank">Popper.js docs</a>
+     * it will attempt to change its direction to the "fallbackPlacements".
+     * <a
+     *   class="d-link"
+     *   href="https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements"
+     *   target="_blank"
+     * >
+     *   Popper.js docs
+     * </a>
      * */
     fallbackPlacements: {
       type: Array,
@@ -334,7 +346,13 @@ export default {
 
     /**
      * The direction the popover displays relative to the anchor.
-     * See <a href="https://atomiks.github.io/tippyjs/v6/all-props/#placement" target="_blank">Tippy.js docs</a>
+     * <a
+     *   class="d-link"
+     *   href="https://atomiks.github.io/tippyjs/v6/all-props/#placement"
+     *   target="_blank"
+     * >
+     *   Tippy.js docs
+     * </a>
      * @values top, top-start, top-end,
      * right, right-start, right-end,
      * left, left-start, left-end,
@@ -349,7 +367,13 @@ export default {
     /**
      * If set to false the dialog will display over top of the anchor when there is insufficient space.
      * If set to true it will never move from its position relative to the anchor and will clip instead.
-     * See <a href="https://popper.js.org/docs/v2/modifiers/prevent-overflow/#tether" target="_blank">Popper.js docs</a>
+     * <a
+     *   class="d-link"
+     *   href="https://popper.js.org/docs/v2/modifiers/prevent-overflow/#tether"
+     *   target="_blank"
+     * >
+     *   Popper.js docs
+     * </a>
      * @values true, false
      */
     tether: {
@@ -363,7 +387,13 @@ export default {
      * position in those cases the DOM layout changes the reference element's position.
      * `true` enables it, `reference` only checks the "reference" rect for changes and `popper` only
      * checks the "popper" rect for changes.
-     * See <a href="https://atomiks.github.io/tippyjs/v6/all-props/#sticky" target="_blank">Tippy.js docs</a>
+     * <a
+     *   class="d-link"
+     *   href="https://atomiks.github.io/tippyjs/v6/all-props/#sticky"
+     *   target="_blank"
+     * >
+     *   Tippy.js docs
+     * </a>
      * @values true, false, reference, popper
      */
     sticky: {

--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -83,10 +83,16 @@ export default {
 
     /**
      * If the popover does not fit in the direction described by "placement",
-     * it will attempt to change it's direction to the "fallbackPlacements"
+     * it will attempt to change its direction to the "fallbackPlacements"
      * if defined, otherwise it will automatically position to a new location
-     * as it sees best fit.
-     * See <a href="https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements" target="_blank">Popper.js docs</a>
+     * as it sees best fit. See
+     * <a
+     *   class="d-link"
+     *   href="https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements"
+     *   target="_blank"
+     * >
+     *   Popper.js docs
+     * </a>
      * */
     fallbackPlacements: {
       type: Array,
@@ -105,7 +111,13 @@ export default {
     /**
      *  Displaces the tooltip from its reference element
      *  by the specified number of pixels. See
-     *  <a href="https://atomiks.github.io/tippyjs/v6/all-props/#offset" target="_blank">Tippy.js docs</a>
+     *  <a
+     *    class="d-link"
+     *    href="https://atomiks.github.io/tippyjs/v6/all-props/#offset"
+     *    target="_blank"
+     *  >
+     *    Tippy.js docs
+     *  </a>
      */
     offset: {
       type: Array,
@@ -113,8 +125,14 @@ export default {
     },
 
     /**
-     * The direction the popover displays relative to the anchor.
-     * See <a href="https://atomiks.github.io/tippyjs/v6/all-props/#placement" target="_blank">Tippy.js docs</a>
+     * The direction the popover displays relative to the anchor. See
+     * <a
+     *   class="d-link"
+     *   href="https://atomiks.github.io/tippyjs/v6/all-props/#placement"
+     *   target="_blank"
+     * >
+     *   Tippy.js docs
+     * </a>
      * @values top, top-start, top-end,
      * right, right-start, right-end,
      * left, left-start, left-end,
@@ -134,8 +152,14 @@ export default {
      * if the reference element's position is animating, or to automatically update the popover
      * position in those cases the DOM layout changes the reference element's position.
      * `true` enables it, `reference` only checks the "reference" rect for changes and `popper` only
-     * checks the "popper" rect for changes.
-     * See <a href="https://atomiks.github.io/tippyjs/v6/all-props/#sticky" target="_blank">Tippy.js docs</a>
+     * checks the "popper" rect for changes. See
+     * <a
+     *   class="d-link"
+     *   href="https://atomiks.github.io/tippyjs/v6/all-props/#sticky"
+     *   target="_blank"
+     * >
+     *   Tippy.js docs
+     * </a>
      * @values true, false, reference, popper
      */
     sticky: {


### PR DESCRIPTION
# Fix: Component documentation links

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added `d-link` class to documentation links so we can render them properly on https://dialpad.design

## :bulb: Context

The auto-generated dialtone-vue documentation is rendered through markdownIt on dialpad.design, but the renderer doesn't properly detects `<a></a>` elements to manipulate them and add `d-link` class.

So I'm adding `d-link` class manually here to properly render the links.

## :pencil: Checklist

- [x] I have reviewed my changes