### PR TITLE
fix(callbar-button-with-popover): show popover on demand and emit mod…

### DIFF
--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
@@ -16,8 +16,10 @@ const iconsList = getIconNames();
 // Default Prop Values
 export const argsData = {
   buttonWidthSize: 'xl',
+  openPopover: false,
   onArrowClick: action('arrowClick'),
   onClick: action('click'),
+  onModalIsOpened: action('opened'),
 };
 
 export const argTypesData = {
@@ -99,6 +101,9 @@ export const argTypesData = {
       },
     },
     control: 'text',
+  },
+  openPopover: {
+    control: 'boolean',
   },
 
   // Popover slots
@@ -215,6 +220,7 @@ export const Default = {
     headerContent: 'Header content',
     showCloseButton: true,
     forceShowArrow: false,
+    openPopover: false,
     icon: 'dialpad-ai',
   },
 };

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
@@ -19,7 +19,7 @@ export const argsData = {
   openPopover: false,
   onArrowClick: action('arrowClick'),
   onClick: action('click'),
-  onModalIsOpened: action('opened'),
+  onOpened: action('opened'),
 };
 
 export const argTypesData = {
@@ -156,6 +156,24 @@ export const argTypesData = {
       },
     },
   },
+  onClick: {
+    table: {
+      disable: true,
+    },
+  },
+  opened: {
+    table: {
+      disable: false,
+      type: {
+        summary: 'event',
+      },
+    },
+  },
+  onOpened: {
+    table: {
+      disable: true,
+    },
+  },
 
   id: {
     table: {
@@ -176,18 +194,6 @@ export const argTypesData = {
     options: POPOVER_DIRECTIONS,
     control: {
       type: 'select',
-    },
-  },
-
-  // Action Event Handlers
-  onArrowClick: {
-    table: {
-      disable: true,
-    },
-  },
-  onClick: {
-    table: {
-      disable: true,
     },
   },
 };

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -36,6 +36,7 @@
       :dialog-class="['dt-recipe--callbar-button-with-popover--popover', contentClass]"
       header-class="d-d-flex d-ai-center d-fw-normal d-px12"
       v-bind="$attrs"
+      :open-popover="showPopover"
       @opened="onModalIsOpened"
     >
       <template #anchor>
@@ -233,6 +234,14 @@ export default {
       type: [String, Array, Object],
       default: '',
     },
+
+    /**
+     * To open the modal popover.
+     */
+    openPopover: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   emits: [
@@ -248,6 +257,11 @@ export default {
      * @type {PointerEvent | KeyboardEvent}
      */
     'click',
+
+    /**
+     * Emitted when modal popover is opened or closed.
+     */
+    'opened',
   ],
 
   data () {
@@ -263,6 +277,14 @@ export default {
 
     isCompactMode () {
       return this.buttonWidthSize === 'sm' || this.buttonWidthSize === 'md';
+    },
+
+    showPopover () {
+      if (!this.openPopover || this.open) {
+        return false;
+      }
+
+      return this.arrowClick();
     },
   },
 
@@ -284,6 +306,7 @@ export default {
 
     onModalIsOpened (isOpened) {
       this.open = isOpened;
+      this.$emit('opened', isOpened);
     },
   },
 

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -236,7 +236,7 @@ export default {
     },
 
     /**
-     * To open the modal popover.
+     * To auto open the modal popover.
      */
     openPopover: {
       type: Boolean,

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_default.story.vue
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_default.story.vue
@@ -14,6 +14,7 @@
     :button-width-size="buttonWidthSize"
     :text-class="textClass"
     :content-class="contentClass"
+    :open-popover="openPopover"
     @arrow-click="onClick"
     @click="onClick"
   >

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_default.story.vue
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_default.story.vue
@@ -17,6 +17,7 @@
     :open-popover="openPopover"
     @arrow-click="onClick"
     @click="onClick"
+    @opened="onOpened"
   >
     <span
       v-if="defaultSlot"


### PR DESCRIPTION
…al opened event

# PR Title

show popover on demand and emit modal opened event

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [X] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

show popover on demand and emit modal opened event.


## :bulb: Context

show popover on demand and emit modal opened event. Required to auto open the Ai Assist panel. Ubervoice PR https://github.com/dialpad/firespotter/pull/30372

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [X] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root


## :camera: Screenshots / GIFs
No UI changes in this PR.

<img width="538" alt="Screen Shot 2023-06-09 at 4 35 56 PM" src="https://github.com/dialpad/dialtone-vue/assets/70488122/2aae5c8d-179f-47ad-9bb8-ba26e4c2ba2b">

