### PR TITLE
fix(callbox, avatar): events and styling

### DIFF
--- a/components/avatar/avatar.vue
+++ b/components/avatar/avatar.vue
@@ -5,7 +5,7 @@
     :class="avatarClasses"
     data-qa="dt-avatar"
     :aria-label="buttonAriaLabel"
-    @click.stop="handleClick"
+    @click="handleClick"
   >
     <div
       ref="canvas"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@commitlint/cli": "^17.6.6",
         "@commitlint/config-conventional": "^17.6.6",
         "@dialpad/conventional-changelog-angular": "^1.1.1",
-        "@dialpad/dialtone": "^8.15.0",
+        "@dialpad/dialtone": "^8.16.1",
         "@dialpad/semantic-release-changelog-json": "^1.0.0",
         "@percy/cli": "^1.26.2",
         "@percy/storybook": "^4.3.6",
@@ -2615,11 +2615,12 @@
       }
     },
     "node_modules/@dialpad/dialtone": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-8.15.0.tgz",
-      "integrity": "sha512-EBeyCiEfiRn9HCVxQA5bEoBP+YhiNMTfFBgofU2ocrV+ybAD2XrJZ6LJzr2lPvFpD0FtuynwtP6JLXT6EeqA8w==",
+      "version": "8.16.1",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-8.16.1.tgz",
+      "integrity": "sha512-PabATV0QCHfyrK1q/N8tM8IDXJ10T5QCU56a4xNQVJO6o60OnzGxLqI5FXsEgu1tDFMPyJl2UTFe/5JfMLEk8w==",
       "dev": true,
       "dependencies": {
+        "@dialpad/dialtone-icons": "^3.2.0",
         "docopt": "^0.6.2"
       },
       "bin": {
@@ -2638,6 +2639,118 @@
       "integrity": "sha512-5tS0o/0vHtBbQT9RXsjw7jinRQlIZO9+gzgPzsVTFcHhNOXQtcrzFKMhZltCce+1H2j9heGsuO78M+Po9HAt/w==",
       "peerDependencies": {
         "vue": ">=2.6"
+      }
+    },
+    "node_modules/@dialpad/dialtone/node_modules/@dialpad/dialtone-icons": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-3.2.0.tgz",
+      "integrity": "sha512-zzvdJXitzmt5bfO/XnHULhqUuvD4cm57UU2xCbDTuEsqOAyYE4Qxa6DPbjHIOfDl92Rdb0N9R8+R35O4YjcbxQ==",
+      "dev": true,
+      "peerDependencies": {
+        "vue": ">=3.2"
+      }
+    },
+    "node_modules/@dialpad/dialtone/node_modules/@vue/compiler-core": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
+      "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.21.3",
+        "@vue/shared": "3.3.4",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@dialpad/dialtone/node_modules/@vue/compiler-dom": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
+      "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.3.4",
+        "@vue/shared": "3.3.4"
+      }
+    },
+    "node_modules/@dialpad/dialtone/node_modules/@vue/compiler-sfc": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
+      "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@vue/compiler-core": "3.3.4",
+        "@vue/compiler-dom": "3.3.4",
+        "@vue/compiler-ssr": "3.3.4",
+        "@vue/reactivity-transform": "3.3.4",
+        "@vue/shared": "3.3.4",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.0",
+        "postcss": "^8.1.10",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@dialpad/dialtone/node_modules/@vue/compiler-ssr": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
+      "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.3.4",
+        "@vue/shared": "3.3.4"
+      }
+    },
+    "node_modules/@dialpad/dialtone/node_modules/@vue/reactivity-transform": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
+      "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@vue/compiler-core": "3.3.4",
+        "@vue/shared": "3.3.4",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.0"
+      }
+    },
+    "node_modules/@dialpad/dialtone/node_modules/@vue/server-renderer": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
+      "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-ssr": "3.3.4",
+        "@vue/shared": "3.3.4"
+      },
+      "peerDependencies": {
+        "vue": "3.3.4"
+      }
+    },
+    "node_modules/@dialpad/dialtone/node_modules/@vue/shared": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@dialpad/dialtone/node_modules/vue": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
+      "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.3.4",
+        "@vue/compiler-sfc": "3.3.4",
+        "@vue/runtime-dom": "3.3.4",
+        "@vue/server-renderer": "3.3.4",
+        "@vue/shared": "3.3.4"
       }
     },
     "node_modules/@dialpad/semantic-release-changelog-json": {
@@ -11075,6 +11188,43 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
       "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
       "dev": true
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
+      "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@vue/reactivity": "3.3.4",
+        "@vue/shared": "3.3.4"
+      }
+    },
+    "node_modules/@vue/runtime-core/node_modules/@vue/shared": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
+      "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@vue/runtime-core": "3.3.4",
+        "@vue/shared": "3.3.4",
+        "csstype": "^3.1.1"
+      }
+    },
+    "node_modules/@vue/runtime-dom/node_modules/@vue/shared": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@vue/shared": {
       "version": "3.3.2",
