### PR TITLE
fix(avatar): thin border behind image

### DIFF
--- a/components/avatar/avatar.vue
+++ b/components/avatar/avatar.vue
@@ -6,7 +6,7 @@
   >
     <div
       ref="canvas"
-      :class="[canvasClass, 'd-avatar__canvas']"
+      :class="[canvasClass, 'd-avatar__canvas', { 'd-avatar--image-loaded': imageLoadedSuccessfully }]"
     >
       <!-- @slot Slot for avatar content -->
       <slot v-if="showDefaultSlot" />
@@ -345,12 +345,10 @@ export default {
     _loadedImageEventHandler (el) {
       this.imageLoadedSuccessfully = true;
       el.classList.remove('d-d-none');
-      el.classList.add('d-avatar--image-loaded');
     },
 
     _erroredImageEventHandler (el) {
       this.imageLoadedSuccessfully = false;
-      el.classList.remove('d-avatar--image-loaded');
       el.classList.add('d-d-none');
     },
   },


### PR DESCRIPTION
# Fix (Avatar): Thin border behind image

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Removed almost invisible thin border behind DtAvatar's image

## :bulb: Context

Found a thin line that was almost no visible, but that was making our visual tests to flaky sometimes due to that thin line being random color.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

<img width="333" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/87546543/96036ac4-d86f-4dd2-90c9-7ecb10d5901f">
<img width="347" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/87546543/b6ef336c-6fe4-47c0-bba1-4821b4507d03">