### PR TITLE
fix: set node engine minimum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "yorkie": "^2.0.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 12.20"
       },
       "peerDependencies": {
         "@dialpad/dialtone": ">=7.26",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
   ],
   "engineStrict": true,
   "engines": {
-    "node": ">= 18"
+    "node": ">= 12.20"
   },
   "type": "module",
   "main": "./dist/dialtone-vue.cjs",


### PR DESCRIPTION
# fix: set node engine minimum

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

While we use node 18, it doesn't mean it's actually required to use our library. Used [ls-engines](https://www.npmjs.com/package/ls-engines) to determine what our actual node required version is and set it to that.
