### PR TITLE
fix(message-input): emoji picker to insert the emoji node into editor

### DIFF
--- a/recipes/conversation_view/message_input/message_input.vue
+++ b/recipes/conversation_view/message_input/message_input.vue
@@ -597,7 +597,13 @@ export default {
         return;
       }
 
-      this.internalInputValue = this.internalInputValue + emoji.shortname;
+      // Insert emoji into the editor
+      this.$refs.richTextEditor.editor.commands.insertContent({
+        type: 'emoji',
+        attrs: {
+          code: emoji.shortname,
+        },
+      });
       this.emojiPickerOpened = false;
     },
 


### PR DESCRIPTION
# fix(message-input): emoji picker to insert the emoji node into editor

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

When an emoji is selected by emoji picker, we currently just insert plain text that does not trigger the emoji plugin to show the exact emoji. it also overwrote the previously rendered emoji. We fix this by using insertContent that allows you to insert the specific node that can be parsed by the plugin. it also makes sure we dont overwrite previous text/ emoji or nodes.


## :link: Sources

https://tiptap.dev/api/commands/insert-content
