### PR TITLE
fix(tooltip): anchor display property issue

### DIFF
--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -1,5 +1,5 @@
 <template>
-  <span data-qa="dt-tooltip-container">
+  <div data-qa="dt-tooltip-container">
     <!-- disabling as the below events are for capturing events from interactive
          elements within the span rather than on the span itself -->
     <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
@@ -43,7 +43,7 @@
         {{ message }}
       </slot>
     </dt-lazy-show>
-  </span>
+  </div>
 </template>
 
 <script>

--- a/components/tooltip/tooltip_variants.vue
+++ b/components/tooltip/tooltip_variants.vue
@@ -34,7 +34,7 @@
       </div>
     </div>
     <div class="d-d-flex d-jc-center d-ai-center d-w100p">
-      <div>
+      <div id="circle-button-tooltip-label">
         Circle button tooltip
       </div>
       <dt-tooltip
@@ -44,7 +44,10 @@
         :show="show"
       >
         <template #anchor>
-          <dt-button circle>
+          <dt-button
+            aria-labelledby="circle-button-tooltip-label"
+            circle
+          >
             <template #icon>
               <dt-icon
                 name="dp-phone"

--- a/components/tooltip/tooltip_variants.vue
+++ b/components/tooltip/tooltip_variants.vue
@@ -33,6 +33,28 @@
         </dt-tooltip>
       </div>
     </div>
+    <div class="d-d-flex d-jc-center d-ai-center d-w100p">
+      <div>
+        Circle button tooltip
+      </div>
+      <dt-tooltip
+        class="d-ml4"
+        :transition="transition"
+        :message="localMessage"
+        :show="show"
+      >
+        <template #anchor>
+          <dt-button circle>
+            <template #icon>
+              <dt-icon
+                name="dp-phone"
+                size="300"
+              />
+            </template>
+          </dt-button>
+        </template>
+      </dt-tooltip>
+    </div>
     <div class="d-d-flex d-jc-center d-w100p">
       <!-- Text -->
       <dt-tooltip
@@ -92,6 +114,7 @@
 <script>
 import DtTooltip from './tooltip.vue';
 import { DtButton } from './../button';
+import { DtIcon } from './../icon';
 import { TOOLTIP_DIRECTIONS } from './tooltip_constants';
 
 function sliceIntoChunks (arr, chunkSize) {
@@ -105,7 +128,7 @@ function sliceIntoChunks (arr, chunkSize) {
 
 export default {
   name: 'TooltipVariants',
-  components: { DtTooltip, DtButton },
+  components: { DtTooltip, DtIcon, DtButton },
   data () {
     return {
       TOOLTIP_DIRECTIONS: sliceIntoChunks(this.customDirections || TOOLTIP_DIRECTIONS, 3),


### PR DESCRIPTION
# fix(tooltip): anchor display property issue

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Previous PR was meant to fix the issue of the `<a>` tag but I changed both the container tag and anchor tag to spans. Changing the container tag caused issues with popovers dialogs showing higher than they should and overlapping the anchor in an awkward way. I should have only changed the anchor and not the outer container to a span. This fixes the issue.

Also added a tooltip variant for circle button tooltip so we can easily test if the "corners" are cut off

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
