### PR TITLE
fix(general-row): nested a tags

### DIFF
--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -106,8 +106,6 @@
               :aria-label="callButtonTooltip"
               @focus="actionFocused = true"
               @blur="actionFocused = false"
-              @mouseover="actionFocused = true"
-              @mouseleave="actionFocused = false"
               @click.stop="$emit('call', $event)"
             >
               <template #icon>

--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -46,6 +46,7 @@
       </div>
     </a>
     <div
+      v-if="hasActions"
       class="dt-leftbar-row__omega"
     >
       <dt-tooltip
@@ -80,43 +81,45 @@
             kind="count"
             type="bulletin"
             data-qa="dt-leftbar-row-unread-badge"
+            class="dt-leftbar-row__unread-badge"
           >
             {{ unreadCount }}
           </dt-badge>
         </template>
       </dt-tooltip>
-    </div>
-    <div
-      v-if="hasCallButton"
-      class="dt-leftbar-row__action"
-      data-qa="dt-leftbar-row-action"
-    >
-      <dt-tooltip
-        :message="callButtonTooltip"
-        placement="top"
+      <div
+        v-if="hasCallButton"
+        class="dt-leftbar-row__action"
+        data-qa="dt-leftbar-row-action"
       >
-        <template #anchor>
-          <dt-button
-            class="dt-leftbar-row__action-button"
-            data-qa="dt-leftbar-row-action-call-button"
-            circle
-            size="xs"
-            kind="inverted"
-            :aria-label="callButtonTooltip"
-            @focus="actionFocused = true"
-            @blur="actionFocused = false"
-            @mouseleave="actionFocused = false"
-            @click.stop="$emit('call', $event)"
-          >
-            <template #icon>
-              <dt-icon
-                name="phone"
-                size="200"
-              />
-            </template>
-          </dt-button>
-        </template>
-      </dt-tooltip>
+        <dt-tooltip
+          :message="callButtonTooltip"
+          placement="top"
+        >
+          <template #anchor>
+            <dt-button
+              class="dt-leftbar-row__action-button"
+              data-qa="dt-leftbar-row-action-call-button"
+              :circle="true"
+              size="xs"
+              kind="inverted"
+              :aria-label="callButtonTooltip"
+              @focus="actionFocused = true"
+              @blur="actionFocused = false"
+              @mouseover="actionFocused = true"
+              @mouseleave="actionFocused = false"
+              @click.stop="$emit('call', $event)"
+            >
+              <template #icon>
+                <dt-icon
+                  name="phone"
+                  size="200"
+                />
+              </template>
+            </dt-button>
+          </template>
+        </dt-tooltip>
+      </div>
     </div>
   </div>
 </template>
@@ -347,6 +350,10 @@ export default {
       return this.ariaLabel
         ? this.ariaLabel
         : safeConcatStrings([this.description, this.unreadCountTooltip, this.dndTextTooltip]);
+    },
+
+    hasActions () {
+      return this.dndText || this.activeVoiceChat || (!!this.unreadCount && this.hasUnreads) || this.hasCallButton;
     },
   },
 

--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -44,48 +44,48 @@
           </dt-emoji-text-wrapper>
         </slot>
       </div>
-      <div
-        class="dt-leftbar-row__omega"
-      >
-        <dt-tooltip
-          v-if="dndText"
-          placement="top"
-          :message="dndTextTooltip"
-        >
-          <template #anchor>
-            <div
-              class="dt-leftbar-row__dnd"
-            >
-              {{ dndText }}
-            </div>
-          </template>
-        </dt-tooltip>
-        <div
-          v-if="activeVoiceChat"
-          class="dt-leftbar-row__active-voice"
-        >
-          <dt-icon
-            size="300"
-            name="activity"
-          />
-        </div>
-        <dt-tooltip
-          v-else-if="!!unreadCount && hasUnreads"
-          :message="unreadCountTooltip"
-          placement="top"
-        >
-          <template #anchor>
-            <dt-badge
-              kind="count"
-              type="bulletin"
-              data-qa="dt-leftbar-row-unread-badge"
-            >
-              {{ unreadCount }}
-            </dt-badge>
-          </template>
-        </dt-tooltip>
-      </div>
     </a>
