### PR TITLE
fix(list-item): apply correct color design tokens

### DIFF
--- a/components/list_item/list_item.vue
+++ b/components/list_item/list_item.vue
@@ -240,6 +240,7 @@ export default {
 <style lang="less">
 .dt-list-item {
   list-style: none;
+  background-color: var(--dt-action-color-background-muted-default);
 
   &:not(.dt-list-item--static) {
     cursor: pointer;

--- a/components/list_item/list_item.vue
+++ b/components/list_item/list_item.vue
@@ -243,17 +243,17 @@ export default {
 
   &:not(.dt-list-item--static) {
     cursor: pointer;
-    border-radius: var(--dt-size-300);
+    border-radius: var(--dt-size-radius-300);
   }
 
   &--focusable:focus,
   &--focusable:focus-within,
   &--highlighted {
-    background-color: var(--dt-color-surface-moderate-opaque);
+    background-color: var(--dt-action-color-background-muted-hover);
   }
 
   &--highlighted:active {
-    background-color: var(--dt-color-surface-bold-opaque);
+    background-color: var(--dt-action-color-background-muted-active);
   }
 
   &--selected-icon {


### PR DESCRIPTION
# List item: apply correct color design tokens

<img width="1181" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/1165933/b8768b70-c9fd-473f-afc0-e85923acab0e">

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

