### PR TITLE
fix(recipe-callbar-button-with-popover): do not autofocus on the popover

### DIFF
--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -24,6 +24,7 @@
     <dt-popover
       v-if="showArrowButton"
       :id="id"
+      :modal="false"
       :open="open"
       :placement="placement"
       :initial-focus-element="initialFocusElement"


### PR DESCRIPTION
# PR Title

do not autofocus on the popover

## :hammer_and_wrench: Type Of Change

- [X] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

do not autofocus on the popover, so the other control buttons in the panel can get the click event.

## :bulb: Context

do not autofocus on the popover, so the other control buttons in the panel can get the click event.
https://dialpad.atlassian.net/browse/DP-78031

## :pencil: Checklist

- [X] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

N/A

## :camera: Screenshots / GIFs

N/A

