### PR TITLE
fix(general-row): call resize handler on mounted

### DIFF
--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -379,6 +379,7 @@ export default {
   mounted () {
     this.resizeObserver = new ResizeObserver(this.handleResize);
     this.resizeObserver.observe(this.$el);
+    this.handleResize();
   },
 
   beforeDestroy: function () {
@@ -393,7 +394,7 @@ export default {
       }
     },
 
-    async handleResize () {
+    handleResize () {
       const labelWidth = this.$el?.querySelector('.dt-leftbar-row__primary')?.clientWidth || 0;
       const omegaWidth = this.$el?.querySelector('.dt-leftbar-row__omega')?.clientWidth || 0;
       const alphaWidth = this.$el?.querySelector('.dt-leftbar-row__alpha')?.clientWidth || 0;


### PR DESCRIPTION
# Fix (General row): Call resize handler on mounted

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added `this.handleResize()` call on mounted function to call the resizeObserver when reloading.

## :bulb: Context

A bug is persisting on product, unread badge keeps overlapping the names of the contact centers.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Update dialtone8 branch, release, update on product and CP