### PR TITLE
fix(item-layout): selected slot alignment

### DIFF
--- a/components/item_layout/item_layout.vue
+++ b/components/item_layout/item_layout.vue
@@ -48,8 +48,14 @@
       <!-- @slot Slot for right content -->
       <slot name="right" />
     </section>
-    <!-- @slot Slot for selected icon -->
-    <slot name="selected" />
+    <section
+      v-if="$slots.selected"
+      data-qa="dt-item-layout-selected-wrapper"
+      class="dt-item-layout--selected"
+    >
+      <!-- @slot Slot for selected icon -->
+      <slot name="selected" />
+    </section>
   </component>
 </template>
 
@@ -82,6 +88,11 @@ export default {
     display: flex;
     flex-direction: column;
     justify-content: center;
+  }
+
+  &--selected {
+    display: flex;
+    align-items: center;
   }
 }
 </style>


### PR DESCRIPTION
# Fix (Item layout): Selected slot alignment

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added a wrapper around the selected slot to style the content.

## :bulb: Context

The selected slot was misaligned after #1186, this will fix the issue

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

<img width="784" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/87546543/5d6fbf4b-645f-421e-bc78-fc03910d6085">
