### PR TITLE
fix(rich-text-editor): fix v-model not working

### DIFF
--- a/components/rich_text_editor/extensions/link/utils.js
+++ b/components/rich_text_editor/extensions/link/utils.js
@@ -115,8 +115,8 @@ export function getWordAtUntil (text, index, direction, regex) {
  * Remove marks from a range.
  */
 export function removeMarks (range, doc, tr, type) {
-  const from = range.from - 1;
-  const to = range.to + 1;
+  const from = Math.max(range.from - 1, 0);
+  const to = Math.min(range.to + 1, doc.content.size);
   const marksInRange = getMarksBetween(from, to, doc);
 
   for (const mark of marksInRange) {


### PR DESCRIPTION
# Fix v-model not working properly in Rich Text Editor

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Currently if you try to pass a new value using v-model to the Rich Text Editor it'll fail with an error `Cannot read properties of undefined (reading 'nodeSize')`. This is caused by a bug in the Link extension where basically I was too liberal with the way how I defined the range for the changed content and this caused problems deeper in TipTap's code. The fix is to limit the `from` and `to` ranges to not exceed the actual size of the content.