### PR TITLE
fix(unread-pill): contrasting unread messages

### DIFF
--- a/recipes/leftbar/unread_pill/unread_pill.vue
+++ b/recipes/leftbar/unread_pill/unread_pill.vue
@@ -80,8 +80,8 @@ export default {
   }
 
   &--messages {
-    background-color: var(--dt-color-surface-primary);
-    color: var(--dt-color-foreground-primary);
+    background-color: var(--dt-color-surface-contrast);
+    color: var(--dt-color-foreground-secondary-inverted);
   }
 }
 </style>


### PR DESCRIPTION
# Contrasting Unread Messages pill

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

**Unread Messages** pill lacked all contrast in both light and dark.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

![image](https://github.com/dialpad/dialtone-vue/assets/1165933/026c76a2-50b0-457b-a09d-84b97a92b2d7)
