### PR TITLE
docs(stack): add new defaults for alignment

### DIFF
--- a/components/stack/stack.vue
+++ b/components/stack/stack.vue
@@ -25,7 +25,10 @@ export default {
     /**
      * Set this prop to the direction to stack the items.
      * You can override the default direction with 'default' key.
-     * All the undefined breakpoints will have 'default' value
+     * All the undefined breakpoints will have 'default' value.
+     * By default, for the column direction it will have `justify-content: flex-start`
+     * and for the row direction `align-items: center`. This can be overriden
+     * by utility classes.
      */
     direction: {
       type: [String, Object],

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@commitlint/cli": "^17.6.6",
         "@commitlint/config-conventional": "^17.6.6",
         "@dialpad/conventional-changelog-angular": "^1.1.1",
-        "@dialpad/dialtone": "^8.16.1",
+        "@dialpad/dialtone": "^8.17.0",
         "@dialpad/semantic-release-changelog-json": "^1.0.0",
         "@percy/cli": "^1.26.2",
         "@percy/storybook": "^4.3.6",
@@ -2615,9 +2615,9 @@
       }
     },
     "node_modules/@dialpad/dialtone": {
-      "version": "8.16.1",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-8.16.1.tgz",
-      "integrity": "sha512-PabATV0QCHfyrK1q/N8tM8IDXJ10T5QCU56a4xNQVJO6o60OnzGxLqI5FXsEgu1tDFMPyJl2UTFe/5JfMLEk8w==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-8.17.0.tgz",
+      "integrity": "sha512-QJRuFM694a3tlhmPjrwPQBH3iRfXnQzkfLPgixiFk5CFJ3TJq474U8h8W/09JCLyniRwgqxKkq4N7sNDbyZ5CA==",
       "dev": true,
       "dependencies": {
         "@dialpad/dialtone-icons": "^3.2.0",
@@ -41465,9 +41465,9 @@
       }
     },
     "@dialpad/dialtone": {
-      "version": "8.16.1",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-8.16.1.tgz",
-      "integrity": "sha512-PabATV0QCHfyrK1q/N8tM8IDXJ10T5QCU56a4xNQVJO6o60OnzGxLqI5FXsEgu1tDFMPyJl2UTFe/5JfMLEk8w==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-8.17.0.tgz",
+      "integrity": "sha512-QJRuFM694a3tlhmPjrwPQBH3iRfXnQzkfLPgixiFk5CFJ3TJq474U8h8W/09JCLyniRwgqxKkq4N7sNDbyZ5CA==",
       "dev": true,
       "requires": {
         "@dialpad/dialtone-icons": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@commitlint/cli": "^17.6.6",
     "@commitlint/config-conventional": "^17.6.6",
     "@dialpad/conventional-changelog-angular": "^1.1.1",
-    "@dialpad/dialtone": "^8.16.1",
+    "@dialpad/dialtone": "^8.17.0",
     "@dialpad/semantic-release-changelog-json": "^1.0.0",
     "@percy/cli": "^1.26.2",
     "@percy/storybook": "^4.3.6",


### PR DESCRIPTION
# docs(stack): add new defaults for alignment
Adds to the docs the new defaults for alignment for the stack component.
Dialtone change: https://github.com/dialpad/dialtone/pull/961
Jira ticket: https://dialpad.atlassian.net/browse/DLT-1265

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [ ] Feature
- [ ] Refactoring
- [x] Documentation

## :book: Description

<!--- Describe the changes -->

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [x] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

<img width="580" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/24460973/d4ff6d2f-e1d9-470e-a253-17a63699c42c">


<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
