### PR TITLE
chore: add release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:docs": "markdownlint '**/*.mdx'",
     "prepublishOnly": "npm run build",
     "pretest": "npm run clean",
-    "release": "bash ./scripts/release",
+    "release": "./scripts/release.sh",
     "start": "npm run storybook",
     "storybook": "STORYBOOK_ENV=development storybook dev -p 9010",
     "storybook:clean": "rm -rf ./storybook-static",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:docs": "markdownlint '**/*.mdx'",
     "prepublishOnly": "npm run build",
     "pretest": "npm run clean",
-    "release": "semantic-release --no-ci --extends ./release-local.config.cjs",
+    "release": "bash ./scripts/release",
     "start": "npm run storybook",
     "storybook": "STORYBOOK_ENV=development storybook dev -p 9010",
     "storybook:clean": "rm -rf ./storybook-static",

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [[ $branch != "staging" || $branch != "staging-vue3" ]]; then
+  echo "This script can only be run while on staging or staging-vue3 branches"
+  exit 1;
+fi
+
+git pull &&
+semantic-release --no-ci --extends ./release-local.config.cjs;
+
+case $branch in
+  "staging")
+    git checkout production &&
+    git merge --ff-only staging &&
+    git push -u origin production
+    ;;
+
+  "staging-vue3")
+    git checkout vue3 &&
+    git merge --ff-only staging-vue3 &&
+    git push -u origin vue3
+    ;;
+esac

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,7 +3,7 @@ set -e
 
 branch="$(git rev-parse --abbrev-ref HEAD)"
 
-if [[ $branch != "staging" || $branch != "staging-vue3" ]]; then
+if ! [[ "$branch" =~ ^staging(-vue3)?$ ]]; then
   echo "This script can only be run while on staging or staging-vue3 branches"
   exit 1;
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 branch="$(git rev-parse --abbrev-ref HEAD)"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,7 +9,7 @@ if [[ $branch != "staging" || $branch != "staging-vue3" ]]; then
 fi
 
 git pull &&
-semantic-release --no-ci --extends ./release-local.config.cjs;
+npx semantic-release --no-ci --extends ./release-local.config.cjs;
 
 case $branch in
   "staging")


### PR DESCRIPTION
# Chore: Add release script

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added a release script to automate the release command a bit more. This way you only need to be on either staging/staging-vue3 and run `npm run release` and it'd pull the latest changes, run semantic release, checkout to corresponding branch, merge and push the changes.

## :bulb: Context

I always struggle having to read documentation on how to release dialtone-vue again because I forgot the commands and the order and this might lead to some errors.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

Update documentation and remove the unneccesary steps.