### PR TITLE
fix(avatar): overlay icon alignment

### DIFF
--- a/components/avatar/avatar.vue
+++ b/components/avatar/avatar.vue
@@ -402,6 +402,7 @@ export default {
   height: 100%;
   display: flex;
   align-items: center;
+  justify-content: center;
   border-radius: var(--dt-size-radius-circle);
   z-index: var(--zi-base);
 }

--- a/components/avatar/avatar_variants.story.vue
+++ b/components/avatar/avatar_variants.story.vue
@@ -5,7 +5,7 @@
       <div class="d-flow16 d-d-flex d-ai-center">
         <dt-avatar
           v-for="size in avatarSizes"
-          :key="`default-${size}`"
+          :key="`image-${size}`"
           :seed="seed"
           :size="size"
           full-name="Avatar Image"
@@ -18,7 +18,7 @@
       <div class="d-flow16 d-d-flex d-ai-center">
         <dt-avatar
           v-for="size in avatarSizes"
-          :key="`default-${size}`"
+          :key="`initials-${size}`"
           :seed="seed"
           :size="size"
           full-name="Avatar Icon"
@@ -30,7 +30,7 @@
       <div class="d-flow16 d-d-flex d-ai-center">
         <dt-avatar
           v-for="size in avatarSizes"
-          :key="`default-${size}`"
+          :key="`icon-${size}`"
           :seed="seed"
           :size="size"
           full-name="Avatar Icon"
@@ -41,19 +41,34 @@
     <div>
       <h2>Presence</h2>
       <div class="d-flow16 d-d-flex d-ai-center">
-        <div
+        <dt-avatar
           v-for="size in avatarSizes"
-          :key="`default-${size}`"
-          class="d-d-inline-flex"
-        >
-          <dt-avatar
-            :seed="seed"
-            :size="size"
-            full-name="Person avatar"
-            presence="busy"
-            image-src="/common/assets/person.png"
-          />
-        </div>
+          :key="`presence-${size}`"
+          :seed="seed"
+          :size="size"
+          full-name="Person avatar"
+          presence="busy"
+          image-src="/common/assets/person.png"
+        />
+      </div>
+    </div>
+    <div>
+      <h2>Overlay</h2>
+      <div class="d-flow16 d-d-flex">
+        <dt-avatar
+          :seed="seed"
+          size="xl"
+          full-name="Person avatar"
+          image-src="/common/assets/person.png"
+          overlay-icon="hear"
+        />
+        <dt-avatar
+          :seed="seed"
+          size="xl"
+          full-name="Person avatar"
+          image-src="/common/assets/person.png"
+          overlay-text="+3"
+        />
       </div>
     </div>
   </div>

--- a/components/chip/chip.stories.js
+++ b/components/chip/chip.stories.js
@@ -143,6 +143,13 @@ export const WithIcon = {
 export const WithAvatar = {
   render: Template,
 
+  parameters: {
+    percy: {
+      args: {
+        avatarSeed: 'seed',
+      },
+    },
+  },
   args: {
     ...Default.args,
     avatar: 'Jaqueline Nackos',

--- a/components/chip/chip_default.story.vue
+++ b/components/chip/chip_default.story.vue
@@ -26,6 +26,7 @@
     >
       <dt-avatar
         :full-name="avatar"
+        :seed="avatarSeed"
       />
     </template>
     <span


### PR DESCRIPTION
# Fix (Avatar): Overlay icon alignment

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added `justify-content: center` to be sure the icon is always at the center of the overlay regarding its size.

## :bulb: Context

Issues on product with icon alignment where reported and tried to fix it [here](https://github.com/dialpad/dialtone-vue/pull/1113) but it was better to add the fix on the actual avatar instead of just the recipe.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

<img width="169" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/87546543/037eec4d-5fae-46b7-8353-ed4f3eaa44c3">