### PR TITLE
feat(leftbar-row): add new icon color for contact center type

### DIFF
--- a/recipes/leftbar/general_row/general_row_constants.js
+++ b/recipes/leftbar/general_row/general_row_constants.js
@@ -39,6 +39,7 @@ export const LEFTBAR_GENERAL_ROW_CONTACT_CENTER_COLORS = {
   'purple-100': 'd-bgc-purple-100',
   'magenta-400': 'd-bgc-magenta-400',
   'magenta-100': 'd-bgc-magenta-100',
+  'black-300': 'd-bgc-black-300',
 };
 
 export const LEFTBAR_GENERAL_ROW_CONTACT_CENTER_VALIDATION_ERROR = 'If type is contact center, color must be one' +


### PR DESCRIPTION
# Add leftbar item icon color

[DP-80384](https://dialpad.atlassian.net/browse/DP-80384)

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

As part of a redesign in the Contact Centers, we need add a new color for the square icon color in the leftbar item recipe.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root
-- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

![image-20230913-163856](https://github.com/dialpad/dialtone-vue/assets/547211/eeab5993-00ef-4a25-9413-16cf5ead4ae2)

[Figma link](https://www.figma.com/file/3rPXbc4k15ywmnVAM6Yrf6/%5BDP-74441%5D-Design-for-Busy-State-in-Supervisor-View?type=design&node-id=410%3A14812&mode=design&t=MU7UbOJbf3i6vzkJ-1)

[DP-80384]: https://dialpad.atlassian.net/browse/DP-80384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