### PR TITLE
fix(avatar): dynamic icon sizes

### DIFF
--- a/components/avatar/avatar.vue
+++ b/components/avatar/avatar.vue
@@ -19,7 +19,7 @@
       <dt-icon
         v-else-if="iconName"
         :name="iconName"
-        :size="iconSize"
+        :size="iconSize || AVATAR_ICON_SIZES[size]"
         :class="[iconClass, AVATAR_KIND_MODIFIERS.icon]"
         data-qa="dt-avatar-icon"
       />
@@ -76,6 +76,7 @@ import {
   AVATAR_PRESENCE_STATES,
   AVATAR_COLORS,
   AVATAR_GROUP_VALIDATOR,
+  AVATAR_ICON_SIZES,
 } from './avatar_constants';
 import { getIconNames } from '@/common/storybook_utils.js';
 import { ICON_SIZE_MODIFIERS } from '@/components/icon/icon_constants.js';
@@ -243,8 +244,8 @@ export default {
      */
     iconSize: {
       type: String,
-      default: '500',
-      validator: (size) => Object.keys(ICON_SIZE_MODIFIERS).includes(size),
+      default: '',
+      validator: (size) => !size || Object.keys(ICON_SIZE_MODIFIERS).includes(size),
     },
 
     /**
@@ -261,6 +262,7 @@ export default {
       AVATAR_SIZE_MODIFIERS,
       AVATAR_KIND_MODIFIERS,
       AVATAR_PRESENCE_SIZE_MODIFIERS,
+      AVATAR_ICON_SIZES,
       imageLoadedSuccessfully: null,
       formattedInitials: '',
       initializing: false,

--- a/components/avatar/avatar_constants.js
+++ b/components/avatar/avatar_constants.js
@@ -26,7 +26,7 @@ export const AVATAR_PRESENCE_STATES = {
 };
 
 export const AVATAR_ICON_SIZES = {
-  xs: undefined,
+  xs: '100',
   sm: '200',
   md: '300',
   lg: '500',


### PR DESCRIPTION
# Fix (Avatar): Dynamic icon sizes

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added back icon sizes according to avatar size

## :bulb: Context

We were missing the dynamic icon size according to the avatar's selected size, can't remember when we loosed this functionality.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

![image](https://github.com/dialpad/dialtone-vue/assets/87546543/df9ea048-7c2a-441c-be4e-c0c84d80279d)