### PR TITLE
fix(callbar-button): slot not working

### DIFF
--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -195,7 +195,7 @@ export default {
     callbarButtonListeners () {
       return {
         ...this.$listeners,
-        click: (event) => this.$emit('click'),
+        click: (event) => this.$emit('click', event),
       };
     },
   },

--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -19,10 +19,9 @@
           v-on="$listeners"
         >
           <slot />
-          <slot
-            slot="icon"
-            name="icon"
-          />
+          <template #icon>
+            <slot name="icon" />
+          </template>
         </dt-button>
       </span>
     </template>

--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -2,8 +2,6 @@
   <dt-tooltip
     :id="id"
     :offset="[0, 8]"
-    v-bind="$attrs"
-    v-on="callbarButtonListeners"
   >
     <template #anchor>
       <span
@@ -18,6 +16,8 @@
           :label-class="callbarButtonTextClass"
           :width="buttonWidth"
           :class="callbarButtonClass"
+          v-bind="$attrs"
+          v-on="callbarButtonListeners"
         >
           <slot />
           <template #icon>

--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -2,6 +2,7 @@
   <dt-tooltip
     :id="id"
     :offset="[0, 8]"
+    v-bind="$attrs"
     v-on="callbarButtonListeners"
   >
     <template #anchor>

--- a/recipes/buttons/callbar_button/callbar_button.vue
+++ b/recipes/buttons/callbar_button/callbar_button.vue
@@ -2,6 +2,7 @@
   <dt-tooltip
     :id="id"
     :offset="[0, 8]"
+    v-on="callbarButtonListeners"
   >
     <template #anchor>
       <span
@@ -16,7 +17,6 @@
           :label-class="callbarButtonTextClass"
           :width="buttonWidth"
           :class="callbarButtonClass"
-          v-on="$listeners"
         >
           <slot />
           <template #icon>
@@ -40,7 +40,7 @@ export default {
 
   components: { DtButton, DtTooltip },
 
-  inheritAttrs: true,
+  inheritAttrs: false,
 
   props: {
     /**
@@ -190,6 +190,13 @@ export default {
         return this.importance;
       }
       return this.circle ? 'outlined' : 'clear';
+    },
+
+    callbarButtonListeners () {
+      return {
+        ...this.$listeners,
+        click: (event) => this.$emit('click'),
+      };
     },
   },
 };

--- a/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.test.js
+++ b/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.test.js
@@ -4,7 +4,9 @@ import DtRecipeCallbarButton from '../callbar_button/callbar_button.vue';
 import DtPopover from '@/components/popover/popover.vue';
 
 // Constants
-const basePropsData = {};
+const basePropsData = {
+  arrowButtonLabel: 'arrowButton',
+};
 
 describe('DtRecipeCallbarButtonWithPopover Tests', () => {
   let testContext;
@@ -156,7 +158,6 @@ describe('DtRecipeCallbarButtonWithPopover Tests', () => {
           _setWrappers();
 
           await button.find('button').trigger('click');
-          await wrapper.vm.$nextTick();
 
           const clickEvents = wrapper.emitted().click;
           expect(clickEvents.length).toBe(1);


### PR DESCRIPTION
# Fix (Callbar button): Slot not working

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Fixed button icon slot that was incorrectly using <slot> instead of <template>

## :bulb: Context

Issues were reported on callbar button with popover on vue 3 version, but found it was incorrect on vue 2 version too.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root