### PR TITLE
fix(rich-text-editor): add a check and workaround for phone regex

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -262,8 +262,19 @@ const emailAddressRegex = new RegExp(
  * @returns {RegExp}
  */
 export function getPhoneNumberRegex (minLength = 7, maxLength = 15) {
+  // Some older browser versions don't support lookbehind, so provide a RegExp
+  // version without it. It fails just one test case, so IMO it's still good
+  // enough to use. https://caniuse.com/js-regexp-lookbehind
+  let canUseLookBehind = true;
+  try {
+    // eslint-disable-next-line prefer-regex-literals
+    RegExp('(?<=\\W)');
+  } catch (e) {
+    canUseLookBehind = false;
+  }
   return new RegExp(
-    '(?:^|(?<=\\W))(?![\\s\\-])\\+?(?:[0-9()\\- \\t]' +
+    `${canUseLookBehind ? '(?:^|(?<=\\W))' : ''}` +
+    '(?![\\s\\-])\\+?(?:[0-9()\\- \\t]' +
     `{${minLength},${maxLength}}` +
     ')(?=\\b)(?=\\W(?=\\W|$)|\\s|$)',
   );


### PR DESCRIPTION
# UC-18072: add a check and workaround for phone regex

So this regex I added fails on some older browser versions in a spectacular way that renders the whole app unusable. I didn't realize that the support for [lookbehind is so bad](https://caniuse.com/js-regexp-lookbehind) in JavaScript, so we need some workaround for it. I couldn't find a completely working alternative, but just omitting that part works for all except one edge case (+1234567890123456 will match the last 15 characters when it should discard the whole match), so I _think_ this is good enough.

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation
