### PR TITLE
fix(combobox-multi-select): fix ref not existing error

### DIFF
--- a/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -383,13 +383,8 @@ export default {
 
   watch: {
     selectedItems: {
-      immediate: true,
       async handler () {
-        await this.$nextTick();
-        this.setInputPadding();
-        this.setChipsTopPosition();
-        this.setInputMinWidth();
-        this.checkMaxSelected();
+        this.initSelectedItems();
       },
     },
 
@@ -414,8 +409,6 @@ export default {
         this.setInputPadding();
         this.setChipsTopPosition();
       },
-
-      immediate: true,
     },
   },
 
@@ -426,6 +419,8 @@ export default {
       this.setInputPadding();
     });
     this.resizeWindowObserver.observe(document.body);
+
+    this.initSelectedItems();
   },
 
   beforeDestroy () {
@@ -433,6 +428,14 @@ export default {
   },
 
   methods: {
+    async initSelectedItems () {
+      await this.$nextTick();
+      this.setInputPadding();
+      this.setChipsTopPosition();
+      this.setInputMinWidth();
+      this.checkMaxSelected();
+    },
+
     onChipRemove (item) {
       this.$emit('remove', item);
       this.$refs.input?.focus();


### PR DESCRIPTION
# fix(combobox-multi-select): fix ref not existing error

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Related to https://dialpad.atlassian.net/browse/DP-71242

## :bulb: Context

Error found in product for multiselect. Immediate watchers initialize BEFORE mount so any interactions with the dom are potentially going to be undefined. Changed this init to run on mounted rather than on watcher init, should fix the issue.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Update in other branches / product.
