### PR TITLE
chore: hovercard demo with popover

### DIFF
--- a/components/popover/popover_variants.story.vue
+++ b/components/popover/popover_variants.story.vue
@@ -446,6 +446,64 @@
         </p>
       </template>
     </dt-popover>
+
+    <dt-popover
+      :modal="false"
+      :hide-on-click="true"
+      transition="fade"
+      initial-focus-element="#call-user-button"
+      content-class="d-pl12 d-pr16"
+      class="d-my128 d-jc-flex-end"
+      max-height="20rem"
+      max-width="50rem"
+      :open.sync="showHoverCard"
+    >
+      <template #anchor="{ attrs }">
+        <!-- eslint-disable-next-line vuejs-accessibility/mouse-events-have-key-events -->
+        <dt-link
+          v-bind="attrs"
+          @mouseover="toggleHoverCard(true)"
+          @mouseout="toggleHoverCard(false)"
+        >
+          @josephlumaban
+        </dt-link>
+      </template>
+      <template #content>
+        <dt-recipe-contact-info
+          avatar-initials="JL"
+          avatar-size="LG"
+          avatar-seed="some-seed"
+          presence="active"
+        >
+          <template #header>
+            <div class="d-fs-200 d-fw-bold">
+              Joseph Lumaban
+            </div>
+          </template>
+          <template #subtitle>
+            <div class="d-fs-100 d-mt2">
+              +1 (415) 123-4567
+            </div>
+          </template>
+        </dt-recipe-contact-info>
+        <div class="d-d-flex d-jc-flex-end d-mt8">
+          <dt-button
+            id="call-user-button"
+            size="xs"
+            importance="outlined"
+            kind="muted"
+          >
+            <template #icon>
+              <dt-icon
+                name="phone"
+                size="200"
+              />
+            </template>
+            Call user
+          </dt-button>
+        </div>
+      </template>
+    </dt-popover>
   </div>
 </template>
 
@@ -456,21 +514,26 @@ import { DtDropdown } from '@/components/dropdown';
 import { DtListItem } from '@/components/list_item';
 import { DtTooltip } from '@/components/tooltip';
 import { DtIcon } from '@/components/icon';
+import { DtLink } from '@/components/link';
+import { DtRecipeContactInfo } from '@/recipes/list_items/contact_info';
 
 export default {
   name: 'PopoverVariantsStory',
   components: {
+    DtRecipeContactInfo,
     DtPopover,
     DtButton,
     DtDropdown,
     DtTooltip,
     DtIcon,
     DtListItem,
+    DtLink,
   },
 
   data () {
     return {
       openPopoverWithTriggerOverride: this.open,
+      showHoverCard: false,
       sampleText: `Lorem ipsum dolor sit amet, consectetur adipisicing elit.
             Consequuntur delectus distinctio id iure labore,
             maiores mollitia reprehenderit sunt tempore veritatis.
@@ -480,6 +543,10 @@ export default {
   },
 
   methods: {
+    toggleHoverCard (show) {
+      this.showHoverCard = show;
+    },
+
     onMouseOver () {
       this.openPopoverWithTriggerOverride = true;
     },


### PR DESCRIPTION
# HoverCard Demo

## :book: Description

I made an investigation about existing Hover Cards, the results are written down on this [JIRA ticket](https://dialpad.atlassian.net/browse/DLT-1036)

Created a HoverCard demo using the popover as is, just setting up properties.

We might need to adjust the popover behavior to achieve the proper HoverCard behavior but I think this is really close to what we would need to do with HoverCard.

You can find the demo under components/popover/variants

## :bulb: Context

*This is not for review, just so we can play with the demo as comment about it*

## :crystal_ball: Next Steps

- Talk with the team about the research on existing HoverCards.
- Determine the proper behavior we want on the HoverCard.

## :camera: Screenshots / GIFs

<img width="311" alt="Screenshot 2023-06-27 at 5 51 59 p m" src="https://github.com/dialpad/dialtone-vue/assets/87546543/1a948c73-00c1-4963-b9dc-546eb47d1373">