+    <div
+      class="dt-leftbar-row__omega"
+    >
+      <dt-tooltip
+        v-if="dndText"
+        placement="top"
+        :message="dndTextTooltip"
+      >
+        <template #anchor>
+          <div
+            class="dt-leftbar-row__dnd"
+          >
+            {{ dndText }}
+          </div>
+        </template>
+      </dt-tooltip>
+      <div
+        v-if="activeVoiceChat"
+        class="dt-leftbar-row__active-voice"
+      >
+        <dt-icon
+          size="300"
+          name="activity"
+        />
+      </div>
+      <dt-tooltip
+        v-else-if="!!unreadCount && hasUnreads"
+        :message="unreadCountTooltip"
+        placement="top"
+      >
+        <template #anchor>
+          <dt-badge
+            kind="count"
+            type="bulletin"
+            data-qa="dt-leftbar-row-unread-badge"
+          >
+            {{ unreadCount }}
+          </dt-badge>
+        </template>
+      </dt-tooltip>
+    </div>
     <div
       v-if="hasCallButton"
       class="dt-leftbar-row__action"

--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -72,7 +72,7 @@
         />
       </div>
       <dt-tooltip
-        v-else-if="!!unreadCount && hasUnreads"
+        v-else-if="showUnreadCount"
         :message="unreadCountTooltip"
         placement="top"
       >
@@ -351,7 +351,11 @@ export default {
     },
 
     hasActions () {
-      return this.dndText || this.activeVoiceChat || (!!this.unreadCount && this.hasUnreads) || this.hasCallButton;
+      return this.dndText || this.activeVoiceChat || this.showUnreadCount || this.hasCallButton;
+    },
+
+    showUnreadCount () {
+      return !!this.unreadCount && this.hasUnreads;
     },
   },
 

--- a/recipes/leftbar/style/leftbar_row.less
+++ b/recipes/leftbar/style/leftbar_row.less
@@ -16,7 +16,7 @@
   --leftbar-row-alpha-height: calc(var(--size-300) * 9);
   --leftbar-row-omega-min-width: 0;
   --leftbar-row-omega-height: var(--leftbar-row-alpha-height);
-  --leftbar-row-omega-visibility: visible;
+  --leftbar-row-omega-display: block;
   --leftbar-row-description-font-weight: var(--fw-normal);
   --leftbar-row-description-font-size: var(--fs-200);
   --leftbar-row-description-line-height: var(--lh-200);
@@ -34,13 +34,12 @@
   position: relative;
   opacity: var(--leftbar-row-opacity);
   display: flex;
-  background-color: var(--leftbar-row-color-background);
+  background-color: var(--theme-sidebar-row-color-background);
   border-radius: var(--leftbar-row-radius);
   transition-duration: var(--td200);
   transition-property: background-color,border,box-shadow;
   transition-timing-function: var(--ttf-out-quint);
   cursor: pointer;
-  //overflow: hidden;
 
   //  ============================================================================
   //  $   VARIANTS
@@ -51,15 +50,12 @@
   //  </div>
   //
   &:not(.dt-leftbar-row--no-action):hover {
-    --leftbar-row-omega-visibility: hidden;
+    --leftbar-row-omega-display: none;
     --leftbar-row-omega-min-width: var(--leftbar-row-alpha-width);
   }
 
-  &:not(.dt-leftbar-row--action-focused):hover {
-    --leftbar-row-color-background: var(--theme-sidebar-row-color-background-hover);
-  }
-
   &:hover {
+      --leftbar-row-color-background: var(--theme-sidebar-row-color-background-hover);
     .d-presence {
       --presence-color-border-base: var(--theme-sidebar-selected-row-color-background);
     }
@@ -86,7 +82,7 @@
   }
 
   &--action-focused {
-    --leftbar-row-omega-visibility: hidden;
+    --leftbar-row-omega-display: none;
     --leftbar-row-omega-min-width: var(--leftbar-row-alpha-width);
   }
 
@@ -144,6 +140,7 @@
     flex: 1;
     width: 100%;
     text-align: left;
+    background-color: var(--leftbar-row-color-background);
     color: var(--leftbar-row-color-foreground);
     text-decoration: none;
     appearance: none;
@@ -152,6 +149,7 @@
     margin: 0;
     border: 0;
     padding: 0;
