### PR TITLE
fix(tooltip): change anchor tag to span

### DIFF
--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -1,9 +1,10 @@
 <template>
-  <div data-qa="dt-tooltip-container">
-    <a
+  <span data-qa="dt-tooltip-container">
+    <!-- disabling as the below events are for capturing events from interactive
+         elements within the span rather than on the span itself -->
+    <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
+    <span
       ref="anchor"
-      tabindex="-1"
-      role="presentation"
       data-qa="dt-tooltip-anchor"
       @focusin="onEnterAnchor"
       @focusout="onLeaveAnchor"
@@ -15,7 +16,7 @@
       <slot
         name="anchor"
       />
-    </a>
+    </span>
     <dt-lazy-show
       :id="id"
       ref="content"
@@ -42,7 +43,7 @@
         {{ message }}
       </slot>
     </dt-lazy-show>
-  </div>
+  </span>
 </template>
 
 <script>


### PR DESCRIPTION
# fix(tooltip): change anchor tag to span

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Changed anchor tag on tooltip to a span. I think the real issue was just that it needed to be a `display: inline` element rather than a `display: block` element, so no reason for the `<a>` tag

## :bulb: Context

Users were sometimes having a tooltip navigate to the root page when clicked because it was wrapped in an `<a>` tag. Additionally it is invalid html to have buttons nested within `<a>` tags which is a very common way to use a tooltip.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
