### PR TITLE
fix(select-menu): emit value first

### DIFF
--- a/components/select_menu/select_menu.test.js
+++ b/components/select_menu/select_menu.test.js
@@ -341,10 +341,10 @@ describe('DtSelectMenu Tests', () => {
       });
 
       it('should emit input event', () => {
-        expect(wrapper.emitted('input')[0][1]).toBe(selectedValue.toString());
+        expect(wrapper.emitted('input')[0][0]).toBe(selectedValue.toString());
       });
       it('should emit change event', () => {
-        expect(wrapper.emitted('change')[0][1]).toBe(selectedValue.toString());
+        expect(wrapper.emitted('change')[0][0]).toBe(selectedValue.toString());
       });
     });
   });

--- a/components/select_menu/select_menu.vue
+++ b/components/select_menu/select_menu.vue
@@ -255,7 +255,7 @@ export default {
          * emitted input event by the change listener).
         */
         input: () => {},
-        change: event => this.emitValue(event, event.target.value),
+        change: event => this.emitValue(event.target.value, event),
       };
     },
 
@@ -289,9 +289,9 @@ export default {
   },
 
   methods: {
-    emitValue (event, value) {
-      this.$emit('input', event, value);
-      this.$emit('change', event, value);
+    emitValue (value, event) {
+      this.$emit('input', value, event);
+      this.$emit('change', value, event);
     },
 
     getOptionKey (value) {


### PR DESCRIPTION
# fix(select-menu): emit value first

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Silly mistake by me, I changed the order of parameters in the select menu change event here https://github.com/dialpad/dialtone-vue/commit/5a1d26193106485f30112bc4ea1e002be8503b26 which of course broke everything that was capturing an event from a select menu and then trying to reference the value. Changed the order.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root
