### PR TITLE
fix(general-row): resize observer

### DIFF
--- a/recipes/leftbar/contact_row/contact_row.stories.js
+++ b/recipes/leftbar/contact_row/contact_row.stories.js
@@ -60,7 +60,7 @@ export const argTypesData = {
 };
 
 const decorator = () => ({
-  template: '<div class="d-w264 d-theme-sidebar-bgc d-p8"><story /></div>',
+  template: '<div class="d-wmx264 d-theme-sidebar-bgc d-p8"><story /></div>',
 });
 
 // Story Collection

--- a/recipes/leftbar/general_row/general_row.stories.js
+++ b/recipes/leftbar/general_row/general_row.stories.js
@@ -81,7 +81,7 @@ export const argTypesData = {
 };
 
 const decorator = () => ({
-  template: '<div class="d-w264 d-theme-sidebar-bgc d-p8"><story /></div>',
+  template: '<div class="d-wmx264 d-theme-sidebar-bgc d-p8"><story /></div>',
 });
 
 // Story Collection

--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -376,17 +376,13 @@ export default {
     },
   },
 
-  beforeUpdate () {
-    this.handleResize();
-  },
-
-  mounted: function () {
-    this.handleResize();
-    window.addEventListener('resize', this.handleResize);
+  mounted () {
+    this.resizeObserver = new ResizeObserver(this.handleResize);
+    this.resizeObserver.observe(this.$el);
   },
 
   beforeDestroy: function () {
-    window.removeEventListener('resize', this.handleResize);
+    this.resizeObserver.disconnect();
   },
 
   methods: {

--- a/recipes/leftbar/general_row/general_row_variants.story.vue
+++ b/recipes/leftbar/general_row/general_row_variants.story.vue
@@ -47,6 +47,16 @@
         color="magenta-200"
       />
     </div>
+    <div>
+      <h3>
+        Contact Center with active voice chat
+      </h3>
+      <dt-recipe-general-row
+        :active-voice-chat="true"
+        description="Long contact center name"
+        color="magenta-200"
+      />
+    </div>
   </dt-stack>
 </template>
 

--- a/recipes/leftbar/group_row/group_row.stories.js
+++ b/recipes/leftbar/group_row/group_row.stories.js
@@ -29,7 +29,7 @@ export const argTypesData = {
 };
 
 const decorator = () => ({
-  template: '<div class="d-w264 d-theme-sidebar-bgc d-p8"><story /></div>',
+  template: '<div class="d-wmx264 d-theme-sidebar-bgc d-p8"><story /></div>',
 });
 
 // Story Collection

--- a/recipes/leftbar/style/leftbar_row.less
+++ b/recipes/leftbar/style/leftbar_row.less
@@ -52,7 +52,7 @@
   &:not(.dt-leftbar-row--no-action):focus-within {
     --leftbar-row-unread-badge-display: none;
 
-    &::v-deep .dt-leftbar-row__action {
+    &:deep(.dt-leftbar-row__action) {
       display: inline-flex;
     }
 
@@ -64,11 +64,11 @@
   &:hover, &:focus-within {
     --leftbar-row-color-background: var(--theme-sidebar-row-color-background-hover);
 
-    &::v-deep .d-presence {
+    &:deep(.d-presence) {
       --presence-color-border-base: var(--theme-sidebar-selected-row-color-background);
     }
 
-    &::v-deep .d-avatar__count {
+    &:deep(.d-avatar__count) {
       --avatar-count-color-shadow: var(--theme-sidebar-selected-row-color-background);
     }
   }
@@ -77,7 +77,7 @@
     --leftbar-row-description-font-weight: var(--fw-bold);
     --leftbar-row-alpha-color-foreground: var(--leftbar-row-color-foreground);
 
-    &::v-deep .dt-leftbar-row__action {
+    &:deep(.dt-leftbar-row__action) {
       display: none;
     }
   }
@@ -90,7 +90,7 @@
     --leftbar-row-color-background: var(--theme-sidebar-selected-row-color-background);
     --leftbar-row-color-foreground: var(--theme-sidebar-selected-row-color);
 
-    &::v-deep .d-avatar__count {
+    &:deep(.d-avatar__count) {
       --avatar-count-color-shadow: var(--theme-sidebar-selected-row-color-background);
     }
   }
@@ -274,7 +274,7 @@
   }
 
   &__meta-custom:not(:empty) {
-    &::v-deep .dt-leftbar-row__meta-context ~ &:before {
+    &:deep(.dt-leftbar-row__meta-context ~ &:before) {
       content: ' • ';
       color: var(--theme-sidebar-status-color);
     }

--- a/recipes/leftbar/style/leftbar_row.less
+++ b/recipes/leftbar/style/leftbar_row.less
@@ -15,7 +15,7 @@
   --leftbar-row-alpha-width: calc(var(--size-300) * 10);
   --leftbar-row-alpha-height: calc(var(--size-300) * 9);
   --leftbar-row-omega-height: var(--leftbar-row-alpha-height);
-  --leftbar-row-omega-display: inline-flex;
+  --leftbar-row-unread-badge-display: inline-flex;
   --leftbar-row-description-font-weight: var(--fw-normal);
   --leftbar-row-description-font-size: var(--fs-200);
   --leftbar-row-description-line-height: var(--lh-200);
@@ -48,15 +48,20 @@
   //    ...
   //  </div>
   //
-  &:not(.dt-leftbar-row--no-action):hover {
-    --leftbar-row-omega-display: none;
+  &:not(.dt-leftbar-row--no-action):hover,
+  &:not(.dt-leftbar-row--no-action):focus-within {
+    --leftbar-row-unread-badge-display: none;
 
     &::v-deep .dt-leftbar-row__action {
       display: inline-flex;
     }
+
+    &:deep(.dt-leftbar-row__action-button) {
+      opacity: 1;
+    }
   }
 
-  &:hover {
+  &:hover, &:focus-within {
     --leftbar-row-color-background: var(--theme-sidebar-row-color-background-hover);
 
     &::v-deep .d-presence {
@@ -88,10 +93,6 @@
     &::v-deep .d-avatar__count {
       --avatar-count-color-shadow: var(--theme-sidebar-selected-row-color-background);
     }
-  }
-
-  &--action-focused {
-    --leftbar-row-omega-display: none;
   }
 
   &__is-typing {
@@ -174,11 +175,6 @@
     opacity: 0;
     width: var(--leftbar-row-action-width);
     height: var(--leftbar-row-action-height);
-
-    .dt-leftbar-row:hover &,
-    &:focus-visible {
-      opacity: 1;
-    }
   }
 
   //  ============================================================================
@@ -221,11 +217,13 @@
   }
 
   &__unread-badge {
-    display: var(--leftbar-row-omega-display);
+    display: var(--leftbar-row-unread-badge-display);
   }
 
   &__active-voice {
     color: var(--fc-success);
+    display: inline-flex;
+
     .opacity-pulsate();
   }
 
@@ -250,7 +248,7 @@
   //    <span class="dt-leftbar-row__meta-custom">...</span>
   //  </div>
   //
-  &__description {
+  &:deep(&__description) {
     display: block;
     font-weight: var(--leftbar-row-description-font-weight);
     font-size: var(--leftbar-row-description-font-size);
@@ -260,7 +258,7 @@
     white-space: nowrap;
   }
 
-  &__status {
+  &:deep(&__status) {
     display: block;
     color: var(--leftbar-row-status-color-foreground);
     font-size: var(--leftbar-row-status-font-size);


### PR DESCRIPTION
# General row: fix resize eventListener 

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

- Changed resize event listener to a resize observer to detect the resizing of the element in a more accurate way.
- Added an example including active voice chat.
- Fixed behavior
  - Call button were not appearing while keyboard focusing the item
  - Active voice chat icon where not properly aligned

## :bulb: Context

We were having issue on product due to the item not detecting the resizing of the sidebar.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

<img width="1378" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/87546543/f49b2735-f619-44fb-bda0-a9bca353386b">
<img width="1390" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/87546543/4f5647d1-c2fd-4419-9210-ec52973b218a">
<img width="1381" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/87546543/587ff9b2-7e4f-4a6c-929b-faa2307ba42b">
<img width="364" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/87546543/4c117bc1-4ed2-4f1a-9b2a-661d1ae824a3">


## :link: Sources

https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
