### PR TITLE
fix: `contact_info` style override issue (Vue3)

### DIFF
--- a/recipes/list_items/contact_info/contact_info.vue
+++ b/recipes/list_items/contact_info/contact_info.vue
@@ -221,21 +221,21 @@ export default {
 };
 </script>
 
-<style>
-.dt-contact-info .dt-item-layout--content {
+<style scoped>
+.dt-contact-info :deep(.dt-item-layout--content) {
   /*
   DP-74536: Add `min-width` to make the width of "contact info" adjustable.
   */
   min-width: var(--space-825);
 }
-.dt-contact-info .dt-item-layout--left {
+.dt-contact-info :deep(.dt-item-layout--left) {
   /*
   DP-74536: To make 'Avatar' in fixed position when resizing the window.
   */
   min-width: var(--space-650);
   justify-content: flex-start;
 }
-.dt-contact-info .dt-item-layout--right {
+.dt-contact-info :deep(.dt-item-layout--right) {
   /*
   DP-74536: Remove `min-width` which cause extra unused empty space on the right of "contact info".
   */

--- a/recipes/list_items/contact_info/contact_info.vue
+++ b/recipes/list_items/contact_info/contact_info.vue
@@ -221,7 +221,7 @@ export default {
 };
 </script>
 
-<style scoped>
+<style>
 .dt-contact-info .dt-item-layout--content {
   /*
   DP-74536: Add `min-width` to make the width of "contact info" adjustable.


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Per comment: https://github.com/dialpad/dialtone-vue/pull/1077#discussion_r1267416074
~With `scoped` tag, the `min-width` override does not work. It looks like after `scoped` tag is added, `<style>` can only override contact_info (and if `vue` find this is not `contact_info` component element, it will just ignore this override).~ We should use :deep() to access to
```
.dt-item-layout--content
.dt-item-layout--left
.dt-item-layout--right
```
Because these classes are on `item_layout.vue` component, that is a different component.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Make a new release for Dialtone-Vue

## :link: Sources

Original pull request: https://github.com/dialpad/dialtone-vue/pull/1077#discussion_r1267416074
Vue2 pull request: https://github.com/dialpad/dialtone-vue/pull/1078