### PR TITLE
feat(message-input): add focus method

### DIFF
--- a/recipes/conversation_view/message_input/message_input.test.js
+++ b/recipes/conversation_view/message_input/message_input.test.js
@@ -138,6 +138,12 @@ describe('DtMessage tests', () => {
         await messageInputEl.trigger('focusin');
         expect(messageInputEl.classes('d-bc-black-500')).toBe(true);
       });
+
+      it('should programmatically focus to input', async () => {
+        wrapper.vm.focus();
+        await wrapper.vm.$nextTick();
+        expect(messageInputEl.classes('d-bc-black-500')).toBe(true);
+      });
     });
 
     describe('When character Limit is disabled', () => {

--- a/recipes/conversation_view/message_input/message_input.vue
+++ b/recipes/conversation_view/message_input/message_input.vue
@@ -623,6 +623,11 @@ export default {
     noticeClose () {
       this.$emit('notice-close', true);
     },
+
+    focus () {
+      this.$refs.richTextEditor.focusEditor();
+      this.hasFocus = true;
+    },
   },
 };
 </script>

--- a/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="d-h264">
     <dt-recipe-message-input
+      ref="input"
       v-model:show-notice="$attrs.showNotice"
       v-model="$attrs.modelValue"
       :input-aria-label="$attrs.inputAriaLabel"
@@ -48,6 +49,9 @@
       </template>
     </dt-recipe-message-input>
   </div>
+  <button @click="$refs.input.focus()">
+    focus test
+  </button>
 </template>
 
 <script>


### PR DESCRIPTION
# [VUE3 only] add focus method to message input

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

To fix a11y issues we need focus method on message input to programmatically set the focus state

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [ ] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root


## :camera: Screenshots / GIFs

Storybook:
![image](https://github.com/dialpad/dialtone-vue/assets/31652572/1ac0bc2c-6623-46ef-8256-4b85510f6354)


## :link: Sources

<!--- Add any links to external reference material -->