@@ -41315,12 +41465,122 @@
       }
     },
     "@dialpad/dialtone": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-8.15.0.tgz",
-      "integrity": "sha512-EBeyCiEfiRn9HCVxQA5bEoBP+YhiNMTfFBgofU2ocrV+ybAD2XrJZ6LJzr2lPvFpD0FtuynwtP6JLXT6EeqA8w==",
+      "version": "8.16.1",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-8.16.1.tgz",
+      "integrity": "sha512-PabATV0QCHfyrK1q/N8tM8IDXJ10T5QCU56a4xNQVJO6o60OnzGxLqI5FXsEgu1tDFMPyJl2UTFe/5JfMLEk8w==",
       "dev": true,
       "requires": {
+        "@dialpad/dialtone-icons": "^3.2.0",
         "docopt": "^0.6.2"
+      },
+      "dependencies": {
+        "@dialpad/dialtone-icons": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-3.2.0.tgz",
+          "integrity": "sha512-zzvdJXitzmt5bfO/XnHULhqUuvD4cm57UU2xCbDTuEsqOAyYE4Qxa6DPbjHIOfDl92Rdb0N9R8+R35O4YjcbxQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "@vue/compiler-core": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
+          "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@babel/parser": "^7.21.3",
+            "@vue/shared": "3.3.4",
+            "estree-walker": "^2.0.2",
+            "source-map-js": "^1.0.2"
+          }
+        },
+        "@vue/compiler-dom": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
+          "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@vue/compiler-core": "3.3.4",
+            "@vue/shared": "3.3.4"
+          }
+        },
+        "@vue/compiler-sfc": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
+          "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@babel/parser": "^7.20.15",
+            "@vue/compiler-core": "3.3.4",
+            "@vue/compiler-dom": "3.3.4",
+            "@vue/compiler-ssr": "3.3.4",
+            "@vue/reactivity-transform": "3.3.4",
+            "@vue/shared": "3.3.4",
+            "estree-walker": "^2.0.2",
+            "magic-string": "^0.30.0",
+            "postcss": "^8.1.10",
+            "source-map-js": "^1.0.2"
+          }
+        },
+        "@vue/compiler-ssr": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
+          "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@vue/compiler-dom": "3.3.4",
+            "@vue/shared": "3.3.4"
+          }
+        },
+        "@vue/reactivity-transform": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
+          "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@babel/parser": "^7.20.15",
+            "@vue/compiler-core": "3.3.4",
+            "@vue/shared": "3.3.4",
+            "estree-walker": "^2.0.2",
+            "magic-string": "^0.30.0"
+          }
+        },
+        "@vue/server-renderer": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
+          "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@vue/compiler-ssr": "3.3.4",
+            "@vue/shared": "3.3.4"
+          }
+        },
+        "@vue/shared": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+          "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+          "dev": true,
+          "peer": true
+        },
+        "vue": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
+          "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@vue/compiler-dom": "3.3.4",
+            "@vue/compiler-sfc": "3.3.4",
+            "@vue/runtime-dom": "3.3.4",
+            "@vue/server-renderer": "3.3.4",
+            "@vue/shared": "3.3.4"
+          }
+        }
       }
     },
     "@dialpad/dialtone-icons": {
@@ -47382,6 +47642,47 @@
         "@vue/shared": "3.3.2",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.0"
+      }
+    },
+    "@vue/runtime-core": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
+      "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@vue/reactivity": "3.3.4",
+        "@vue/shared": "3.3.4"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+          "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
+    "@vue/runtime-dom": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
+      "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@vue/runtime-core": "3.3.4",
+        "@vue/shared": "3.3.4",
+        "csstype": "^3.1.1"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+          "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "@vue/shared": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@commitlint/cli": "^17.6.6",
     "@commitlint/config-conventional": "^17.6.6",
     "@dialpad/conventional-changelog-angular": "^1.1.1",
-    "@dialpad/dialtone": "^8.15.0",
+    "@dialpad/dialtone": "^8.16.1",
     "@dialpad/semantic-release-changelog-json": "^1.0.0",
     "@percy/cli": "^1.26.2",
     "@percy/storybook": "^4.3.6",

--- a/recipes/leftbar/callbox/callbox.vue
+++ b/recipes/leftbar/callbox/callbox.vue
@@ -291,12 +291,8 @@ export default {
         box-shadow: var(--dt-shadow-focus);
       }
 
-      &:hover {
-        background-color: var(--dt-action-color-background-muted-hover)
-      }
-
-      &:active {
-        background-color: var(--dt-action-color-background-muted-active)
+      &:hover, &:active {
+        text-decoration: underline;
       }
     }
   }

