### PR TITLE
[NO-MERGE] [DISCUSSION] Test workflow reseearch

### DIFF
--- a/components/test_component/checkbox.test_new.test.js
+++ b/components/test_component/checkbox.test_new.test.js
@@ -178,7 +178,6 @@ describe('DtTestComponent Tests', () => {
     });
 
     describe('When disabled', () => {
-      // Test Setup
       beforeEach(() => {
         mockProps = { disabled: true };
 
@@ -315,6 +314,7 @@ describe('DtTestComponent Tests', () => {
     describe('When indeterminate', () => {
       beforeAll(() => {
         mockProps = { indeterminate: true };
+
         updateWrapper();
       });
 
@@ -397,7 +397,6 @@ describe('DtTestComponent Tests', () => {
       });
 
       describe('When the checkbox group has a validation state', () => {
-        // Test Setup
         beforeEach(() => {
           _setGroupContext([], false, VALIDATION_MESSAGE_TYPES.SUCCESS);
         });

--- a/components/test_component/checkbox.test_new.test.js
+++ b/components/test_component/checkbox.test_new.test.js
@@ -1,0 +1,501 @@
+import { mount } from '@vue/test-utils';
+import DtCheckbox from '../checkbox/checkbox.vue';
+import { VALIDATION_MESSAGE_TYPES } from '@/common/constants.js';
+import { CHECKBOX_INPUT_VALIDATION_CLASSES } from '@/components/checkbox/checkbox_constants.js';
+
+const MOCK_SLOT_LABEL = 'My Slotted Label';
+const MOCK_SLOT_DESCRIPTION = 'My Slotted Description';
+const MOCK_INPUT_LISTENER_SPY = vi.fn();
+const MOCK_GROUP_NAME = 'checkboxGroup';
+
+let MOCK_ELEMENT = null;
+const MOCK_CUSTOM_CLASS = 'my-custom-class';
+const MOCK_PROP_NAME = 'some';
+const MOCK_PROP_VALUE = 'prop';
+const MOCK_CHILD_PROPS = {};
+
+const baseProps = {
+  label: 'My Checkbox Label',
+  value: 'Value',
+};
+const baseAttrs = {};
+const baseSlots = {};
+const baseProvide = {};
+
+let mockProps = {};
+let mockAttrs = {};
+let mockSlots = {};
+let mockProvide = {};
+
+describe('DtTestComponent Tests', () => {
+  let wrapper;
+  let checkbox;
+  let input;
+  let label;
+  let description;
+  let labelDescriptionContainer;
+
+  const updateWrapper = () => {
+    wrapper = mount(DtCheckbox, {
+      props: { ...baseProps, ...mockProps },
+      attrs: { ...baseAttrs, ...mockAttrs },
+      slots: { ...baseSlots, ...mockSlots },
+      global: {
+        provide: { ...baseProvide, ...mockProvide },
+      },
+    });
+
+    checkbox = wrapper.findComponent(DtCheckbox);
+    input = wrapper.find('input');
+    label = wrapper.find('[data-qa="checkbox-label"]');
+    description = wrapper.find('[data-qa="checkbox-description"]');
+    labelDescriptionContainer = wrapper.find('[data-qa="checkbox-label-description-container"]');
+  };
+
+  beforeEach(function () {
+    updateWrapper();
+  });
+
+  afterEach(function () {
+    mockProps = {};
+    mockAttrs = {};
+    mockSlots = {};
+    mockProvide = {};
+  });
+
+  describe('Presentation Tests', () => {
+    it('Should render the component', () => {
+      expect(wrapper).toBeDefined();
+      expect(checkbox).toBeDefined();
+    });
+
+    it('should have checkbox group class', () => {
+      expect(wrapper.find('.d-checkbox-group').exists()).toBe(true);
+    });
+
+    describe('Checkbox Input Tests', () => {
+      it('should exist', () => {
+        expect(input.exists()).toBe(true);
+      });
+
+      it('should have type checkbox', () => {
+        expect(input.attributes('type')).toBe('checkbox');
+      });
+
+      it('should not be checked', () => {
+        expect(input.element.checked).toBe(false);
+      });
+    });
+
+    describe('Checkbox Label Tests', () => {
+      it('should exist', () => {
+        expect(label.exists()).toBe(true);
+      });
+
+      it('should match provided label prop', () => {
+        expect(label.text()).toBe(baseProps.label);
+      });
+    });
+
+    describe('When a label prop is provided', () => {
+      it('should exist', () => {
+        mockProps = { label: 'My Label' };
+
+        updateWrapper();
+
+        expect(label.exists()).toBe(true);
+      });
+    });
+
+    describe('When a description prop is provided', () => {
+      it('should exist', () => {
+        mockProps = { description: 'Description' };
+
+        updateWrapper();
+
+        expect(description.exists()).toBe(true);
+      });
+    });
+
+    describe('When neither a label prop/slot nor a description prop/slot is provided', () => {
+      beforeEach(() => {
+        mockProps = { label: undefined };
+
+        updateWrapper();
+      });
+
+      it('should remove the description wrapper if no description is provided', () => {
+        expect(description.exists()).toBe(false);
+      });
+
+      it('should remove the label wrapper if no label is provided', () => {
+        expect(label.exists()).toBe(false);
+      });
+
+      it('should remove the checkbox label/description container if neither is provided', () => {
+        expect(labelDescriptionContainer.exists()).toBe(false);
+      });
+
+      it('should keep the input checkbox', () => {
+        expect(input.exists()).toBe(true);
+      });
+    });
+
+    describe('When a validation state is provided', () => {
+      it('applies validation classes for success state', () => {
+        mockProps = { description: 'Description', validationState: VALIDATION_MESSAGE_TYPES.SUCCESS };
+
+        updateWrapper();
+
+        expect(wrapper.find(`.${CHECKBOX_INPUT_VALIDATION_CLASSES[VALIDATION_MESSAGE_TYPES.SUCCESS]}`).exists()).toBe(true);
+      });
+
+      it('applies validation classes for warning state', () => {
+        mockProps = { description: 'Description', validationState: VALIDATION_MESSAGE_TYPES.WARNING };
+
+        updateWrapper();
+
+        expect(wrapper.find(`.${CHECKBOX_INPUT_VALIDATION_CLASSES[VALIDATION_MESSAGE_TYPES.WARNING]}`).exists()).toBe(true);
+      });
+
+      it('applies validation classes for error state', () => {
+        mockProps = { description: 'Description', validationState: VALIDATION_MESSAGE_TYPES.ERROR };
+
+        updateWrapper();
+
+        expect(wrapper.find(`.${CHECKBOX_INPUT_VALIDATION_CLASSES[VALIDATION_MESSAGE_TYPES.ERROR]}`).exists()).toBe(true);
+      });
+    });
+
+    describe('When checked', () => {
+      it('should be checked', () => {
+        mockProps = { checked: true };
+
+        updateWrapper();
+
+        expect(input.element.checked).toBe(true);
+      });
+    });
+
+    describe('When disabled', () => {
+      // Test Setup
+      beforeEach(() => {
+        mockProps = { disabled: true };
+
+        updateWrapper();
+      });
+
+      it('should disable input', () => {
+        expect(input.element.disabled).toBe(true);
+      });
+
+      it('should have disabled class', () => {
+        expect(wrapper.find('.d-checkbox-group--disabled').exists()).toBe(true);
+      });
+    });
+
+    describe('When slot(s) are provided', () => {
+      describe('When a slotted label is provided', () => {
+        it('should have slotted label', () => {
+          mockSlots = { default: MOCK_SLOT_LABEL };
+
+          updateWrapper();
+
+          expect(label.text()).toBe(MOCK_SLOT_LABEL);
+        });
+      });
+
+      describe('When a slotted description is provided', () => {
+        it('should have slotted description', () => {
+          mockSlots = { description: MOCK_SLOT_DESCRIPTION };
+
+          updateWrapper();
+
+          expect(description.text()).toBe(MOCK_SLOT_DESCRIPTION);
+        });
+      });
+
+      describe('When slotted label and description are provided', () => {
+        beforeEach(() => {
+          mockSlots = { default: MOCK_SLOT_LABEL, description: MOCK_SLOT_DESCRIPTION };
+
+          updateWrapper();
+        });
+
+        it('should have slotted label', () => {
+          expect(label.text()).toBe(MOCK_SLOT_LABEL);
+        });
+
+        it('should have slotted description', () => {
+          expect(description.text()).toBe(MOCK_SLOT_DESCRIPTION);
+        });
+      });
+    });
+  });
+
+  describe('Accessibility Tests', function () {
+    describe('Custom Event Tests', () => {
+      describe('When the checkbox is clicked', () => {
+        it('Should emit an input event', async () => {
+          await input.trigger('change');
+
+          expect(wrapper.emitted('input')).toBeTruthy();
+        });
+      });
+
+      describe('When checked', () => {
+        describe('When the checkbox is clicked', () => {
+          it('Should emit an input event', async () => {
+            mockProps = { checked: true };
+
+            updateWrapper();
+
+            await input.trigger('change');
+
+            expect(wrapper.emitted('input')).toBeTruthy();
+          });
+        });
+      });
+
+      describe('When disabled', () => {
+        describe('When the checkbox is clicked', () => {
+          it('Should not emit an input event', async () => {
+            mockProps = { disabled: true };
+
+            updateWrapper();
+
+            await input.trigger('click');
+
+            expect(wrapper.emitted('input')).toBeFalsy();
+          });
+        });
+      });
+    });
+  });
+
+  describe('Interactivity Tests', function () {
+    describe('Custom Event Tests', () => {
+      describe('When the checkbox is clicked', () => {
+        it('Should emit an input event', async () => {
+          await input.trigger('change');
+
+          expect(wrapper.emitted('input')).toBeTruthy();
+        });
+      });
+
+      describe('When checked', () => {
+        describe('When the checkbox is clicked', () => {
+          it('Should emit an input event', async () => {
+            mockProps = { checked: true };
+
+            updateWrapper();
+
+            await input.trigger('change');
+
+            expect(wrapper.emitted('input')).toBeTruthy();
+          });
+        });
+      });
+
+      describe('When disabled', () => {
+        describe('When the checkbox is clicked', () => {
+          it('Should not emit an input event', async () => {
+            mockProps = { disabled: true };
+
+            updateWrapper();
+
+            await input.trigger('click');
+
+            expect(wrapper.emitted()).toEqual({});
+          });
+        });
+      });
+    });
+
+    describe('When indeterminate', () => {
+      beforeAll(() => {
+        mockProps = { indeterminate: true };
+        updateWrapper();
+      });
+
+      it('shows indeterminate visual state', () => {
+        expect(input.element.indeterminate).toBe(true);
+      });
+
+      describe('When clicking on an indeterminate checkbox', () => {
+        it('should uncheck', async () => {
+          input.element.value = false;
+
+          await input.trigger('change');
+
+          expect(input.element.checked).toBe(false);
+        });
+      });
+    });
+
+    describe('Listener Tests', () => {
+      describe('When there is a provided input listener', () => {
+        describe('When the checkbox is clicked', () => {
+          it('Should call input handler once', async () => {
+            mockAttrs = { onInput: MOCK_INPUT_LISTENER_SPY };
+
+            updateWrapper();
+
+            await input.trigger('change');
+
+            expect(MOCK_INPUT_LISTENER_SPY).toHaveBeenCalledTimes(1);
+          });
+        });
+      });
+    });
+
+    describe('Group Context Tests', () => {
+      const _setGroupContext = (selectedValues, groupDisabled = false, groupValidationState = null) => {
+        mockProvide = {
+          groupContext: {
+            name: MOCK_GROUP_NAME,
+            selectedValues,
+            disabled: groupDisabled,
+            validationState: groupValidationState,
+          },
+        };
+        mockProps = { description: 'Description' };
+
+        updateWrapper();
+      };
+
+      describe('When a group name is provided', () => {
+        it('sets the input name', () => {
+          _setGroupContext([]);
+
+          expect(input.attributes('name')).toBe(MOCK_GROUP_NAME);
+        });
+      });
+
+      describe('When the group is disabled', () => {
+        it('should disable input', () => {
+          _setGroupContext([], true);
+
+          expect(input.element.disabled).toBe(true);
+        });
+      });
+
+      describe('When the Checkbox value is in checked', () => {
+        it('should be checked', () => {
+          _setGroupContext([baseProps.value]);
+
+          expect(input.element.checked).toBe(true);
+        });
+      });
+
+      describe('When the Checkbox value is not in checked', () => {
+        it('should not be checked', () => {
+          _setGroupContext([]);
+
+          expect(input.element.checked).toBe(false);
+        });
+      });
+
+      describe('When the checkbox group has a validation state', () => {
+        // Test Setup
+        beforeEach(() => {
+          _setGroupContext([], false, VALIDATION_MESSAGE_TYPES.SUCCESS);
+        });
+
+        it('has validation classes', () => {
+          expect(wrapper.find(`.${CHECKBOX_INPUT_VALIDATION_CLASSES[VALIDATION_MESSAGE_TYPES.SUCCESS]}`).exists()).toBe(true);
+        });
+
+        describe('When the checkbox has a validation state', () => {
+          it('has validation classes', () => {
+            mockProps = { validationState: VALIDATION_MESSAGE_TYPES.WARNING };
+
+            updateWrapper();
+
+            expect(wrapper.find(`.${CHECKBOX_INPUT_VALIDATION_CLASSES[VALIDATION_MESSAGE_TYPES.SUCCESS]}`).exists()).toBe(true);
+          });
+        });
+      });
+    });
+  });
+
+  describe('Extendability Tests', function () {
+    const _setupChildClassTest = (childClassName, selector) => {
+      mockProps[childClassName] = MOCK_CUSTOM_CLASS;
+
+      updateWrapper();
+
+      MOCK_ELEMENT = wrapper.find(selector);
+    };
+
+    const _setupChildPropsTest = (childPropsName, selector) => {
+      mockProps[childPropsName] = MOCK_CHILD_PROPS;
+
+      updateWrapper();
+
+      MOCK_ELEMENT = wrapper.find(selector);
+    };
+
+    beforeAll(() => {
+      MOCK_CHILD_PROPS[MOCK_PROP_NAME] = MOCK_PROP_VALUE;
+    });
+
+    beforeEach(() => {
+      mockProps = { label: 'Label', description: 'Description' };
+
+      updateWrapper();
+    });
+
+    describe('When an input class is provided', () => {
+      it('should apply custom class to child', () => {
+        _setupChildClassTest('inputClass', 'input');
+
+        expect(wrapper.find('.my-custom-class').html()).toBe(MOCK_ELEMENT.html());
+      });
+    });
+
+    describe('When an label class is provided', () => {
+      it('should apply custom class to child', () => {
+        _setupChildClassTest('labelClass', '[data-qa="checkbox-label"]');
+
+        expect(wrapper.find('.my-custom-class').html()).toBe(MOCK_ELEMENT.html());
+      });
+    });
+
+    describe('When an description class is provided', () => {
+      it('should apply custom class to child', () => {
+        _setupChildClassTest('descriptionClass', '[data-qa="checkbox-description"]');
+
+        expect(wrapper.find('.my-custom-class').html()).toBe(MOCK_ELEMENT.html());
+      });
+    });
+
+    describe('When label child props are provided', () => {
+      it('should have provided child prop', () => {
+        _setupChildPropsTest('labelChildProps', '[data-qa="checkbox-label"]');
+
+        expect(MOCK_ELEMENT.attributes(MOCK_PROP_NAME)).toBe(MOCK_PROP_VALUE);
+      });
+    });
+
+    describe('When description child props are provided', () => {
+      it('should have provided child prop', () => {
+        _setupChildPropsTest('descriptionChildProps', '[data-qa="checkbox-description"]');
+
+        expect(MOCK_ELEMENT.attributes(MOCK_PROP_NAME)).toBe(MOCK_PROP_VALUE);
+      });
+    });
+
+    describe('When attrs are provided', () => {
+      it('should have provided child prop', () => {
+        mockAttrs = { some: 'prop' };
+
+        updateWrapper();
+
+        MOCK_ELEMENT = input;
+
+        expect(MOCK_ELEMENT.attributes(MOCK_PROP_NAME)).toBe(MOCK_PROP_VALUE);
+      });
+    });
+  });
+});

--- a/components/test_component/icon.test_new.test.js
+++ b/components/test_component/icon.test_new.test.js
@@ -37,7 +37,6 @@ describe('DtIcon Tests', () => {
     describe('When size prop is set', () => {
       it('Should have correct class', () => {
         mockProps = { size: '800' };
-        // await wrapper.setProps({ size: '800' });
 
         updateWrapper();
 
@@ -50,13 +49,14 @@ describe('DtIcon Tests', () => {
     describe('When ariaLabel prop is set', () => {
       beforeEach(() => {
         mockProps = { ariaLabel: 'icon description' };
-        // await wrapper.setProps({ ariaLabel: 'icon description' });
 
         updateWrapper();
       });
+
       it('sets the aria-label attribute', () => {
         expect(wrapper.attributes()['aria-label']).toBe('icon description');
       });
+
       it('sets aria-hidden to false', () => {
         expect(wrapper.attributes()['aria-hidden']).toBe('false');
       });

--- a/components/test_component/icon.test_new.test.js
+++ b/components/test_component/icon.test_new.test.js
@@ -1,0 +1,65 @@
+import DtIcon from '../icon/icon.vue';
+import { mount } from '@vue/test-utils';
+
+const baseProps = { name: 'accessibility' };
+
+let mockProps = {};
+
+describe('DtIcon Tests', () => {
+  let wrapper;
+
+  const updateWrapper = () => {
+    wrapper = mount(DtIcon, {
+      props: { ...baseProps, ...mockProps },
+    });
+  };
+
+  beforeEach(function () {
+    updateWrapper();
+  });
+
+  afterEach(function () {
+    mockProps = {};
+  });
+
+  describe('Presentation Tests', () => {
+    it('Should render the accessibility icon', () => {
+      expect(wrapper).toBeDefined();
+      expect(wrapper.classes().includes('d-icon--accessibility')).toBe(true);
+    });
+
+    describe('When size prop is not set', () => {
+      it('Should have default class', () => {
+        expect(wrapper.classes().includes('d-icon--size-500')).toBe(true);
+      });
+    });
+
+    describe('When size prop is set', () => {
+      it('Should have correct class', () => {
+        mockProps = { size: '800' };
+        // await wrapper.setProps({ size: '800' });
+
+        updateWrapper();
+
+        expect(wrapper.classes().includes('d-icon--size-800')).toBe(true);
+      });
+    });
+  });
+
+  describe('Accessibility Tests', () => {
+    describe('When ariaLabel prop is set', () => {
+      beforeEach(() => {
+        mockProps = { ariaLabel: 'icon description' };
+        // await wrapper.setProps({ ariaLabel: 'icon description' });
+
+        updateWrapper();
+      });
+      it('sets the aria-label attribute', () => {
+        expect(wrapper.attributes()['aria-label']).toBe('icon description');
+      });
+      it('sets aria-hidden to false', () => {
+        expect(wrapper.attributes()['aria-hidden']).toBe('false');
+      });
+    });
+  });
+});

--- a/components/test_component/index.js
+++ b/components/test_component/index.js
@@ -1,0 +1,2 @@
+export { default as DtTestComponent } from './test_component.vue';
+export {} from './test_component_constants';

--- a/components/test_component/test_component.mdx
+++ b/components/test_component/test_component.mdx
@@ -1,0 +1,48 @@
+import { Canvas, Story, Subtitle, Controls, Meta } from '@storybook/blocks';
+import * as DtTestComponentStories from './test_component.stories.js';
+
+<Meta of={DtTestComponentStories}/>
+
+# DtTestComponent
+
+<Subtitle>
+  Some description of the component functionality.
+</Subtitle>
+
+## Base Style
+
+Some description of how to use the base component, potential gotchas and limitations.
+
+<Canvas of={DtTestComponentStories.Default} />
+
+## Variants
+
+<Canvas of={DtTestComponentStories.Variants} />
+
+## Slots, Props & Events
+
+<Controls />
+
+## Usage
+
+### Import
+
+```jsx
+import { DtTestComponent } from '@dialpad/dialtone-vue';
+```
+
+### With Some Variant
+
+```jsx
+<dt-test-component
+  some="variant"
+/>
+```
+
+### With Some Other Variant
+
+```jsx
+<dt-test-component
+  some-other="variant"
+/>
+```

--- a/components/test_component/test_component.stories.js
+++ b/components/test_component/test_component.stories.js
@@ -1,0 +1,97 @@
+import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import DtTestComponent from './test_component.vue';
+import DtTestComponentDefaultTemplate from './test_component_default.story.vue';
+import DtTestComponentVariantsTemplate from './test_component_variants.story.vue';
+
+/*
+  Controls
+  ========
+
+  Here we define any custom configuration for props / slots / events in storybook
+
+  By default storybook will display any props / slots / events from the associated component. It will also use jsdoc
+  comments on the component to populate details such as description and default value. You should only enter config
+  here if it was not possible to add into the jsdoc of the component itself.
+
+  See https://storybook.js.org/docs/vue/api/argtypes#manual-specification
+
+  To set the description of a slot, add the below comment to the line above where the slot is defined:
+  <!-- @slot example slot decorator -->
+*/
+
+export const argTypesData = {
+  // Props: only define things here that cannot be set by jsdoc comments on the component itself.
+  genericProp: {
+    table: {
+      type: {
+        summary: 'summary for test purposes',
+      },
+    },
+  },
+
+  // Slots
+  default: {
+    control: 'text',
+    table: {
+      type: {
+        summary: 'VNode',
+      },
+    },
+  },
+  /*
+    We use the following naming scheme `<SLOT_NAME>Slot` for slot controls to prevent conflicts with props that share
+    the same name.
+  */
+  namedSlot: {
+    control: 'text',
+    table: {
+      type: {
+        summary: 'VNode',
+      },
+    },
+  },
+
+  // Events: Exclude this from the table as event names will automatically be added from the component itself.
+  onGenericEvent: {
+    action: 'generic-event',
+    table: {
+      disable: true,
+    },
+  },
+};
+
+// Set default values at the story level here.
+export const argsData = {
+  namedSlot: 'This is a named slot with it\'s default set at the story level.',
+};
+
+// Story Collection
+export default {
+  title: 'Components/Test Component',
+  component: DtTestComponent,
+  args: argsData,
+  argTypes: argTypesData,
+  excludeStories: /.*Data$/,
+};
+
+// Templates
+const DefaultTemplate = (args) => createTemplateFromVueFile(
+  args,
+  DtTestComponentDefaultTemplate,
+);
+
+// Stories
+export const Default = {
+  render: DefaultTemplate,
+  args: {},
+};
+
+const VariantsTemplate = (args) => createTemplateFromVueFile(
+  args,
+  DtTestComponentVariantsTemplate,
+);
+
+export const Variants = {
+  render: VariantsTemplate,
+  args: {},
+};

--- a/components/test_component/test_component.test.js
+++ b/components/test_component/test_component.test.js
@@ -1,0 +1,90 @@
+import { shallowMount } from '@vue/test-utils';
+import DtTestComponent from './test_component.vue';
+
+// Constants
+const baseProps = {};
+
+describe('DtTestComponent Tests', function () {
+  // Wrappers
+  let wrapper;
+  let childContainer;
+
+  // Environment
+  let props = baseProps;
+  let attrs = {};
+  let slots = {};
+  let provide = {};
+
+  // Helpers
+  const _setChildWrappers = () => {
+    childContainer = wrapper.find('[data-qa="child-container"]');
+  };
+
+  const _setWrappers = () => {
+    wrapper = shallowMount(DtTestComponent, {
+      props,
+      attrs,
+      slots,
+      provide,
+    });
+    _setChildWrappers();
+  };
+
+  // Shared Examples
+  const itBehavesLikeSomeExpectation = () => {
+    it('should be equal', function () { assert.strictEqual(1, 1); });
+  };
+
+  // Setup
+  beforeAll(function () {});
+  beforeEach(function () {});
+
+  // Teardown
+  afterEach(function () {
+    props = baseProps;
+    attrs = {};
+    slots = {};
+    provide = {};
+  });
+  afterAll(function () {});
+
+  describe('Presentation Tests', function () {
+    /*
+     * Test(s) to ensure that the component is correctly rendering
+     */
+
+    describe('When some description of the current environment', function () {});
+  });
+
+  describe('Accessibility Tests', function () {
+    /*
+     * Test(s) to ensure that the component is accessible
+     */
+
+    describe('When some description of the current environment', function () {});
+  });
+
+  describe('Interactivity Tests', function () {
+    /*
+     * Test(s) to ensure that the component correctly handles user input
+     */
+
+    describe('When some description of the current environment', function () {});
+  });
+
+  describe('Validation Tests', function () {
+    /*
+     * Test(s) to ensure that custom validators are working as expected
+     */
+
+    describe('When some description of the current environment', function () {});
+  });
+
+  describe('Extendability Tests', function () {
+    /*
+     * Test(s) to ensure that the component can be correctly extended
+     */
+
+    describe('When some description of the current environment', function () {});
+  });
+});

--- a/components/test_component/test_component.test.js
+++ b/components/test_component/test_component.test.js
@@ -30,11 +30,6 @@ describe('DtTestComponent Tests', function () {
     _setChildWrappers();
   };
 
-  // Shared Examples
-  const itBehavesLikeSomeExpectation = () => {
-    it('should be equal', function () { assert.strictEqual(1, 1); });
-  };
-
   // Setup
   beforeAll(function () {});
   beforeEach(function () {});

--- a/components/test_component/test_component.vue
+++ b/components/test_component/test_component.vue
@@ -1,0 +1,70 @@
+<template>
+  <div>
+    <div>
+      {{ genericProp }}
+    </div>
+    <div>
+      <!-- @slot description of the default slot -->
+      <slot>
+        The default slot
+      </slot>
+    </div>
+    <div>
+      <!-- @slot description of the named slot -->
+      <slot name="namedSlot" />
+    </div>
+    <button @click="$emit('generic-event')">Click to fire generic-event</button>
+  </div>
+</template>
+
+<script>
+import {} from './test_component_constants';
+
+export default {
+  name: 'DtTestComponent',
+
+  components: {},
+
+  mixins: [],
+
+  /* inheritAttrs: false is generally an option we want to set on library
+    components. This allows any attributes passed in that are not recognized
+    as props to be passed down to another element or component using v-bind:$attrs
+    more info: https://vuejs.org/v2/api/#inheritAttrs */
+  // inheritAttrs: false,
+
+  props: {
+    /**
+     * description of this generic prop
+     */
+    genericProp: {
+      type: String,
+      default: 'a generic prop'
+    }
+  },
+
+  emits: [
+    /**
+     * Event fired when something happens
+     *
+     * @event generic-event
+     * @type {Boolean}
+     */
+    'generic-event'
+  ],
+
+  data () {
+    return {};
+  },
+
+  computed: {},
+
+  watch: {},
+
+  methods: {},
+};
+</script>
+
+<style lang="less">
+
+</style>

--- a/components/test_component/test_component4.test.js
+++ b/components/test_component/test_component4.test.js
@@ -5,7 +5,7 @@ import DtTestComponent from './test_component.vue';
  * Auxiliary variables
  * These variables will be used inside tests to help readability and DRY
  * @prefix MOCK_
- * @notation MOCK_[NAME]_[TYPE]
+ * @notation MOCK_[NAME]
  */
 const MOCK_EXPECTED_VALUE = true;
 const MOCK_FIELD_NAME = 'mockFieldName';
@@ -17,7 +17,7 @@ const MOCK_FUNCTION = vi.fn();
  * @prefix base
  * @notation base[NAME]
  */
-const baseProps = {}; // This way of doing can be replaced with setProps, but this is more consistent with the rest of the code
+const baseProps = {};
 const baseAttrs = {};
 const baseSlots = {};
 const baseProvide = {};
@@ -71,6 +71,9 @@ describe('DtTestComponent Tests', () => {
   });
 
   describe('Presentation Tests', () => {
+    /*
+     * Test(s) to ensure that the component is correctly rendering
+     */
     it('Should render the component', () => {
       expect(wrapper).toBeDefined();
     });

--- a/components/test_component/test_component4.test.js
+++ b/components/test_component/test_component4.test.js
@@ -1,0 +1,102 @@
+import { mount } from '@vue/test-utils';
+import DtTestComponent from './test_component.vue';
+
+/**
+ * Auxiliary variables
+ * These variables will be used inside tests to help readability and DRY
+ * @prefix MOCK_
+ * @notation MOCK_[NAME]_[TYPE]
+ */
+const MOCK_EXPECTED_VALUE = true;
+const MOCK_FIELD_NAME = 'mockFieldName';
+const MOCK_FUNCTION = vi.fn();
+
+/**
+ * Constants variables
+ * Will be always present in every test
+ * @prefix base
+ * @notation base[NAME]
+ */
+const baseProps = {}; // This way of doing can be replaced with setProps, but this is more consistent with the rest of the code
+const baseAttrs = {};
+const baseSlots = {};
+const baseProvide = {};
+
+/**
+ * Environment variables
+ * Will be reset after each test
+ * @prefix mock
+ * @notation mock[NAME]
+ */
+let mockProps = {};
+let mockAttrs = {};
+let mockSlots = {};
+let mockProvide = {};
+
+describe('DtTestComponent Tests', () => {
+  /**
+   * Wrappers
+   * Will contain the component and all its necessary children
+   */
+  let wrapper;
+
+  const updateWrapper = () => {
+    wrapper = mount(DtTestComponent, {
+      props: { ...baseProps, ...mockProps },
+      attrs: { ...baseAttrs, ...mockAttrs },
+      slots: { ...baseSlots, ...mockSlots },
+      global: {
+        provide: { ...baseProvide, ...mockProvide },
+      },
+    });
+  };
+
+  /**
+   * Setup
+   * Will prepare the environment for each test
+   */
+  beforeEach(function () {
+    updateWrapper();
+  });
+
+  /**
+   * Teardown
+   * Will reset the environment after each test
+   */
+  afterEach(function () {
+    mockProps = {};
+    mockAttrs = {};
+    mockSlots = {};
+    mockProvide = {};
+  });
+
+  describe('Presentation Tests', () => {
+    it('Should render the component', () => {
+      expect(wrapper).toBeDefined();
+    });
+  });
+
+  describe('Accessibility Tests', function () {
+    /*
+     * Test(s) to ensure that the component is accessible
+     */
+  });
+
+  describe('Interactivity Tests', function () {
+    /*
+     * Test(s) to ensure that the component correctly handles user input
+     */
+  });
+
+  describe('Validation Tests', function () {
+    /*
+     * Test(s) to ensure that custom validators are working as expected
+     */
+  });
+
+  describe('Extendability Tests', function () {
+    /*
+     * Test(s) to ensure that the component can be correctly extended
+     */
+  });
+});

--- a/components/test_component/test_component4.test.js
+++ b/components/test_component/test_component4.test.js
@@ -12,7 +12,7 @@ const MOCK_FIELD_NAME = 'mockFieldName';
 const MOCK_FUNCTION = vi.fn();
 
 /**
- * Constants variables
+ * Environment Constants variables
  * Will be always present in every test
  * @prefix base
  * @notation base[NAME]

--- a/components/test_component/test_component_constants.js
+++ b/components/test_component/test_component_constants.js
@@ -1,0 +1,5 @@
+export const DEFAULT_CONSTANTS = null;
+
+export default {
+  DEFAULT_CONSTANTS,
+};

--- a/components/test_component/test_component_default.story.vue
+++ b/components/test_component/test_component_default.story.vue
@@ -1,0 +1,39 @@
+<!-- Use this template story to allow the user control the component's props and slots -->
+<template>
+  <!--
+    We can bind the data that the user entered into the storybook controls to props by using a property of the same name
+    as the storybook control defined in the corresponding `.story.js` file.
+  -->
+  <dt-test-component
+    :generic-prop="$attrs.genericProp"
+    @generic-event="$attrs.onGenericEvent"
+  >
+    <!--
+      We can also bind any slot data that the user has entered into the storybook controls. In this example we
+      conditionally render slots using a custom storybook control defined in the corresponding `.story.js`.
+
+      The preferred naming scheme for storybook slot controls uses the following format `<SLOT_NAME>Slot`.
+
+      We use this storybook control naming scheme to prevent conflicts between controls for props and slots with the
+      same name.
+    -->
+    <template v-if="defaultSlot">
+      <span v-html="defaultSlot" />
+    </template>
+    <template
+      v-if="namedSlot"
+      #namedSlot
+    >
+      <span v-html="namedSlot" />
+    </template>
+  </dt-test-component>
+</template>
+
+<script>
+import DtTestComponent from './test_component.vue';
+
+export default {
+  name: 'DtTestComponentDefault',
+  components: { DtTestComponent },
+};
+</script>

--- a/components/test_component/test_component_variants.story.vue
+++ b/components/test_component/test_component_variants.story.vue
@@ -1,0 +1,39 @@
+<!-- Use this template story to allow the user control the component's props and slots -->
+<template>
+  <!--
+    We can bind the data that the user entered into the storybook controls to props by using a property of the same name
+    as the storybook control defined in the corresponding `.story.js` file.
+  -->
+  <dt-test-component
+    :generic-prop="$attrs.genericProp"
+    @generic-event="$attrs.onGenericEvent"
+  >
+    <!--
+      We can also bind any slot data that the user has entered into the storybook controls. In this example we
+      conditionally render slots using a custom storybook control defined in the corresponding `.story.js`.
+
+      The preferred naming scheme for storybook slot controls uses the following format `<SLOT_NAME>Slot`.
+
+      We use this storybook control naming scheme to prevent conflicts between controls for props and slots with the
+      same name.
+    -->
+    <template v-if="defaultSlot">
+      <span v-html="defaultSlot" />
+    </template>
+    <template
+      v-if="namedSlot"
+      #namedSlot
+    >
+      <span v-html="namedSlot" />
+    </template>
+  </dt-test-component>
+</template>
+
+<script>
+import DtTestComponent from './test_component.vue';
+
+export default {
+  name: 'DtTestComponentVariants',
+  components: { DtTestComponent },
+};
+</script>


### PR DESCRIPTION
# Test workflow research 

## FIRST ROUND IMPLEMENTATION

## :book: Description

Important files:

- **old test template generated:** 
components/test_component/test_component.test.js 

- **new test template generated:**
components/test_component/test_component4.test.js

- **checkbox test migrated to new template:**
components/test_component/checkbox.test_new.test.js

- **icon test migrated to new template:**
components/test_component/icon.test_new.test.js


-----------------------
-----------------------

Notes:

- Removed functions like `itBehavesLikeAppliesChildProp` or `itBehavesLikeAppliesClassToChild` from `tests/shared_examples/extendability'`, It also removes `// eslint-disable-next-line vitest/expect-expect `
Not agree on the use of them.

I could agree on the use of sth like `expectClassToExist` so we can replace this:
```expect(wrapper.find(`.${CHECKBOX_INPUT_VALIDATION_CLASSES[VALIDATION_MESSAGE_TYPES.ERROR]}`).exists()).toBe(true);```
to this
```expectClassToExist(wrapper, CHECKBOX_INPUT_VALIDATION_CLASSES[VALIDATION_MESSAGE_TYPES.ERROR]);```
but still not sure.

- Removed beforeEach on test with a single test.

- Added initial test which will assert for the exist of the component. 
This is helpful because guaranteed an initial working test.

- Fixed some ways of write test.

Previously:
<img width="717" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/89984179/d4203e83-cdb5-4a0b-ae2c-ee9a33c64ec2">

Now:
<img width="484" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/89984179/0c9134fa-5b70-4dd4-8c56-6f3946376aad">


- Updated BeforeEach in one line, should have a break line.

- Updated test in one line, should have a break line.

- Updated test with a break line in the description, description should be in one line.

- Removed unnecessary comments.

- Tests now should follow certain rules while writing. (Its shown on the new migrated tets)
This will improve consistency between test and readability.
These are for example: 
All following test description will not have break line.
Non related sentences will have a break line.
<img width="541" alt="Screenshot 2023-07-27 at 22 04 15" src="https://github.com/dialpad/dialtone-vue/assets/89984179/65e48567-820e-486b-ab6e-e38ba0bd46a4">

-  There is a possibility where you can update props using `setProps` method isntead the `mockProps` proposed by the test template. IMO we should follow `mockProps` for consitency.

- Outside test, will propose 3 `variable structuring`

<img width="531" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/89984179/2b18b43a-e4cf-42fd-a08f-bed312953d9b">


- This template is easy to replicate in existing tests to do a quick migration.







