### PR TITLE
docs(avatar): missing examples

### DIFF
--- a/components/avatar/avatar_variants.story.vue
+++ b/components/avatar/avatar_variants.story.vue
@@ -42,13 +42,13 @@
       <h2>Presence</h2>
       <div class="d-flow16 d-d-flex d-ai-center">
         <dt-avatar
-          v-for="size in avatarSizes"
-          :key="`presence-${size}`"
+          v-for="state in AVATAR_PRESENCE_STATES"
+          :key="state"
           :seed="seed"
-          :size="size"
+          size="md"
           full-name="Person avatar"
-          presence="busy"
           :image-src="imageSrc"
+          :presence="state"
         />
       </div>
     </div>
@@ -77,12 +77,6 @@
         <dt-avatar
           :seed="seed"
           full-name="Person avatar"
-          :image-src="imageSrc"
-          clickable
-        />
-        <dt-avatar
-          :seed="seed"
-          full-name="Person avatar"
           clickable
         />
         <dt-avatar
@@ -91,6 +85,33 @@
           aria-label="user icon avatar"
           clickable
         />
+        <dt-avatar
+          :seed="seed"
+          full-name="Person avatar"
+          :image-src="imageSrc"
+          clickable
+        />
+      </div>
+    </div>
+    <div>
+      <h2>Group</h2>
+      <div class="d-flow16 d-d-flex">
+        <dt-avatar
+          :seed="seed"
+          full-name="Person avatar"
+          group="3"
+        />
+        <dt-avatar
+          :seed="seed"
+          icon-name="user"
+          group="10"
+        />
+        <dt-avatar
+          :seed="seed"
+          full-name="Person avatar"
+          :image-src="imageSrc"
+          group="100"
+        />
       </div>
     </div>
   </div>
@@ -98,7 +119,7 @@
 
 <script>
 import DtAvatar from './avatar.vue';
-import { AVATAR_SIZE_MODIFIERS } from './avatar_constants.js';
+import { AVATAR_PRESENCE_STATES, AVATAR_SIZE_MODIFIERS } from './avatar_constants.js';
 
 export default {
   name: 'DtAvatarVariants',
@@ -107,6 +128,12 @@ export default {
     return {
       avatarSizes: Object.keys(AVATAR_SIZE_MODIFIERS),
     };
+  },
+
+  computed: {
+    AVATAR_PRESENCE_STATES () {
+      return AVATAR_PRESENCE_STATES;
+    },
   },
 };
 </script>

--- a/components/avatar/avatar_variants.story.vue
+++ b/components/avatar/avatar_variants.story.vue
@@ -43,7 +43,7 @@
       <div class="d-flow16 d-d-flex d-ai-center">
         <dt-avatar
           v-for="state in AVATAR_PRESENCE_STATES"
-          :key="state"
+          :key="`presence-${state}`"
           :seed="seed"
           size="md"
           full-name="Person avatar"


### PR DESCRIPTION
# Docs (Avatar): Missing examples

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [ ] Feature
- [ ] Refactoring
- [x] Documentation

## :book: Description

- Added avatar group examples to variants.
- Updated presence examples to showcase different presence states.
- Reordered clickable examples.

## :bulb: Context

Designers reported outdated/out of sync documentation between dialpad.design and vue.dialpad.design avatar examples.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

<img width="314" alt="Screenshot 2023-10-05 at 12 23 01 p m" src="https://github.com/dialpad/dialtone-vue/assets/87546543/c615bc12-56c0-48b0-98af-ed027d1f6e7d">
<img width="207" alt="Screenshot 2023-10-05 at 12 23 08 p m" src="https://github.com/dialpad/dialtone-vue/assets/87546543/b1968807-8c6e-4742-88ac-c62f29c3d9e1">
<img width="171" alt="Screenshot 2023-10-05 at 12 23 37 p m" src="https://github.com/dialpad/dialtone-vue/assets/87546543/1e8c6d57-159a-4c84-97a4-e010989ee889">