### PR TITLE
fix(image-viewer): fix close icon not visible on dark mode

### DIFF
--- a/components/image_viewer/image_viewer.vue
+++ b/components/image_viewer/image_viewer.vue
@@ -51,6 +51,7 @@
           >
             <template #icon>
               <dt-icon
+                class="d-fc-neutral-white"
                 name="close"
                 size="400"
               />


### PR DESCRIPTION
# PR Title

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Hard code the close button to white as we don't want it inverting on dark mode (Otherwise it blends into the background)


## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs
<img width="941" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/92543354/bb7a636c-eb34-441b-b02a-e675ac5aeccd">
<img width="937" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/92543354/f3351062-eb16-48aa-a32e-2ddb78ea3c63">

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

https://dialpad.atlassian.net/browse/DP-79085
<!--- Add any links to external reference material -->
