### PR TITLE
fix(leftbar-row): avatar presence color on selected row

### DIFF
--- a/recipes/leftbar/style/leftbar_row.less
+++ b/recipes/leftbar/style/leftbar_row.less
@@ -92,6 +92,10 @@
     --leftbar-row-color-background: var(--theme-sidebar-selected-row-color-background);
     --leftbar-row-color-foreground: var(--theme-sidebar-selected-row-color);
 
+    &:deep(.d-presence) {
+      --presence-color-border-base: var(--dt-color-black-200);
+    }
+
     &:deep(.d-avatar__count) {
       --avatar-count-color-shadow: var(--theme-sidebar-selected-row-color-background);
     }


### PR DESCRIPTION
# Fix(Leftbar row): Avatar presence color on selected row

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Changed presence color on selected state

## :bulb: Context

Noticed the avatar's presence border on lefbar selected row was not correct.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

<img width="300" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/87546543/e1a819c6-8f62-456f-b904-3678de2131fa">
<img width="299" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/87546543/a98ae882-d8e2-4a8c-b19e-eca7921d38f1">