### PR TITLE
fix(contact-info): avatar's border color

### DIFF
--- a/recipes/list_items/contact_info/contact_info.vue
+++ b/recipes/list_items/contact_info/contact_info.vue
@@ -14,23 +14,20 @@
       >
         <div
           v-if="avatarList"
-          class="d-mrn4 d-d-flex d-fd-row"
+          class="dt-contact-info--avatars d-mrn4 d-d-flex d-fd-row"
         >
-          <div
+          <dt-avatar
             v-for="(avatar, index) in avatarList"
             :key="index"
-          >
-            <dt-avatar
-              :size="avatarSize"
-              :seed="avatar.seed"
-              :full-name="avatar.fullName"
-              :image-src="avatar.src"
-              :icon-name="avatarIcon"
-              :overlay-icon="avatar.icon"
-              :overlay-text="avatar.text"
-              :avatar-class="[{ 'd-mln24': index > 0, 'd-bc-brand': !!avatar.halo }]"
-            />
-          </div>
+            :size="avatarSize"
+            :seed="avatar.seed"
+            :full-name="avatar.fullName"
+            :image-src="avatar.src"
+            :icon-name="avatarIcon"
+            :overlay-icon="avatar.icon"
+            :overlay-text="avatar.text"
+            :avatar-class="[{ 'd-mln24': index > 0, 'd-bc-brand': !!avatar.halo }]"
+          />
         </div>
         <dt-avatar
           v-else
@@ -191,6 +188,8 @@ export default {
 
 <style lang="less" scoped>
 .dt-contact-info {
+  --contact-info-avatar-border-color: var(--dt-color-surface-primary);
+
   &:deep(.dt-item-layout--content) {
     /*
     DP-74536: Add `min-width` to make the width of "contact info" adjustable.
@@ -213,9 +212,9 @@ export default {
     min-width: 0;
   }
 
-  &:deep(.d-avatar) {
+  &--avatars .d-avatar {
     border-radius: var(--dt-size-radius-pill);
-    border: var(--dt-size-300) solid var(--dt-color-surface-primary);
+    border: var(--dt-size-300) solid var(--contact-info-avatar-border-color);
     box-sizing: unset;
   }
 }


### PR DESCRIPTION
# Fix(Contact Info): Avatar's border color

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added border color only to contact-info with multiple avatars, single avatar doesn't need a colored border.

## :bulb: Context

Issues reported on product: https://dialpad.atlassian.net/browse/DP-78700

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

![image](https://github.com/dialpad/dialtone-vue/assets/87546543/ee7c70a7-6c37-4585-8762-da8cf034521a)
![image](https://github.com/dialpad/dialtone-vue/assets/87546543/d59e7782-320d-4a41-92f3-75b483a16b0f)