### PR TITLE
fix(recipe-callbar-button-with-popover): change event name and sync open state

### DIFF
--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
@@ -17,7 +17,7 @@ const iconsList = getIconNames();
 export const argsData = {
   buttonWidthSize: 'xl',
   openPopover: false,
-  onArrowClick: action('arrowClick'),
+  onArrowClick: action('arrow-click'),
   onClick: action('click'),
   onOpened: action('opened'),
 };
@@ -138,13 +138,18 @@ export const argTypesData = {
   },
 
   // Action Event Handlers
-  arrowClick: {
+  'arrow-click': {
     description: 'Triggered when the arrow is clicked',
     table: {
       disable: false,
       type: {
         summary: 'event',
       },
+    },
+  },
+  onArrowClick: {
+    table: {
+      disable: true,
     },
   },
   click: {

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.test.js
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.test.js
@@ -140,10 +140,10 @@ describe('DtRecipeCallbarButtonWithPopover Tests', () => {
   describe('Interactivity Tests', () => {
     describe('When clicking on the button', () => {
       it(
-        'should trigger the "arrowClick" event when no listener attached',
+        'should trigger the "arrow-click" event when no listener attached',
         async () => {
           await button.find('button').trigger('click');
-          const arrowClickEvents = wrapper.emitted().arrowClick;
+          const arrowClickEvents = wrapper.emitted()['arrow-click'];
           expect(arrowClickEvents.length).toBe(1);
         },
       );
@@ -174,8 +174,8 @@ describe('DtRecipeCallbarButtonWithPopover Tests', () => {
         expect(wrapper.vm.open).toBe(true);
       });
 
-      it('should trigger the "arrowClick" event', () => {
-        const arrowClickEvents = wrapper.emitted().arrowClick;
+      it('should trigger the "arrow-click" event', () => {
+        const arrowClickEvents = wrapper.emitted()['arrow-click'];
         expect(arrowClickEvents.length).toBe(1);
       });
     });

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -249,7 +249,7 @@ export default {
     /**
      * Emitted when the arrow is clicked
      */
-    'arrowClick',
+    'arrow-click',
 
     /**
      * Native click event
@@ -282,17 +282,26 @@ export default {
 
     showPopover () {
       if (!this.openPopover || this.open) {
+        this.syncOpenState();
         return false;
       }
 
-      return this.arrowClick();
+      return this.toggleOpen();
     },
   },
 
   methods: {
     arrowClick (ev) {
-      this.$emit('arrowClick', ev);
+      this.$emit('arrow-click', ev);
+      return this.toggleOpen();
+    },
+
+    toggleOpen () {
       return (this.open = !this.open);
+    },
+
+    syncOpenState () {
+      this.open = this.openPopover;
     },
 
     buttonClick (ev) {

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_default.story.vue
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_default.story.vue
@@ -15,7 +15,7 @@
     :text-class="textClass"
     :content-class="contentClass"
     :open-popover="openPopover"
-    @arrow-click="onClick"
+    @arrow-click="onArrowClick"
     @click="onClick"
     @opened="onOpened"
   >


### PR DESCRIPTION
# fix(recipe-callbar-button-with-popover): change event name and sync open state

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

<!--- Describe the changes -->
1. The arrow click event name should change to `arrow-click`, or we'll get "vue/v-on-event-hyphenation" warning.
2. The open state should be synced with `openPopover` property, or it will cause issue https://dialpad.atlassian.net/browse/DP-80569

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

Raise PR in UV and add `arrow-click` event handle in parent component.

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->

https://dialpad.atlassian.net/browse/DP-80569
