### PR TITLE
feat(modal): show event and initial-focus-element

### DIFF
--- a/common/mixins/modal.js
+++ b/common/mixins/modal.js
@@ -35,9 +35,23 @@ export default {
      * @param {object} el - optional - ref of dom element to trap focus on.
      *  will default to the root node of the vue component
      */
-    async focusFirstElement (el) {
+    async focusFirstElement (el = this.$el) {
       const elToFocus = await this.getFirstFocusableElement(el);
       elToFocus?.focus({ preventScroll: true });
+    },
+
+    async focusElementById (elementId) {
+      await this.$nextTick();
+      const result = this.$el.querySelector(elementId);
+      if (result) {
+        result.focus();
+        return;
+      }
+
+      // eslint-disable-next-line no-console
+      console.warn('Could not find the element specified in dt-modal prop "initialFocusElement". ' +
+          'Defaulting to focusing the first element.');
+      await this.focusFirstElement();
     },
 
     /**

--- a/common/mixins/modal.js
+++ b/common/mixins/modal.js
@@ -42,7 +42,7 @@ export default {
 
     async focusElementById (elementId) {
       await this.$nextTick();
-      const result = this.$el.querySelector(elementId);
+      const result = this.$el?.querySelector(elementId);
       if (result) {
         result.focus();
         return;
@@ -50,7 +50,7 @@ export default {
 
       // eslint-disable-next-line no-console
       console.warn('Could not find the element specified in dt-modal prop "initialFocusElement". ' +
-          'Defaulting to focusing the first element.');
+        'Defaulting to focusing the first element.');
       await this.focusFirstElement();
     },
 

--- a/components/modal/modal.stories.js
+++ b/components/modal/modal.stories.js
@@ -20,7 +20,7 @@ maximus ipsum ex. Curabitur elementum luctus augue, quis eleifend tortor feugiat
 Maecenas maximus, ipsum et laoreet congue, diam massa aliquam libero, at pellentesque \
 orci ipsum et velit.`,
   title: 'Example Title',
-  onClose: action('update:show'),
+  toggleOpen: action('update:show'),
   visuallyHiddenCloseLabel: 'Close Modal',
 };
 
@@ -93,16 +93,16 @@ export const argTypesData = {
 
   // Events
   'update:show': {
-    description: `The modal will emit a "false" boolean value for this event when the \
-user performs a modal-closing action.  Parent components can sync on this value to create \
-a 2-way binding to control modal visibility.`,
+    description: `The modal will emit a "false" boolean value when the user performs a modal-closing action \
+     and a "true" boolean value after the modal is fully-shown.\
+     Parent components can sync on this value to create a 2-way binding to control modal visibility.`,
     table: {
       type: {
         summary: 'boolean',
       },
     },
   },
-  onClose: {
+  toggleOpen: {
     table: {
       disable: true,
     },

--- a/components/modal/modal.vue
+++ b/components/modal/modal.vue
@@ -119,7 +119,11 @@
 import { DtButton } from '@/components/button';
 import { DtIcon } from '@/components/icon';
 import Modal from '../../common/mixins/modal';
-import { MODAL_BANNER_KINDS, MODAL_KIND_MODIFIERS, MODAL_SIZE_MODIFIERS } from './modal_constants';
+import {
+  MODAL_BANNER_KINDS,
+  MODAL_KIND_MODIFIERS,
+  MODAL_SIZE_MODIFIERS,
+} from './modal_constants';
 import { getUniqueString } from '@/common/utils';
 import { DtLazyShow } from '@/components/lazy_show';
 import { EVENT_KEYNAMES } from '@/common/constants';
@@ -307,6 +311,23 @@ export default {
       type: Boolean,
       default: true,
     },
+
+    /**
+     * The element that is focused when the modal is opened. This can be an
+     * HTMLElement within the modal, a string starting with '#' which will
+     * find the element by ID. 'first' which will automatically focus
+     * the first element, or 'dialog' which will focus the dialog window itself.
+     * If the dialog is modal this prop cannot be 'none'.
+     */
+    initialFocusElement: {
+      type: [String, HTMLElement],
+      default: 'first',
+      validator: initialFocusElement => {
+        return initialFocusElement === 'first' ||
+          (initialFocusElement instanceof HTMLElement) ||
+          initialFocusElement.startsWith('#');
+      },
+    },
   },
 
   emits: [
@@ -354,6 +375,7 @@ export default {
         },
 
         'after-enter': event => {
+          this.$emit('update:show', true);
           (event.target === event.currentTarget) && this.setFocusAfterTransition();
         },
       };
@@ -402,7 +424,13 @@ export default {
     },
 
     setFocusAfterTransition () {
-      this.focusFirstElement();
+      if (this.initialFocusElement === 'first') {
+        this.focusFirstElement();
+      } else if (this.initialFocusElement.startsWith('#')) {
+        this.focusElementById(this.initialFocusElement);
+      } else if (this.initialFocusElement instanceof HTMLElement) {
+        this.initialFocusElement.focus();
+      }
     },
 
     trapFocus (e) {

--- a/components/modal/modal_default.story.vue
+++ b/components/modal/modal_default.story.vue
@@ -19,7 +19,8 @@
       :visually-hidden-close="visuallyHiddenClose"
       :visually-hidden-close-label="visuallyHiddenCloseLabel"
       :close-on-click="closeOnClick"
-      @update:show="close"
+      :initial-focus-element="initialFocusElement"
+      @update:show="updateShow"
     >
       <template
         v-if="banner"
@@ -49,11 +50,13 @@
         />
         <div v-else>
           <dt-button
+            id="cancel-button"
             importance="clear"
           >
             Cancel
           </dt-button>
           <dt-button
+            id="confirm-button"
             :kind="kind"
             importance="primary"
             class="d-ml6"
@@ -114,9 +117,9 @@ export default {
   },
 
   methods: {
-    close (event) {
-      this.isOpen = !this.isOpen;
-      this.onClose(event);
+    updateShow (open) {
+      this.isOpen = open;
+      this.toggleOpen(open);
     },
   },
 


### PR DESCRIPTION
# Modal - Emit Show event when opened and add initialFocusElement prop.

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

- Added the emit of update:show event after modal opened (previously were only emitted on close)
- Added initialFocusElement prop to enable the control of the initially focused element.

## :bulb: Context

This were missing features we had reported long time ago, adding them.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [x] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Migrate to Vue 3 and dialtone8 branches