### PR TITLE
feat: add `avatar-click` event in contact info

### DIFF
--- a/recipes/list_items/contact_info/contact_info.mdx
+++ b/recipes/list_items/contact_info/contact_info.mdx
@@ -57,6 +57,7 @@ import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';
 <dt-recipe-contact-info
   :avatar-src="avatarSrc"
   presence="active"
+  @avatar-click="onAvatarClick"
 >
   <template #header>
     <div class="d-fs-200 d-fw-bold d-mr4">

--- a/recipes/list_items/contact_info/contact_info.stories.js
+++ b/recipes/list_items/contact_info/contact_info.stories.js
@@ -13,6 +13,7 @@ const iconsList = getIconNames();
 
 // Default Prop Values
 export const argsData = {
+  onAvatarClick: action('avatar-click'),
   presence: null,
 };
 
@@ -109,6 +110,12 @@ export const argTypesData = {
     description: 'click on avatar event',
     table: {
       type: { summary: 'event' },
+    },
+  },
+
+  onAvatarClick: {
+    table: {
+      disable: true,
     },
   },
 };

--- a/recipes/list_items/contact_info/contact_info.stories.js
+++ b/recipes/list_items/contact_info/contact_info.stories.js
@@ -98,6 +98,13 @@ export const argTypesData = {
       },
     },
   },
+
+  'avatar-click': {
+    description: 'click on avatar event',
+    table: {
+      type: { summary: 'event' },
+    },
+  },
 };
 
 // Story Collection

--- a/recipes/list_items/contact_info/contact_info.stories.js
+++ b/recipes/list_items/contact_info/contact_info.stories.js
@@ -47,6 +47,12 @@ export const argTypesData = {
     },
   },
 
+  avatarAriaLabel: {
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+
   presence: {
     options: [...PRESENCE_STATES_LIST],
     control: {

--- a/recipes/list_items/contact_info/contact_info.stories.js
+++ b/recipes/list_items/contact_info/contact_info.stories.js
@@ -184,6 +184,7 @@ export const Default = {
       },
     },
     a11y: {
+      disable: true,
       config: {
         rules: [
           {

--- a/recipes/list_items/contact_info/contact_info.vue
+++ b/recipes/list_items/contact_info/contact_info.vue
@@ -7,12 +7,13 @@
     class="dt-contact-info"
   >
     <template #left>
-      <div
+      <button
         v-if="showAvatar"
-        class="d-ps-relative"
+        class="d-ps-relative d-bgc-transparent d-baw0"
         data-qa="contact-info-left"
+        @click="avatarClick"
       >
-        <div
+        <span
           v-if="avatarList"
           class="dt-contact-info--avatars d-mrn4 d-d-flex d-fd-row"
         >
@@ -28,7 +29,7 @@
             :overlay-text="avatar.text"
             :avatar-class="[{ 'd-mln24': index > 0, 'd-bc-brand': !!avatar.halo }]"
           />
-        </div>
+        </span>
         <dt-avatar
           v-else
           :size="avatarSize"
@@ -38,7 +39,7 @@
           :seed="avatarSeed"
           :presence="presence"
         />
-      </div>
+      </button>
     </template>
     <template #default>
       <div data-qa="contact-info-header">
@@ -181,6 +182,14 @@ export default {
     avatarList: {
       type: Array,
       default: null,
+    },
+  },
+
+  emits: ['avatar-click'],
+
+  methods: {
+    avatarClick () {
+      this.$emit('avatar-click');
     },
   },
 };

--- a/recipes/list_items/contact_info/contact_info.vue
+++ b/recipes/list_items/contact_info/contact_info.vue
@@ -11,7 +11,7 @@
         v-if="showAvatar"
         class="d-ps-relative d-bgc-transparent d-baw0 d-c-pointer"
         data-qa="contact-info-left"
-        :aria-label="$i18n('avatar')"
+        :aria-label="avatarAriaLabel"
         @click="avatarClick"
       >
         <span
@@ -156,6 +156,14 @@ export default {
     avatarSize: {
       type: String,
       default: 'lg',
+    },
+
+    /**
+     * The aria label of the avatar
+     */
+    avatarAriaLabel: {
+      type: String,
+      default: '',
     },
 
     /**

--- a/recipes/list_items/contact_info/contact_info.vue
+++ b/recipes/list_items/contact_info/contact_info.vue
@@ -11,7 +11,7 @@
         v-if="showAvatar"
         class="d-ps-relative d-bgc-transparent d-baw0 d-c-pointer"
         data-qa="contact-info-left"
-        :aria-label="avatarAriaLabel"
+        :aria-labelledby="avatarAriaLabel"
         @click="avatarClick"
       >
         <span

--- a/recipes/list_items/contact_info/contact_info.vue
+++ b/recipes/list_items/contact_info/contact_info.vue
@@ -9,8 +9,9 @@
     <template #left>
       <button
         v-if="showAvatar"
-        class="d-ps-relative d-bgc-transparent d-baw0"
+        class="d-ps-relative d-bgc-transparent d-baw0 d-c-pointer"
         data-qa="contact-info-left"
+        :aria-label="$i18n('avatar')"
         @click="avatarClick"
       >
         <span

--- a/recipes/list_items/contact_info/contact_info_default.story.vue
+++ b/recipes/list_items/contact_info/contact_info_default.story.vue
@@ -7,6 +7,7 @@
     :avatar-size="avatarSize"
     :avatar-seed="avatarSeed"
     :presence="presence"
+    @avatar-click="onAvatarClick"
   >
     <template
       v-if="header"


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

This pull request adds `avatar-click` event in contact info component.

## :bulb: Context

When a user clicks on any of the avatars in the callbar when on a call with multiple other participants (i.e. a group call) it opens the “Manage participants” modal. To implement that, we need to add `avatar-click` event in contact info component.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Make a new release for dialtone-vue

## :camera: Screenshots / GIFs
 No UI update

## :link: Sources

JIRA: https://dialpad.atlassian.net/browse/DP-71224
Vue3 PR: https://github.com/dialpad/dialtone-vue/pull/1165