### PR TITLE
fix(callbox): video height

### DIFF
--- a/recipes/leftbar/callbox/callbox.vue
+++ b/recipes/leftbar/callbox/callbox.vue
@@ -198,10 +198,7 @@ export default {
     display: flex;
     border-radius: var(--dt-size-radius-200) var(--dt-size-radius-200) 0 0;
     overflow: clip;
-
-    & ~ .dt-recipe-callbox--main-content {
-      border-radius: 0 0 var(--dt-size-radius-300) var(--dt-size-radius-300);
-    }
+    margin-bottom: var(--dt-space-300-negative);
   }
 
   &--main-content {

--- a/recipes/leftbar/callbox/callbox.vue
+++ b/recipes/leftbar/callbox/callbox.vue
@@ -195,15 +195,12 @@ export default {
   border-radius: var(--dt-size-radius-300);
 
   &--video {
+    display: flex;
     border-radius: var(--dt-size-radius-200) var(--dt-size-radius-200) 0 0;
     overflow: clip;
-    height: calc(var(--dt-size-760) + var(--dt-size-650));
-    margin-bottom: var(--dt-size-300-negative);
 
-    :deep(img) {
-      object-fit: cover;
-      width: 100%;
-      height: 100%;
+    & ~ .dt-recipe-callbox--main-content {
+      border-radius: 0 0 var(--dt-size-radius-300) var(--dt-size-radius-300);
     }
   }
 

--- a/recipes/leftbar/callbox/callbox_variants.story.vue
+++ b/recipes/leftbar/callbox/callbox_variants.story.vue
@@ -93,6 +93,7 @@
         <img
           src="/common/assets/chatting-person-example.png"
           alt="person avatar"
+          class="callbox-image"
         >
       </template>
       <template #subtitle>
@@ -413,3 +414,11 @@ export default {
   components: { DtItemLayout, DtIcon, DtButton, DtRecipeCallbox },
 };
 </script>
+
+<style lang="less" scoped>
+.callbox-image {
+  height: 140px;
+  object-fit: cover;
+  width: 100%;
+}
+</style>


### PR DESCRIPTION
# Fix (Callbox): Video height

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

- Removed video slot default height
- Changed to `display: flex` so the items fill the available space easier

## :bulb: Context

Found issues on video slot, it only needs to be shown when actually having content

<img width="284" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/87546543/f3e701c6-a503-45df-83e4-964d517be6e7">

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Release and update on product

## :camera: Screenshots / GIFs

![image](https://github.com/dialpad/dialtone-vue/assets/87546543/9428853d-4add-48b4-bab5-a33e5ba05ce0)
