### PR TITLE
feat(scroller): updates in dynamic scroller

### DIFF
--- a/components/scroller/modules/dynamic_scroller.vue
+++ b/components/scroller/modules/dynamic_scroller.vue
@@ -236,6 +236,16 @@ export default {
   },
 
   methods: {
+    dynamicScrollerUpdateItems () {
+      const scroller = this.$refs.scroller;
+      if (scroller) scroller._updateVisibleItems(true);
+    },
+
+    dynamicScrollerUpdateItemsFromBottom () {
+      const scroller = this.$refs.scroller;
+      if (scroller) scroller._updateVisibleItems(false, true);
+    },
+
     scrollToItem (index) {
       const scroller = this.$refs.scroller;
       if (scroller) scroller.scrollToItem(index);

--- a/components/scroller/scroller.mdx
+++ b/components/scroller/scroller.mdx
@@ -35,7 +35,8 @@ This function will scroll to the bottom of the scroller, this is necessary becau
 `updateItems(dynamic = false)` This function is necessary to call when the user do some update to the list
 (add elements from the top with unshift or update some item).
 
-`updateItemsFromBottom(dynamic = false)` This function is necessary to call when the user push some element to the array list.
+`updateItemsFromBottom(dynamic = false)` This function is necessary to call when the user push some
+ element to the array list.
 
 ### Important
 

--- a/components/scroller/scroller.mdx
+++ b/components/scroller/scroller.mdx
@@ -32,10 +32,10 @@ We are also exposing:
 `scrollToBottom()` (only accessible by the dynamic component)
 This function will scroll to the bottom of the scroller, this is necessary because the dynamic component has variable size.
 
-`updateItems()` This function is necessary to call when the user do some update to the list
+`updateItems(dynamic = false)` This function is necessary to call when the user do some update to the list
 (add elements from the top with unshift or update some item).
 
-`updateItemsFromBottom()` This function is necessary to call when the user push some element to the array list.
+`updateItemsFromBottom(dynamic = false)` This function is necessary to call when the user push some element to the array list.
 
 ### Important
 
@@ -44,6 +44,8 @@ Due the flexibility of the component IT WILL NOT UPDATE AUTOMATICALLY.
 You MUST use `updateItems()` when use `unshift` or update some item data.
 
 You MUST use `updateItemsFromBottom()` if you use `push` to add some element to the array list.
+
+`updateItems()` and `updateItemsFromBottom()` in dynamic mode should be called with a `true` parameter.
 
 The list item components must be reactive to the item prop being updated without
 being re-created (use computed props or watchers to properly react to props changes!).

--- a/components/scroller/scroller.mdx
+++ b/components/scroller/scroller.mdx
@@ -32,7 +32,8 @@ We are also exposing:
 `scrollToBottom()` (only accessible by the dynamic component)
 This function will scroll to the bottom of the scroller, this is necessary because the dynamic component has variable size.
 
-`updateItems()` This function is necessary to call when the user do some update to the list (add elements from the top with unshift or update some item).
+`updateItems()` This function is necessary to call when the user do some update to the list
+(add elements from the top with unshift or update some item).
 
 `updateItemsFromBottom()` This function is necessary to call when the user push some element to the array list.
 

--- a/components/scroller/scroller.mdx
+++ b/components/scroller/scroller.mdx
@@ -32,11 +32,9 @@ We are also exposing:
 `scrollToBottom()` (only accessible by the dynamic component)
 This function will scroll to the bottom of the scroller, this is necessary because the dynamic component has variable size.
 
-`updateItems(dynamic = false)` This function is necessary to call when the user do some update to the list
-(add elements from the top with unshift or update some item).
+`updateItems()` This function is necessary to call when the user do some update to the list (add elements from the top with unshift or update some item).
 
-`updateItemsFromBottom(dynamic = false)` This function is necessary to call when the user push some
- element to the array list.
+`updateItemsFromBottom()` This function is necessary to call when the user push some element to the array list.
 
 ### Important
 
@@ -45,8 +43,6 @@ Due the flexibility of the component IT WILL NOT UPDATE AUTOMATICALLY.
 You MUST use `updateItems()` when use `unshift` or update some item data.
 
 You MUST use `updateItemsFromBottom()` if you use `push` to add some element to the array list.
-
-`updateItems()` and `updateItemsFromBottom()` in dynamic mode should be called with a `true` parameter.
 
 The list item components must be reactive to the item prop being updated without
 being re-created (use computed props or watchers to properly react to props changes!).

--- a/components/scroller/scroller.stories.js
+++ b/components/scroller/scroller.stories.js
@@ -46,8 +46,8 @@ export const argTypesData = {
   direction: {
     control: {
       type: 'select',
-      options: ['horizontal', 'vertical'],
     },
+    options: ['horizontal', 'vertical'],
   },
 
   listTag: {

--- a/components/scroller/scroller.vue
+++ b/components/scroller/scroller.vue
@@ -165,12 +165,22 @@ function scrollToItem (index) {
   if (scroller.value) scroller.value.scrollToItem(index);
 }
 
-function updateItems () {
-  if (scroller.value) scroller.value._updateVisibleItems(true);
+function updateItems (dynamic = false) {
+  if (!scroller.value) return;
+  if (dynamic) {
+    scroller.value.dynamicScrollerUpdateItems();
+  } else {
+    scroller.value._updateVisibleItems(true);
+  }
 }
 
-function updateItemsFromBottom () {
-  if (scroller.value) scroller.value._updateVisibleItems(false, true);
+function updateItemsFromBottom (dynamic = false) {
+  if (!scroller.value) return;
+  if (dynamic) {
+    scroller.value.dynamicScrollerUpdateItemsFromBottom();
+  } else {
+    scroller.value._updateVisibleItems(false, true);
+  }
 }
 
 function validateProps () {

--- a/components/scroller/scroller.vue
+++ b/components/scroller/scroller.vue
@@ -165,18 +165,18 @@ function scrollToItem (index) {
   if (scroller.value) scroller.value.scrollToItem(index);
 }
 
-function updateItems (dynamic = false) {
+function updateItems () {
   if (!scroller.value) return;
-  if (dynamic) {
+  if (props.dynamic) {
     scroller.value.dynamicScrollerUpdateItems();
   } else {
     scroller.value._updateVisibleItems(true);
   }
 }
 
-function updateItemsFromBottom (dynamic = false) {
+function updateItemsFromBottom () {
   if (!scroller.value) return;
-  if (dynamic) {
+  if (props.dynamic) {
     scroller.value.dynamicScrollerUpdateItemsFromBottom();
   } else {
     scroller.value._updateVisibleItems(false, true);

--- a/components/scroller/scroller_dynamic.story.vue
+++ b/components/scroller/scroller_dynamic.story.vue
@@ -7,6 +7,11 @@
     </button>
     <br>
     <br>
+    <button @click="replaceItems()">
+      Replace Items
+    </button>
+    <br>
+    <br>
     <button
       class="autoscrolling"
       @click="switchAutoScrolling"
@@ -97,6 +102,11 @@ function switchAutoScrolling () {
       }
     });
   }, 1000);
+}
+
+function replaceItems () {
+  dynamicItems.value = [...dynamicItems.value].reverse();
+  scroller.value.updateItems(true);
 }
 </script>
 

--- a/components/scroller/scroller_dynamic.story.vue
+++ b/components/scroller/scroller_dynamic.story.vue
@@ -106,7 +106,7 @@ function switchAutoScrolling () {
 
 function replaceItems () {
   dynamicItems.value = [...dynamicItems.value].reverse();
-  scroller.value.updateItems(true);
+  scroller.value.updateItems();
 }
 </script>
 


### PR DESCRIPTION
# UpdateItems and updateItemsFromBottom exposes in dynimic scroller

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Description

`UpdateItems` and `updateItemsFromBottom` exposes in dynimic scroller.

Trigger the appropriate method should fix the overlapping issue.


Issue: 
<img width="447" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/89984179/95c55dbe-efaf-4f71-bf23-943d2756db40">

<img width="530" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/89984179/5f7ba6db-1d93-4638-8c4c-41cf56e580c4">

With fix:
<img width="447" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/89984179/d7a7d66d-46a4-4980-b294-4d42a1434ea7">

<img width="630" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/89984179/b4ce6d45-c649-4676-907e-e6df5ee1f241">

