### PR TITLE
fix(general-row): adjust label width on prop change

### DIFF
--- a/recipes/leftbar/general_row/general_row.vue
+++ b/recipes/leftbar/general_row/general_row.vue
@@ -332,6 +332,7 @@ export default {
         {
           'dt-leftbar-row--no-action': !this.hasCallButton,
           'dt-leftbar-row--has-unread': this.hasUnreads,
+          'dt-leftbar-row--unread-count': this.showUnreadCount,
           'dt-leftbar-row--selected': this.selected,
           'dt-leftbar-row--muted': this.muted,
           'dt-leftbar-row--action-focused': this.actionFocused,
@@ -370,16 +371,18 @@ export default {
     $props: {
       immediate: true,
       deep: true,
-      handler () {
+      async handler () {
         this.validateProps();
+        await this.$nextTick();
+        this.adjustLabelWidth();
       },
     },
   },
 
   mounted () {
-    this.resizeObserver = new ResizeObserver(this.handleResize);
+    this.resizeObserver = new ResizeObserver(this.adjustLabelWidth);
     this.resizeObserver.observe(this.$el);
-    this.handleResize();
+    this.adjustLabelWidth();
   },
 
   beforeDestroy: function () {
@@ -389,12 +392,12 @@ export default {
   methods: {
     validateProps () {
       if (this.type === LEFTBAR_GENERAL_ROW_TYPES.CONTACT_CENTER &&
-          !Object.keys(LEFTBAR_GENERAL_ROW_CONTACT_CENTER_COLORS).includes(this.color)) {
+        !Object.keys(LEFTBAR_GENERAL_ROW_CONTACT_CENTER_COLORS).includes(this.color)) {
         console.error(LEFTBAR_GENERAL_ROW_CONTACT_CENTER_VALIDATION_ERROR);
       }
     },
 
-    handleResize () {
+    adjustLabelWidth () {
       const labelWidth = this.$el?.querySelector('.dt-leftbar-row__primary')?.clientWidth || 0;
       const omegaWidth = this.$el?.querySelector('.dt-leftbar-row__omega')?.clientWidth || 0;
       const alphaWidth = this.$el?.querySelector('.dt-leftbar-row__alpha')?.clientWidth || 0;

--- a/recipes/leftbar/style/leftbar_row.less
+++ b/recipes/leftbar/style/leftbar_row.less
@@ -76,7 +76,9 @@
   &--has-unread {
     --leftbar-row-description-font-weight: var(--fw-bold);
     --leftbar-row-alpha-color-foreground: var(--leftbar-row-color-foreground);
+  }
 
+  &--unread-count {
     &:deep(.dt-leftbar-row__action) {
       display: none;
     }


### PR DESCRIPTION
# Fix (General row): Adjust label width on prop change

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added `adjustLabelWidth` to `$props` watcher to make sure we're adjusting the width of the component after updating some props.

## :bulb: Context

We were only adjusting the size of the component with a resize observer, but some props might change the size too like `hasUnreads` or `hasCallButton`.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

CP to dialtone8 branch, release next, update on product and CP.