### PR TITLE
fix: href on link

### DIFF
--- a/components/link/link.vue
+++ b/components/link/link.vue
@@ -5,6 +5,7 @@
       LINK_KIND_MODIFIERS[kind],
     ]"
     data-qa="dt-link"
+    :href="'href' in $attrs ? $attrs.href : 'javascript:void(0)'"
   >
     <!-- @slot Slot for main content -->
     <slot />


### PR DESCRIPTION
# fix: ability to not navigate when href is not passed to dt-link - vue3

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

We will reuse dt-link on mention for message input in which case we do not want to navigate anywhere else. this change will allow to do that coupled with the native event link so user can do specific actions without navigating away.
