### PR TITLE
feat(callbox): on hold status

### DIFF
--- a/recipes/leftbar/callbox/callbox.vue
+++ b/recipes/leftbar/callbox/callbox.vue
@@ -165,7 +165,7 @@ export default {
     },
 
     /**
-     * Add an on-hold overlay to the avatar
+     * Controls the avatars overlay icon
      */
     isOnHold: {
       type: Boolean,

--- a/recipes/leftbar/callbox/callbox.vue
+++ b/recipes/leftbar/callbox/callbox.vue
@@ -25,6 +25,7 @@
           :full-name="avatarFullName"
           :seed="avatarSeed"
           :clickable="clickable"
+          :overlay-icon="isOnHold ? 'pause' : null"
           size="sm"
           @click="handleClick"
         />
@@ -159,6 +160,14 @@ export default {
      * emits a click event when clicked.
      */
     clickable: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Add an on-hold overlay to the avatar
+     */
+    isOnHold: {
       type: Boolean,
       default: false,
     },

--- a/recipes/leftbar/callbox/callbox_default.story.vue
+++ b/recipes/leftbar/callbox/callbox_default.story.vue
@@ -8,6 +8,7 @@
     :title="title"
     :border-color="borderColor"
     :clickable="clickable"
+    :is-on-hold="isOnHold"
     @click="onClick"
   >
     <template

--- a/recipes/leftbar/callbox/callbox_variants.story.vue
+++ b/recipes/leftbar/callbox/callbox_variants.story.vue
@@ -418,6 +418,41 @@
         </dt-item-layout>
       </template>
     </dt-recipe-callbox>
+    <dt-recipe-callbox
+      avatar-full-name="Jaqueline Nackos"
+      avatar-seed="Jaqueline Nackos"
+      title="Jaqueline Nackos"
+      is-on-hold
+    >
+      <template #subtitle>
+        <dt-stack
+          direction="row"
+          gap="300"
+          class="d-ai-center"
+        >
+          <dt-icon
+            name="share-screen"
+            size="100"
+          />
+          <span>06:01</span>
+        </dt-stack>
+      </template>
+      <template #right>
+        <dt-button
+          aria-label="hang call"
+          circle
+          importance="clear"
+          kind="danger"
+        >
+          <template #icon>
+            <dt-icon
+              name="phone-hang-up"
+              size="400"
+            />
+          </template>
+        </dt-button>
+      </template>
+    </dt-recipe-callbox>
   </div>
 </template>
 


### PR DESCRIPTION
# Feat (Callbox): On hold status

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Add the `isOnHold` prop that controls the avatars overlay icon to show that the call is on-hold

## :bulb: Context

Need this functionality to solve missing functionality on product: https://dialpad.atlassian.net/browse/DP-81453

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [x] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Release and update on product.

## :camera: Screenshots / GIFs

![image](https://github.com/dialpad/dialtone-vue/assets/87546543/375af4a0-ed98-4d2f-a0be-f886164286e8)