### PR TITLE
fix(select-menu): pass event object onChange

### DIFF
--- a/components/select_menu/select_menu.test.js
+++ b/components/select_menu/select_menu.test.js
@@ -1,6 +1,5 @@
 import { createLocalVue, mount, shallowMount } from '@vue/test-utils';
 import Vue from 'vue';
-import { itBehavesLikeEmitsExpectedEvent } from '../../tests/shared_examples/events';
 import {
   itBehavesLikePassesCustomPropValidation,
   itBehavesLikeFailsCustomPropValidation,
@@ -346,10 +345,11 @@ describe('DtSelectMenu Tests', () => {
       });
 
       it('should emit input event', () => {
-        itBehavesLikeEmitsExpectedEvent(wrapper, 'input', selectedValue.toString());
+        console.log(wrapper.emitted('input'));
+        expect(wrapper.emitted('input')[0][1]).toBe(selectedValue.toString());
       });
       it('should emit change event', () => {
-        itBehavesLikeEmitsExpectedEvent(wrapper, 'change', selectedValue.toString());
+        expect(wrapper.emitted('change')[0][1]).toBe(selectedValue.toString());
       });
     });
   });

--- a/components/select_menu/select_menu.vue
+++ b/components/select_menu/select_menu.vue
@@ -255,7 +255,7 @@ export default {
          * emitted input event by the change listener).
         */
         input: () => {},
-        change: event => this.emitValue(event.target.value),
+        change: event => this.emitValue(event, event.target.value),
       };
     },
 
@@ -289,9 +289,9 @@ export default {
   },
 
   methods: {
-    emitValue (value) {
-      this.$emit('input', value);
-      this.$emit('change', value);
+    emitValue (event, value) {
+      this.$emit('input', event, value);
+      this.$emit('change', event, value);
     },
 
     getOptionKey (value) {


### PR DESCRIPTION
# fix(select-menu): pass event object onChange

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Pass event object with onChange event. Prior to this the consumer was unable to do anything with the native event object such as programatically changing value.

## :bulb: Context

Allow for changing the value programatically

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Let reporter know it's released
