### PR TITLE
fix(modal): secondary action button kind

### DIFF
--- a/components/modal/modal_default.story.vue
+++ b/components/modal/modal_default.story.vue
@@ -49,6 +49,7 @@
         />
         <div v-else>
           <dt-button
+            :kind="secondaryButtonKind"
             importance="clear"
           >
             Cancel
@@ -102,6 +103,10 @@ export default {
         ...this.closeButtonProps,
         ariaLabel: 'Close',
       };
+    },
+
+    secondaryButtonKind () {
+      return this.$attrs.kind === 'danger' ? 'muted' : 'default';
     },
   },
 

--- a/components/modal/modal_default.story.vue
+++ b/components/modal/modal_default.story.vue
@@ -106,7 +106,7 @@ export default {
     },
 
     secondaryButtonKind () {
-      return this.$attrs.kind === 'danger' ? 'muted' : 'default';
+      return this.kind === 'danger' ? 'muted' : 'default';
     },
   },
 


### PR DESCRIPTION
# Fix (Modal): Secondary action button kind

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Changed secondary action button kind to `muted` while modal kind is `danger` this is purely for preview purposes as action buttons are slotted into the footer.

## :bulb: Context

Changes requested by design https://dialpad.atlassian.net/browse/DIALTONE-1079?atlOrigin=eyJpIjoiNGVmOGUxYTU1NzNmNDAyZDlkNGM1ZjA2OTg2YmU2NzEiLCJwIjoiaiJ9

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

![Screenshot 2023-06-08 at 2 33 33 p m](https://github.com/dialpad/dialtone-vue/assets/87546543/7b510509-50f8-4cf3-8ac9-7056428851f5)