### PR TITLE
fix(contact-row, group-row, general-row): null on description

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -314,6 +314,16 @@ export function isEmailAddress (input) {
   return emailAddressRegex.exec(input)?.[0] === input;
 }
 
+/**
+ * Concatenate a string removing null or undefined elements
+ * avoiding parsing them as string with template strings
+ * @param {Array} elements
+ * @returns {String}
+ */
+export function safeConcatStrings (elements) {
+  return elements.filter(str => !!str).join(' ');
+}
+
 export default {
   getUniqueString,
   getRandomElement,
@@ -332,4 +342,5 @@ export default {
   isEmailAddress,
   isPhoneNumber,
   isURL,
+  safeConcatStrings,
 };

--- a/recipes/leftbar/contact_row/contact_row.vue
+++ b/recipes/leftbar/contact_row/contact_row.vue
@@ -1,7 +1,7 @@
 <template>
   <dt-recipe-general-row
     :unread-count="unreadCount"
-    :description="`${name} ${presenceText} ${userStatus}`"
+    :description="contactDescription"
     :has-unreads="hasUnreads"
     :selected="selected"
     :has-call-button="hasCallButton"
@@ -247,6 +247,12 @@ export default {
 
     avatarInitial () {
       return this.name?.[0] ?? '';
+    },
+
+    contactDescription () {
+      return [this.name, this.presenceText, this.userStatus]
+        .filter(str => !!str)
+        .join(' ');
     },
   },
 };

--- a/recipes/leftbar/contact_row/contact_row.vue
+++ b/recipes/leftbar/contact_row/contact_row.vue
@@ -72,6 +72,7 @@ import { DtRecipeGeneralRow } from '@/recipes/leftbar/general_row';
 import DtEmojiTextWrapper from '@/components/emoji_text_wrapper/emoji_text_wrapper.vue';
 import DtAvatar from '@/components/avatar/avatar.vue';
 import DtIcon from '@/components/icon/icon.vue';
+import { safeConcatStrings } from '@/common/utils.js';
 
 export default {
   name: 'DtRecipeGroupRow',
@@ -250,9 +251,7 @@ export default {
     },
 
     contactDescription () {
-      return [this.name, this.presenceText, this.userStatus]
-        .filter(str => !!str)
-        .join(' ');
+      return safeConcatStrings([this.name, this.presenceText, this.userStatus]);
     },
   },
 };

--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -134,6 +134,7 @@ import { DtButton } from '@/components/button';
 import { DtTooltip } from '@/components/tooltip';
 import DtEmojiTextWrapper from '@/components/emoji_text_wrapper/emoji_text_wrapper.vue';
 import DtRecipeLeftbarGeneralRowIcon from './leftbar_general_row_icon.vue';
+import { safeConcatStrings } from '@/common/utils.js';
 
 export default {
   name: 'DtRecipeGeneralRow',
@@ -345,7 +346,7 @@ export default {
     getAriaLabel () {
       return this.ariaLabel
         ? this.ariaLabel
-        : [this.description, this.unreadCountTooltip, this.dndTextTooltip].filter(str => !!str).join(' ');
+        : safeConcatStrings([this.description, this.unreadCountTooltip, this.dndTextTooltip]);
     },
   },
 

--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -343,7 +343,9 @@ export default {
     },
 
     getAriaLabel () {
-      return this.ariaLabel ? this.ariaLabel : `${this.description} ${this.unreadCountTooltip} ${this.dndTextTooltip}`;
+      return this.ariaLabel
+        ? this.ariaLabel
+        : [this.description, this.unreadCountTooltip, this.dndTextTooltip].filter(str => !!str).join(' ');
     },
   },
 

--- a/recipes/leftbar/group_row/group_row.vue
+++ b/recipes/leftbar/group_row/group_row.vue
@@ -22,6 +22,7 @@
 <script>
 import { DtRecipeGeneralRow } from '@/recipes/leftbar/general_row';
 import DtIcon from '@/components/icon/icon.vue';
+import { safeConcatStrings } from '@/common/utils.js';
 
 export default {
   name: 'DtRecipeGroupRow',
@@ -105,7 +106,7 @@ export default {
 
   computed: {
     ariaLabel () {
-      return [this.groupCountText, this.names].filter(str => !!str).join(' ');
+      return safeConcatStrings([this.groupCountText, this.names]);
     },
   },
 };

--- a/recipes/leftbar/group_row/group_row.vue
+++ b/recipes/leftbar/group_row/group_row.vue
@@ -1,7 +1,7 @@
 <template>
   <dt-recipe-general-row
     :description="names"
-    :aria-label="`${groupCountText} ${names}`"
+    :aria-label="ariaLabel"
     :unread-count="unreadCount"
     :has-unreads="hasUnreads"
     :unread-count-tooltip="unreadCountTooltip"
@@ -102,5 +102,11 @@ export default {
      */
     'click',
   ],
+
+  computed: {
+    ariaLabel () {
+      return [this.groupCountText, this.names].filter(str => !!str).join(' ');
+    },
+  },
 };
 </script>


### PR DESCRIPTION
# Fix (contact-row, group-row, general-row): null on description

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Removed template strings from properties in favor or array join with filter to avoid parsing `null` as 'null' string

## :bulb: Context

An issue was reported on product when hovering over contact-row on the leftbar, a 'null' string were being appended at the end of the contact-row title.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Update dialtone-vue on product