### PR TITLE
fix(leftbar-general-row): add href for focusability

### DIFF
--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -8,6 +8,7 @@
       :data-qa="'data-qa' in $attrs ? $attrs['data-qa'] : 'dt-leftbar-row-link'"
       :aria-label="getAriaLabel"
       :title="description"
+      href="javascript:void(0)"
       v-bind="$attrs"
       v-on="$listeners"
     >

--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -8,7 +8,7 @@
       :data-qa="'data-qa' in $attrs ? $attrs['data-qa'] : 'dt-leftbar-row-link'"
       :aria-label="getAriaLabel"
       :title="description"
-      href="javascript:void(0)"
+      :href="'href' in $attrs ? $attrs.href : 'javascript:void(0)'"
       v-bind="$attrs"
       v-on="$listeners"
     >


### PR DESCRIPTION
# fix(leftbar-general-row): add href for focusability

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

`<a>` on leftbar was not naturally focusable unless you manually added a href yourself. This is not really intuitive to developers so added a href with `javascript:void(0)`

Thread here: https://dialpad.slack.com/archives/CEDUKPKC1/p1684281340913299

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes

## :link: Sources

https://stackoverflow.com/questions/134845/which-href-value-should-i-use-for-javascript-links-or-javascriptvoid0
