### PR TITLE
fix: "call bar button" popover arrow icon color for dark mode

### DIFF
--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -52,6 +52,7 @@
           <template #icon>
             <dt-icon
               name="chevron-up"
+              class="d-fc-black-800"
               size="200"
             />
           </template>


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Just a quick fix of "Call Bar Button" popover arrow icon color for dark mode.


## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

Before fix:
 
![Screenshot 2023-06-19 at 2 37 24 PM](https://github.com/dialpad/dialtone-vue/assets/61763780/dce8b8c3-78e1-4742-8eb8-4aaeb34d0c1d)

After fix:

![Screenshot 2023-06-19 at 2 38 23 PM](https://github.com/dialpad/dialtone-vue/assets/61763780/0c6e606e-3a86-4128-87b0-b83ad84b4ed5)


## :link: Sources

Vue3 PR: https://github.com/dialpad/dialtone-vue/pull/1027