### PR TITLE
fix(contact-info): avatar's border color

### DIFF
--- a/recipes/list_items/contact_info/contact_info.vue
+++ b/recipes/list_items/contact_info/contact_info.vue
@@ -26,11 +26,7 @@
               :initials="avatar.initials"
               :overlay-icon="avatar.icon"
               :overlay-text="avatar.text"
-              overlay-class="d-mn4 d-ba d-baw4 d-bc-black-100 d-box-unset"
-              :avatar-class="['d-baw4 d-bar-pill d-ba d-bc-black-100', {
-                'd-mln24': index > 0,
-                'd-bc-brand': !!avatar.halo,
-              }]"
+              :avatar-class="[{ 'd-mln24': index > 0, 'd-bc-brand': !!avatar.halo }]"
             >
               <img
                 v-if="avatar.src"
@@ -221,24 +217,34 @@ export default {
 };
 </script>
 
-<style scoped>
-.dt-contact-info :deep(.dt-item-layout--content) {
-  /*
-  DP-74536: Add `min-width` to make the width of "contact info" adjustable.
-  */
-  min-width: var(--space-825);
-}
-.dt-contact-info :deep(.dt-item-layout--left) {
-  /*
-  DP-74536: To make 'Avatar' in fixed position when resizing the window.
-  */
-  min-width: var(--space-650);
-  justify-content: flex-start;
-}
-.dt-contact-info :deep(.dt-item-layout--right) {
-  /*
-  DP-74536: Remove `min-width` which cause extra unused empty space on the right of "contact info".
-  */
-  min-width: 0;
+<style lang="less" scoped>
+.dt-contact-info {
+  &:deep(.dt-item-layout--content) {
+    /*
+    DP-74536: Add `min-width` to make the width of "contact info" adjustable.
+    */
+    min-width: var(--space-825);
+  }
+
+  &:deep(.dt-item-layout--left) {
+    /*
+    DP-74536: To make 'Avatar' in fixed position when resizing the window.
+    */
+    min-width: var(--space-650);
+    justify-content: flex-start;
+  }
+
+  &:deep(.dt-item-layout--right) {
+    /*
+    DP-74536: Remove `min-width` which cause extra unused empty space on the right of "contact info".
+    */
+    min-width: 0;
+  }
+
+  &:deep(.d-avatar) {
+    border-radius: var(--dt-size-radius-pill);
+    border: var(--dt-size-300) solid var(--dt-color-surface-primary);
+    box-sizing: unset;
+  }
 }
 </style>


### PR DESCRIPTION
# Fix (Contact info): Avatar's border color

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Removed utility classes from `DtRecipeContactInfo` and added custom CSS to scoped style tag

## :bulb: Context

Border color for contact info's avatar was not ok, making it look off on dark-mode.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

Before
<img width="276" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/87546543/51cac34c-8928-4241-ada9-5c41c557fb62">

After
![image](https://github.com/dialpad/dialtone-vue/assets/87546543/927bb0ba-2639-4135-8df3-7dc26f07fc45)