### PR TITLE
fix(contact-info, feed-item-row, item-layout): alignment issues

### DIFF
--- a/components/item_layout/item_layout.vue
+++ b/components/item_layout/item_layout.vue
@@ -72,3 +72,16 @@ export default {
   },
 };
 </script>
+
+<style lang="less" scoped>
+// Move this to dialtone
+.dt-item-layout {
+  align-items: stretch;
+
+  &--content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+}
+</style>

--- a/recipes/conversation_view/feed_item_row/feed_item_row.test.js
+++ b/recipes/conversation_view/feed_item_row/feed_item_row.test.js
@@ -36,11 +36,11 @@ describe('DtFeedItemRow tests', () => {
   // Helpers
   const _setChildWrappers = () => {
     avatarImgWrapper = wrapper.find('[data-qa="dt-avatar-image"]');
-    headerWrapper = wrapper.find('[data-qa="feed-item-row-header"]');
-    leftTimeWrapper = wrapper.find('[data-qa="feed-item-row-left-time"]');
-    contentWrapper = wrapper.find('[data-qa="feed-item-row-content"]');
-    reactionsWrapper = wrapper.find('[data-qa="feed-item-row-reactions"]');
-    menuWrapper = wrapper.find('[data-qa="feed-item-row-menu"]');
+    headerWrapper = wrapper.find('[data-qa="dt-feed-item-row--header"]');
+    leftTimeWrapper = wrapper.find('[data-qa="dt-feed-item-row--left-time"]');
+    contentWrapper = wrapper.find('[data-qa="dt-feed-item-row--content"]');
+    reactionsWrapper = wrapper.find('[data-qa="dt-feed-item-row--reactions"]');
+    menuWrapper = wrapper.find('[data-qa="dt-feed-item-row--menu"]');
   };
 
   const _mountWrapper = () => {

--- a/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -4,7 +4,7 @@
     navigation-type="none"
     v-bind="$attrs"
     :class="listItemClasses"
-    data-qa="feed-item-row"
+    data-qa="dt-feed-item-row"
     v-on="feedListeners"
   >
     <!-- Avatar or time -->
@@ -13,7 +13,6 @@
         v-if="showHeader"
         :full-name="displayName"
         :image-src="avatarImageUrl"
-        avatar-class="d-mt8 d-ps-absolute d-t0"
         :seed="avatarSeed"
       />
       <!-- show time instead of avatar when headers not present -->
@@ -21,7 +20,7 @@
         v-if="!showHeader"
         v-show="isActive"
         class="d-fs-100 d-fw-normal d-ws-nowrap d-lh-100 d-fc-tertiary d-mb6"
-        data-qa="feed-item-row-left-time"
+        data-qa="dt-feed-item-row--left-time"
       >
         {{ shortTime }}
       </div>
@@ -31,7 +30,7 @@
       <!-- Feed Item -->
       <div
         v-if="showHeader"
-        data-qa="feed-item-row-header"
+        data-qa="dt-feed-item-row--header"
         class="d-d-flex d-ai-center"
       >
         <p class="d-fs-200 d-lh-300 d-fw-bold d-to-ellipsis d-of-hidden d-ws-nowrap">
@@ -46,7 +45,7 @@
       <!-- @slot Default content slot for feed item row -->
       <span
         class="content-text-wrapper-class"
-        data-qa="feed-item-row-content"
+        data-qa="dt-feed-item-row--content"
       >
         <slot />
       </span>
@@ -55,7 +54,7 @@
     <template #bottom>
       <div
         class="d-d-flex d-fw-wrap"
-        data-qa="feed-item-row-reactions"
+        data-qa="dt-feed-item-row--reactions"
       >
         <!-- @slot Slot for reactions row component -->
         <slot name="reactions" />
@@ -68,7 +67,7 @@
     <template #right>
       <div
         v-show="isActive"
-        data-qa="feed-item-row-menu"
+        data-qa="dt-feed-item-row--menu"
         class="d-ps-absolute d-tn16 d-r12"
       >
         <dt-lazy-show
@@ -212,7 +211,7 @@ export default {
         'd-px8',
         { 'd-bgc-secondary-opaque': this.isActive && this.state === DEFAULT_FEED_ROW_STATE },
         FEED_ROW_STATE_BACKGROUND_COLOR[this.state],
-        'feed-item-row',
+        'dt-feed-item-row',
         'd-t',
         'd-tp-bgc',
       ];
@@ -241,12 +240,19 @@ export default {
 };
 </script>
 
-<style lang="less">
-content-text-wrapper-class:not(img) {
-  line-height: 1.6rem;
-}
-
-.feed-item-row {
+<style lang="less" scoped>
+.dt-feed-item-row {
   transition-duration: 2s !important;
+
+  .content-text-wrapper-class:not(img) {
+    line-height: 1.6rem;
+  }
+
+  &:deep(.dt-item-layout--left) {
+    .d-avatar {
+      align-self: flex-start;
+      margin-top: var(--dt-space-300);
+    }
+  }
 }
 </style>

--- a/recipes/list_items/contact_info/contact_info.vue
+++ b/recipes/list_items/contact_info/contact_info.vue
@@ -208,6 +208,12 @@ export default {
 .dt-contact-info {
   --contact-info-avatar-border-color: var(--dt-color-surface-primary);
 
+  display: flex;
+
+  &:deep(.dt-item-layout) {
+    flex: 1 1 0;
+  }
+
   &:deep(.dt-item-layout--content) {
     /*
     DP-74536: Add `min-width` to make the width of "contact info" adjustable.
@@ -221,6 +227,7 @@ export default {
     */
     min-width: var(--dt-space-650);
     justify-content: flex-start;
+    align-items: center;
   }
 
   &:deep(.dt-item-layout--right) {
@@ -228,6 +235,7 @@ export default {
     DP-74536: Remove `min-width` which cause extra unused empty space on the right of "contact info".
     */
     min-width: 0;
+    align-items: center;
   }
 
   &--avatars .d-avatar {


### PR DESCRIPTION
# Fix (Contact row, Feed item row, Item layout): Alignment issues

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

- Fixed alignment issues with `dt-item-layout` based components
- Fixed class not being applied to  `content-text-wrapper-class`, is this the right styling now or was it correct before the class being applied?
- Renamed `feed-item-row*` references to `dt-feed-item-row*` to correct naming convention.

## :bulb: Context

Alignment issues were reported: https://dialpad.atlassian.net/browse/DP-80497 and found others while fixing them.

In this PR: https://github.com/dialpad/dialtone-vue/pull/1170 absolute positioning was beign used which is not correct, also we shouldn't use utility classes on dialtone-vue components anymore, so fixed it also.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

- Move `.dt-item-layout` styles to dialtone