### PR TITLE
feat: add avatar slot to feed-item-row

### DIFF
--- a/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
+++ b/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
@@ -48,6 +48,15 @@ export const argTypesData = {
     },
   },
 
+  avatar: {
+    control: 'text',
+    table: {
+      type: {
+        summary: 'VNode',
+      },
+    },
+  },
+
   threading: {
     name: 'threading',
     control: 'text',

--- a/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -9,12 +9,17 @@
   >
     <!-- Avatar or time -->
     <template #left>
-      <dt-avatar
+      <!-- @slot Slot to contain the avatar, overrides avatar props. -->
+      <slot
         v-if="showHeader"
-        :full-name="displayName"
-        :image-src="avatarImageUrl"
-        :seed="avatarSeed"
-      />
+        name="avatar"
+      >
+        <dt-avatar
+          :full-name="displayName"
+          :image-src="avatarImageUrl"
+          :seed="avatarSeed"
+        />
+      </slot>
       <!-- show time instead of avatar when headers not present -->
       <div
         v-if="!showHeader"

--- a/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
+++ b/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
@@ -14,9 +14,11 @@
       <template v-if="defaultSlot">
         <span v-html="defaultSlot" />
       </template>
-      <template #avatar>
+      <template 
+        v-if="avatar"
+        #avatar
+      >
         <span
-          v-if="avatar"
           v-html="avatar"
         />
       </template>

--- a/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
+++ b/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
@@ -14,6 +14,12 @@
       <template v-if="defaultSlot">
         <span v-html="defaultSlot" />
       </template>
+      <template #avatar>
+        <span
+          v-if="avatar"
+          v-html="avatar"
+        />
+      </template>
       <template
         v-if="threading"
         #threading


### PR DESCRIPTION
# feat: add avatar slot to feed-item-row

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

There is a ton of product side logic that is used to correctly display an avatar currently, so it is best that we are able to pass in a slot here. 

Already tested in product via `npm link`

## :bulb: Context

A lot of display issues with avatar on feed item row since we could not implement all the product side logic into a slot.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added all relevant documentation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size

## :crystal_ball: Next Steps

Update in ubervoice for feed item row changes.
