### PR TITLE
fix: add customized css to badge label and contact info

### DIFF
--- a/components/badge/badge.stories.js
+++ b/components/badge/badge.stories.js
@@ -72,6 +72,10 @@ export const argTypesData = {
     options: [undefined, ...Object.keys(BADGE_DECORATION_MODIFIERS)],
     // TODO: Find a way to add conditions on more than one argument
   },
+
+  labelClass: {
+    description: 'Pass through classes. Used to customize the label container',
+  },
 };
 
 // Story Collection

--- a/components/badge/badge.vue
+++ b/components/badge/badge.vue
@@ -21,7 +21,7 @@
         size="200"
       />
     </span>
-    <span class="d-badge__label">
+    <span :class="['d-badge__label', labelClass]">
       <!-- @slot Slot for badge content, defaults to text prop -->
       <slot>
         {{ text }}
@@ -114,6 +114,14 @@ export default {
       type: String,
       default: undefined,
       validator: (type) => Object.keys(BADGE_DECORATION_MODIFIERS).includes(type),
+    },
+
+    /**
+     * Used to customize the label container
+     */
+    labelClass: {
+      type: [String, Array, Object],
+      default: '',
     },
   },
 

--- a/components/badge/badge_default.story.vue
+++ b/components/badge/badge_default.story.vue
@@ -6,6 +6,7 @@
     :decoration="decoration"
     :icon-left="iconLeft"
     :icon-right="iconRight"
+    :label-class="labelClass"
   >
     <template v-if="defaultSlot">
       {{ defaultSlot }}

--- a/recipes/list_items/contact_info/contact_info.vue
+++ b/recipes/list_items/contact_info/contact_info.vue
@@ -4,6 +4,7 @@
     :role="role"
     element-type="div"
     data-qa="contact-info"
+    class="dt-contact-info"
   >
     <template #left>
       <div
@@ -219,3 +220,25 @@ export default {
   },
 };
 </script>
+
+<style>
+.dt-contact-info .dt-item-layout--content {
+  /*
+  DP-74536: Add `min-width` to make the width of "contact info" adjustable.
+  */
+  min-width: var(--space-825);
+}
+.dt-contact-info .dt-item-layout--left {
+  /*
+  DP-74536: To make 'Avatar' in fixed position when resizing the window.
+  */
+  min-width: var(--space-650);
+  justify-content: flex-start;
+}
+.dt-contact-info .dt-item-layout--right {
+  /*
+  DP-74536: Remove `min-width` which cause extra unused empty space on the right of "contact info".
+  */
+  min-width: 0;
+}
+</style>

--- a/recipes/list_items/contact_info/contact_info.vue
+++ b/recipes/list_items/contact_info/contact_info.vue
@@ -221,7 +221,7 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
 .dt-contact-info .dt-item-layout--content {
   /*
   DP-74536: Add `min-width` to make the width of "contact info" adjustable.


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

This pull request adds a property to customize the CSS for badge label and adds fix css for Contact Info conponent.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Make a new release for Dialtone-Vue

## :camera: Screenshots / GIFs
![Screenshot 2023-07-17 at 6 47 17 PM](https://github.com/dialpad/dialtone-vue/assets/61763780/19a2fb97-28e1-44c4-bf1f-ab50e9d84f56)

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

JIRA: https://dialpad.atlassian.net/browse/DP-74536
Vue3 PR: https://github.com/dialpad/dialtone-vue/pull/1077