+    border-radius: var(--leftbar-row-radius);
 
     &:active {
       --leftbar-row-color-background: var(--theme-sidebar-row-color-background-active);
@@ -164,7 +162,7 @@
 
   &__action {
     position: absolute;
-    right: var(--leftbar-row-action-position-right);
+    right: 0;
     top: var(--leftbar-row-action-position-bottom);
     transform: translateY(calc(var(--leftbar-row-action-position-bottom) * -1));
   }
@@ -198,6 +196,7 @@
     padding-right: var(--space-400);
     width: var(--leftbar-row-alpha-width);
     height: var(--leftbar-row-alpha-height);
+    border-radius: var(--leftbar-row-radius) 0 0 var(--leftbar-row-radius);;
   }
 
   &__label {
@@ -206,20 +205,20 @@
   }
 
   &__omega {
+    position: absolute;
     display: flex;
+    right: var(--leftbar-row-action-position-right);
+    top: var(--leftbar-row-action-position-bottom);
+    transform: translateY(calc(var(--leftbar-row-action-position-bottom) * -1));
     gap: var(--space-300);
     justify-content: end;
     align-items: center;
     box-sizing: border-box;
-    min-width: var(--leftbar-row-omega-min-width);
-    height: var(--leftbar-row-omega-height);
-    padding-left: var(--space-400);
-    padding-right: var(--space-400);
     border-radius: var(--leftbar-row-radius);
   }
 
   &__unread-badge {
-    visibility: var(--leftbar-row-omega-visibility);
+    display: var(--leftbar-row-omega-display);
   }
 
   &__active-voice {

--- a/recipes/leftbar/style/leftbar_row.less
+++ b/recipes/leftbar/style/leftbar_row.less
@@ -33,6 +33,13 @@
   //  ----------------------------------------------------------------------------
   position: relative;
   opacity: var(--leftbar-row-opacity);
+  display: flex;
+  background-color: var(--leftbar-row-color-background);
+  border-radius: var(--leftbar-row-radius);
+  transition-duration: var(--td200);
+  transition-property: background-color,border,box-shadow;
+  transition-timing-function: var(--ttf-out-quint);
+  cursor: pointer;
 
   //  ============================================================================
   //  $   VARIANTS
@@ -47,6 +54,8 @@
   }
 
   &:hover {
+    --leftbar-row-color-background: var(--theme-sidebar-row-color-background-hover);
+
     .d-presence {
       --presence-color-border-base: var(--theme-sidebar-selected-row-color-background);
     }
@@ -137,22 +146,12 @@
     text-align: left;
     color: var(--leftbar-row-color-foreground);
     text-decoration: none;
-    background-color: var(--leftbar-row-color-background);
-    border-radius: var(--leftbar-row-radius);
-    transition-duration: var(--td200);
-    transition-property: background-color,border,box-shadow;
-    transition-timing-function: var(--ttf-out-quint);
     appearance: none;
     font-size: inherit;
     line-height: inherit;
     margin: 0;
     border: 0;
     padding: 0;
-    cursor: pointer;
-
-    &:hover {
-      --leftbar-row-color-background: var(--theme-sidebar-row-color-background-hover);
-    }
 
     &:active {
       --leftbar-row-color-background: var(--theme-sidebar-row-color-background-active);

--- a/recipes/leftbar/style/leftbar_row.less
+++ b/recipes/leftbar/style/leftbar_row.less
@@ -40,6 +40,7 @@
   transition-property: background-color,border,box-shadow;
   transition-timing-function: var(--ttf-out-quint);
   cursor: pointer;
+  //overflow: hidden;
 
   //  ============================================================================
   //  $   VARIANTS
@@ -50,12 +51,15 @@
   //  </div>
   //
   &:not(.dt-leftbar-row--no-action):hover {
+    --leftbar-row-omega-visibility: hidden;
     --leftbar-row-omega-min-width: var(--leftbar-row-alpha-width);
   }
 
-  &:hover {
+  &:not(.dt-leftbar-row--action-focused):hover {
     --leftbar-row-color-background: var(--theme-sidebar-row-color-background-hover);
+  }
 
+  &:hover {
     .d-presence {
       --presence-color-border-base: var(--theme-sidebar-selected-row-color-background);
     }
@@ -67,10 +71,6 @@
   &--has-unread {
     --leftbar-row-description-font-weight: var(--fw-bold);
     --leftbar-row-alpha-color-foreground: var(--leftbar-row-color-foreground);
-
-    &:not(.dt-leftbar-row--no-action):hover {
-      --leftbar-row-omega-visibility: hidden;
-    }
   }
 
   &--muted {
@@ -215,6 +215,10 @@
     height: var(--leftbar-row-omega-height);
     padding-left: var(--space-400);
     padding-right: var(--space-400);
+    border-radius: var(--leftbar-row-radius);
+  }
+
+  &__unread-badge {
     visibility: var(--leftbar-row-omega-visibility);
   }
 


### PR DESCRIPTION
# Fix (General row) Remove nested <a> tags

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Moved `dt-leftbar-row__omega` out of the `<a class="dt-leftbar-row__primary" ...>` parent to avoid nesting <a> within <a> tags.

## :bulb: Context

Is not correct to nest <a> tags within <button> or <button> within <button> tags, this will prevent such situations.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

![image](https://github.com/dialpad/dialtone-vue/assets/87546543/1c7e3e61-57cb-4a4d-b567-5f230efb3454)
![image](https://github.com/dialpad/dialtone-vue/assets/87546543/79bb6722-376e-4987-8f22-0a565f512cc5)
![image](https://github.com/dialpad/dialtone-vue/assets/87546543/ca900b74-8eea-4aa3-b0fc-25079b9b73a2)