--- a/recipes/leftbar/callbox/callbox.vue
+++ b/recipes/leftbar/callbox/callbox.vue
@@ -164,6 +164,16 @@ export default {
     },
   },
 
+  emits: [
+    /**
+     * Callbox click event
+     *
+     * @event click
+     * @type {PointerEvent | KeyboardEvent}
+     */
+    'click',
+  ],
+
   computed: {
     shouldShowAvatar () {
       return this.avatarFullName || this.avatarSrc;

--- a/recipes/leftbar/callbox/callbox.vue
+++ b/recipes/leftbar/callbox/callbox.vue
@@ -26,14 +26,14 @@
           :seed="avatarSeed"
           :clickable="clickable"
           size="sm"
-          @click.stop="handleClick"
+          @click="handleClick"
         />
         <div class="dt-recipe-callbox--content">
           <component
             :is="clickable ? 'button' : 'span'"
             data-qa="dt-recipe-callbox--title"
             class="dt-recipe-callbox--content-title"
-            @click.stop="handleClick"
+            @click="handleClick"
           >
             {{ title }}
           </component>

--- a/recipes/leftbar/callbox/callbox_variants.story.vue
+++ b/recipes/leftbar/callbox/callbox_variants.story.vue
@@ -27,11 +27,11 @@
           aria-label="hang call"
           circle
           importance="clear"
+          kind="danger"
         >
           <template #icon>
             <dt-icon
               name="phone-hang-up"
-              class="d-fc-critical"
               size="400"
             />
           </template>
@@ -74,11 +74,11 @@
           aria-label="hang call"
           circle
           importance="clear"
+          kind="danger"
         >
           <template #icon>
             <dt-icon
               name="phone-hang-up"
-              class="d-fc-critical"
               size="400"
             />
           </template>
@@ -128,11 +128,11 @@
           aria-label="hang call"
           circle
           importance="clear"
+          kind="danger"
         >
           <template #icon>
             <dt-icon
               name="phone-hang-up"
-              class="d-fc-critical"
               size="400"
             />
           </template>
@@ -167,11 +167,11 @@
           aria-label="hang call"
           circle
           importance="clear"
+          kind="danger"
         >
           <template #icon>
             <dt-icon
               name="phone-hang-up"
-              class="d-fc-critical"
               size="400"
             />
           </template>
@@ -226,11 +226,11 @@
           aria-label="hang call"
           circle
           importance="clear"
+          kind="danger"
         >
           <template #icon>
             <dt-icon
               name="phone-hang-up"
-              class="d-fc-critical"
               size="400"
             />
           </template>
@@ -259,7 +259,7 @@
         <dt-button
           aria-label="stop call"
           importance="clear"
-          class="d-fc-critical"
+          kind="danger"
         >
           <template #icon>
             <dt-icon
@@ -322,11 +322,11 @@
           aria-label="hang call"
           circle
           importance="clear"
+          kind="danger"
         >
           <template #icon>
             <dt-icon
               name="phone-hang-up"
-              class="d-fc-critical"
               size="400"
             />
           </template>
@@ -368,11 +368,11 @@
           aria-label="hang call"
           circle
           importance="clear"
+          kind="danger"
         >
           <template #icon>
             <dt-icon
               name="phone-hang-up"
-              class="d-fc-critical"
               size="400"
             />
           </template>
@@ -394,7 +394,7 @@
             <dt-button
               aria-label="stop call"
               importance="clear"
-              class="d-fc-critical"
+              kind="danger"
             >
               <template #icon>
                 <dt-icon

--- a/recipes/leftbar/callbox/callbox_variants.story.vue
+++ b/recipes/leftbar/callbox/callbox_variants.story.vue
@@ -188,6 +188,7 @@
         <dt-stack
           direction="row"
           gap="300"
+          class="d-ai-center"
         >
           <dt-icon
             name="share-screen"
@@ -247,12 +248,13 @@
         <dt-stack
           direction="row"
           gap="300"
+          class="d-ai-center"
         >
           <dt-icon
             name="share-screen"
             size="100"
           />
-          <span>Screenshare</span>
+          <p>Screenshare</p>
         </dt-stack>
       </template>
       <template #right>
@@ -282,9 +284,11 @@
         <dt-stack
           direction="row"
           gap="300"
-          class="d-ai-center"
         >
-          <dt-stack direction="row">
+          <dt-stack
+            direction="row"
+            class="d-ai-center"
+          >
             <dt-icon
               name="users"
               size="100"
@@ -295,13 +299,18 @@
           <span class="d-fs-300">
             •
           </span>
-          <dt-icon
-            name="activity"
-            size="100"
-          />
-          <span class="d-to-ellipsis d-ws-nowrap d-of-hidden">
-            Jaqueline Nackos Jaqueline Nackos
-          </span>
+          <dt-stack
+            direction="row"
+            class="d-ai-center d-of-x-hidden"
+          >
+            <dt-icon
+              name="activity"
+              size="100"
+            />
+            <p class="d-to-ellipsis d-ws-nowrap d-of-hidden">
+              Jaqueline Nackos Jaqueline Nackos
+            </p>
+          </dt-stack>
         </dt-stack>
       </template>
       <template #right>
@@ -343,6 +352,7 @@
         <dt-stack
           direction="row"
           gap="300"
+          class="d-ai-center"
         >
           <dt-icon
             name="share-screen"

--- a/recipes/leftbar/callbox/callbox_variants.story.vue
+++ b/recipes/leftbar/callbox/callbox_variants.story.vue
@@ -185,14 +185,16 @@
       border-color="ai"
     >
       <template #subtitle>
-        <div class="d-d-flex d-ai-center">
+        <dt-stack
+          direction="row"
+          gap="300"
+        >
           <dt-icon
             name="share-screen"
             size="100"
-            class="d-mr4"
           />
           <span>06:01</span>
-        </div>
+        </dt-stack>
       </template>
       <template #right>
         <dt-button
@@ -242,14 +244,16 @@
       border-color="ai"
     >
       <template #subtitle>
-        <div class="d-d-flex d-ai-center">
+        <dt-stack
+          direction="row"
+          gap="300"
+        >
           <dt-icon
             name="share-screen"
             size="100"
-            class="d-mr4"
           />
           <span>Screenshare</span>
-        </div>
+        </dt-stack>
       </template>
       <template #right>
         <dt-button
@@ -275,28 +279,30 @@
       clickable
     >
       <template #subtitle>
-        <div class="d-d-flex d-flow4 d-ai-center">
-          <div class="d-d-flex d-ai-center">
+        <dt-stack
+          direction="row"
+          gap="300"
+          class="d-ai-center"
+        >
+          <dt-stack direction="row">
             <dt-icon
               name="users"
               size="100"
               class="d-mr2"
             />
-            <p>3</p>
-          </div>
-          <p class="d-fs-300">
+            <span>3</span>
+          </dt-stack>
+          <span class="d-fs-300">
             •
-          </p>
-          <div class="d-d-flex d-ai-center">
-            <dt-icon
-              name="activity"
-              size="100"
-            />
-          </div>
-          <p class="d-to-ellipsis d-ws-nowrap d-of-hidden">
+          </span>
+          <dt-icon
+            name="activity"
+            size="100"
+          />
+          <span class="d-to-ellipsis d-ws-nowrap d-of-hidden">
             Jaqueline Nackos Jaqueline Nackos
-          </p>
-        </div>
+          </span>
+        </dt-stack>
       </template>
       <template #right>
         <dt-button
@@ -334,14 +340,16 @@
       border-color="ai"
     >
       <template #subtitle>
-        <div class="d-d-flex d-ai-center">
+        <dt-stack
+          direction="row"
+          gap="300"
+        >
           <dt-icon
             name="share-screen"
             size="100"
-            class="d-mr4"
           />
           <span>06:01</span>
-        </div>
+        </dt-stack>
       </template>
       <template #right>
         <dt-button
@@ -408,10 +416,11 @@ import DtRecipeCallbox from './callbox.vue';
 import DtButton from '@/components/button/button.vue';
 import DtIcon from '@/components/icon/icon.vue';
 import DtItemLayout from '@/components/item_layout/item_layout.vue';
+import DtStack from '@/components/stack/stack.vue';
 
 export default {
   name: 'DtRecipeCallboxVariants',
-  components: { DtItemLayout, DtIcon, DtButton, DtRecipeCallbox },
+  components: { DtStack, DtItemLayout, DtIcon, DtButton, DtRecipeCallbox },
 };
 </script>
 


### PR DESCRIPTION
# Fix (Callbox, Avatar): Events and styling

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

- Removed `.stop` modifier from click events to allow click events to bubble up.
- Added `emits` to callbox to avoid duplicating native click event on vue 3
- Changed clickable title styling to use underline instead of background color on :hover and :active.
- Updated callbox variants to use `<dt-stack>` instead of custom divs with `d-d-flex`

## :bulb: Context

Received [design feedback](https://dialpad.atlassian.net/browse/DP-81452) on callbox implementation
Received a [bug report](https://dialpad.atlassian.net/browse/DP-81391) that avatar wasn't triggering the click event correctly.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Release and update on product.

## :camera: Screenshots / GIFs

<img width="356" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/87546543/5eef9af6-d256-4a9b-b64b-a8ef6de577b4">
<img width="360" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/87546543/c6442272-1b20-4eb2-a7a3-5a6316c9472a">
