### PR TITLE
fix(avatar): change avatar seed algorithm to sync with android

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -4,7 +4,6 @@ import {
   VALIDATION_MESSAGE_TYPES,
 } from './constants';
 import Vue from 'vue';
-import fnv from 'fnv-plus';
 
 let UNIQUE_ID_COUNTER = 0;
 let TIMER;
@@ -33,11 +32,35 @@ export function getUniqueString (prefix = DEFAULT_PREFIX) {
  */
 export function getRandomElement (array, seed) {
   if (seed) {
-    const hash = fnv.hash(seed);
-    return array[hash.value % array.length];
+    const hash = javaHashCode(seed);
+    return array[Math.abs(hash) % array.length];
   } else {
     return array[getRandomInt(array.length)];
   }
+}
+
+/**
+ * Returns a hash code for a string.
+ * (Compatible to Java's String.hashCode())
+ * We use this algo to be in sync with android.
+ *
+ * The hash code for a string object is computed as
+ *     s[0]*31^(n-1) + s[1]*31^(n-2) + ... + s[n-1]
+ * using number arithmetic, where s[i] is the i th character
+ * of the given string, n is the length of the string,
+ * and ^ indicates exponentiation.
+ * (The hash value of the empty string is zero.)
+ *
+ * @param {string} str a string
+ * @return {number} a hash code value for the given string.
+ */
+export function javaHashCode (str) {
+  let h;
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(31, h) + str.charCodeAt(i) | 0;
+  }
+
+  return h;
 }
 
 /**

--- a/components/avatar/avatar.test.js
+++ b/components/avatar/avatar.test.js
@@ -166,6 +166,21 @@ describe('DtAvatar Tests', () => {
       });
     });
 
+    describe('When seed is set', () => {
+      // note we keep these tests in sync with the android team, so do not change without communicating with them.
+      it.each([
+        ['a', 'd-avatar--color-800'],
+        ['aaa', 'd-avatar--color-400'],
+        ['bbbbb', 'd-avatar--color-1100'],
+      ])('when seed is set to: %s color class: %s should be set on avatar', (seed, expectedClass) => {
+        mockProps = { seed };
+
+        updateWrapper();
+
+        expect(wrapper.classes(expectedClass)).toBe(true);
+      });
+    });
+
     describe('With Presence', () => {
       it('should not render presence if presence prop is not defined', async () => {
         await wrapper.setProps({ presence: null });

--- a/components/avatar/avatar_constants.js
+++ b/components/avatar/avatar_constants.js
@@ -34,7 +34,6 @@ export const AVATAR_ICON_SIZES = {
 };
 
 export const AVATAR_COLORS = [
-  undefined,
   '100',
   '200',
   '300',

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "date-fns": "^2.30.0",
         "emoji-regex": "^10.2.1",
         "emoji-toolkit": "^6.6.0",
-        "fnv-plus": "^1.3.1",
         "tippy.js": "^6.3.7"
       },
       "devDependencies": {
@@ -17877,11 +17876,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/fnv-plus": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/fnv-plus/-/fnv-plus-1.3.1.tgz",
-      "integrity": "sha512-Gz1EvfOneuFfk4yG458dJ3TLJ7gV19q3OM/vVvvHf7eT02Hm1DleB4edsia6ahbKgAYxO9gvyQ1ioWZR+a00Yw=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.2",
@@ -53071,11 +53065,6 @@
       "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.213.1.tgz",
       "integrity": "sha512-l+vyZO6hrWG60DredryA8mq62fK9vxL6/RR13HA/aVLBNh9No/wEJsKI+CJqPRkF4CIRUfcJQBeaMXSKcncxUQ==",
       "dev": true
-    },
-    "fnv-plus": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/fnv-plus/-/fnv-plus-1.3.1.tgz",
-      "integrity": "sha512-Gz1EvfOneuFfk4yG458dJ3TLJ7gV19q3OM/vVvvHf7eT02Hm1DleB4edsia6ahbKgAYxO9gvyQ1ioWZR+a00Yw=="
     },
     "follow-redirects": {
       "version": "1.15.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "date-fns": "^2.30.0",
     "emoji-regex": "^10.2.1",
     "emoji-toolkit": "^6.6.0",
-    "fnv-plus": "^1.3.1",
     "tippy.js": "^6.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
# fix(avatar): change avatar seed algorithm to sync with android

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Meant to do this a while back but forgot. Updated our avatar random generation algorithm to sync with android. 

## :bulb: Context

Our previous hashing algo FNV was not easy to implement on android, so I've updated our code to use the same algo as java's "hashCode". Our user avatar colors on web and mobile will be in sync after this change.

The exact same tests I've implemented here are also implemented on android, so we should be able to remain in sync.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [x] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Needs to be updated in Dialpad

## :link: Sources

https://www.w3schools.com/java/ref_string_hashcode.asp