### PR TITLE
fix(dt-tooltip-directive): default delay

### DIFF
--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -295,7 +295,7 @@ export default {
     },
 
     anchor () {
-      return this.externalAnchor ? document.querySelector(this.externalAnchor) : getAnchor(this.$refs.anchor);
+      return this.externalAnchor ? document.body.querySelector(this.externalAnchor) : getAnchor(this.$refs.anchor);
     },
   },
 
@@ -372,10 +372,10 @@ export default {
     onEnterAnchor (e) {
       if (this.delay) {
         this.inTimer = setTimeout(function (event) {
-          return this.triggerShow(event);
+          this.triggerShow(event);
         }.bind(this, e), TOOLTIP_DELAY_MS);
       } else {
-        return this.triggerShow(e);
+        this.triggerShow(e);
       }
     },
 
@@ -396,9 +396,11 @@ export default {
       }
     },
 
-    onLeaveAnchor () {
+    onLeaveAnchor (e) {
+      if (e.type === 'keydown' && e.code !== 'Escape') return;
+
       clearTimeout(this.inTimer);
-      return this.triggerHide();
+      this.triggerHide();
     },
 
     triggerHide () {

--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -333,6 +333,7 @@ export default {
   },
 
   mounted () {
+    this.externalAnchor && this.addExternalAnchorEventListeners();
     this.tip = createTippy(this.anchor, this.initOptions());
 
     // immediate watcher fires before mounted, so have this here in case
@@ -343,6 +344,8 @@ export default {
   },
 
   beforeDestroy () {
+    this.externalAnchor && this.removeExternalAnchorEventListeners();
+
     if (this.tip) {
       this.tip?.destroy();
     }
@@ -442,6 +445,24 @@ export default {
         onMount: this.onMount,
         ...this.tippyProps,
       };
+    },
+
+    addExternalAnchorEventListeners () {
+      ['focusin', 'mouseenter'].forEach(listener => {
+        this.anchor.addEventListener(listener, (event) => this.onEnterAnchor(event));
+      });
+      ['focusout', 'mouseleave', 'keydown'].forEach(listener => {
+        this.anchor.addEventListener(listener, (event) => this.onLeaveAnchor(event));
+      });
+    },
+
+    removeExternalAnchorEventListeners () {
+      ['focusin', 'mouseenter'].forEach(listener => {
+        this.anchor.removeEventListener(listener, (event) => this.onEnterAnchor(event));
+      });
+      ['focusout', 'mouseleave', 'keydown'].forEach(listener => {
+        this.anchor.removeEventListener(listener, (event) => this.onLeaveAnchor(event));
+      });
     },
   },
 };

--- a/components/tooltip/tooltip_variants.vue
+++ b/components/tooltip/tooltip_variants.vue
@@ -8,11 +8,6 @@
       <dt-button
         id="external-tooltip-anchor"
         importance="outlined"
-        @focusin="externalAnchorShow = true"
-        @mouseenter="externalAnchorShow = true"
-        @focusout="externalAnchorShow = false"
-        @mouseleave="externalAnchorShow = false"
-        @keydown.esc="externalAnchorShow = false"
       >
         External anchor
       </dt-button>
@@ -127,7 +122,6 @@
     </div>
     <dt-tooltip
       :transition="transition"
-      :show="externalAnchorShow"
       external-anchor="#external-tooltip-anchor"
     >
       This is a tooltip with external anchor, the actual dt-tooltip component
@@ -160,7 +154,6 @@ export default {
 
       localMessage: `This is a simple tooltip. The tooltip can be positioned in multiple areas too!`,
       show1: this.show ?? false,
-      externalAnchorShow: false,
     };
   },
 };

--- a/directives/tooltip/tooltip.js
+++ b/directives/tooltip/tooltip.js
@@ -20,21 +20,11 @@ export const DtTooltipDirective = {
 
       methods: {
         addTooltip (id, message, placement) {
-          this.tooltips.push({ id, message, placement, show: false });
-        },
-
-        hideTooltip (id) {
-          const tooltipIndex = this.tooltips.findIndex(tooltip => tooltip.id === id);
-          this.tooltips[tooltipIndex].show = false;
+          this.tooltips.push({ id, message, placement });
         },
 
         removeTooltip (id) {
           this.tooltips = this.tooltips.filter(tooltip => tooltip.id !== id);
-        },
-
-        showTooltip (id) {
-          const tooltipIndex = this.tooltips.findIndex(tooltip => tooltip.id === id);
-          this.tooltips[tooltipIndex].show = true;
         },
       },
 
@@ -67,35 +57,6 @@ export const DtTooltipDirective = {
       return value === undefined || TOOLTIP_DIRECTIONS.includes(value);
     };
 
-    function showTooltipListener (event) {
-      const tooltipId = event.target.getAttribute('data-dt-tooltip-id');
-      DtTooltipDirectiveApp.showTooltip(tooltipId);
-    }
-
-    function hideTooltipListener (event) {
-      if (event.type === 'keydown' && event.code !== 'Escape') return;
-      const tooltipId = event.target.getAttribute('data-dt-tooltip-id');
-      DtTooltipDirectiveApp.hideTooltip(tooltipId);
-    }
-
-    function addAnchorEventListeners (anchor) {
-      ['focusin', 'mouseenter'].forEach(listener => {
-        anchor.addEventListener(listener, (event) => showTooltipListener(event));
-      });
-      ['focusout', 'mouseleave', 'keydown'].forEach(listener => {
-        anchor.addEventListener(listener, (event) => hideTooltipListener(event));
-      });
-    }
-
-    function removeAnchorEventListeners (anchor) {
-      ['focusin', 'mouseenter'].forEach(listener => {
-        anchor.removeEventListener(listener, (event) => showTooltipListener(event));
-      });
-      ['focusout', 'mouseleave', 'keydown'].forEach(listener => {
-        anchor.removeEventListener(listener, (event) => hideTooltipListener(event));
-      });
-    }
-
     Vue.directive('dt-tooltip', {
       bind (anchor, binding) {
         if (!isValidBindingTextValue(binding.value)) {
@@ -124,10 +85,8 @@ export const DtTooltipDirective = {
 
         anchor.setAttribute('data-dt-tooltip-id', tooltipId);
         DtTooltipDirectiveApp.addTooltip(tooltipId, message, placement);
-        addAnchorEventListeners(anchor);
       },
       unbind (anchor) {
-        removeAnchorEventListeners(anchor);
         DtTooltipDirectiveApp.removeTooltip(anchor.getAttribute('data-dt-tooltip-id'));
       },
     });

--- a/directives/tooltip/tooltip.js
+++ b/directives/tooltip/tooltip.js
@@ -9,6 +9,7 @@ export const DtTooltipDirective = {
 
     const DEFAULT_PLACEMENT = 'top';
     const DtTooltipDirectiveApp = new Vue({
+      el: mountPoint,
       name: 'DtTooltipDirectiveApp',
       components: { DtTooltip },
       data () {
@@ -33,13 +34,16 @@ export const DtTooltipDirective = {
             domProps: { id: 'dt-tooltip-directive-app' },
           },
           [
-            this.tooltips.map(({ id, message, placement, show }) => {
+            this.tooltips.map(({ id, message, placement }) => {
               return h(DtTooltip, {
                 key: id,
                 props: {
                   message,
                   placement,
-                  show,
+                  /**
+                   * Set the delay to false when running tests only.
+                   */
+                  delay: process.env.NODE_ENV !== 'test',
                   externalAnchor: `[data-dt-tooltip-id="${id}"]`,
                 },
               });
@@ -48,8 +52,6 @@ export const DtTooltipDirective = {
         );
       },
     });
-
-    DtTooltipDirectiveApp.$mount(mountPoint);
 
     const isValidBindingTextValue = (value) => typeof value === 'string' && value?.trim();
     const isValidBindingPlacementValue = (value) => value === undefined || TOOLTIP_DIRECTIONS.includes(value);

--- a/directives/tooltip/tooltip.js
+++ b/directives/tooltip/tooltip.js
@@ -9,7 +9,6 @@ export const DtTooltipDirective = {
 
     const DEFAULT_PLACEMENT = 'top';
     const DtTooltipDirectiveApp = new Vue({
-      el: mountPoint,
       name: 'DtTooltipDirectiveApp',
       components: { DtTooltip },
       data () {
@@ -52,6 +51,8 @@ export const DtTooltipDirective = {
         );
       },
     });
+
+    DtTooltipDirectiveApp.$mount(mountPoint);
 
     const isValidBindingTextValue = (value) => typeof value === 'string' && value?.trim();
     const isValidBindingPlacementValue = (value) => value === undefined || TOOLTIP_DIRECTIONS.includes(value);

--- a/directives/tooltip/tooltip.js
+++ b/directives/tooltip/tooltip.js
@@ -9,7 +9,6 @@ export const DtTooltipDirective = {
 
     const DEFAULT_PLACEMENT = 'top';
     const DtTooltipDirectiveApp = new Vue({
-      el: mountPoint,
       name: 'DtTooltipDirectiveApp',
       components: { DtTooltip },
       data () {
@@ -50,12 +49,10 @@ export const DtTooltipDirective = {
       },
     });
 
-    const isValidBindingTextValue = (value) => {
-      return typeof value === 'string' && value?.trim();
-    };
-    const isValidBindingPlacementValue = (value) => {
-      return value === undefined || TOOLTIP_DIRECTIONS.includes(value);
-    };
+    DtTooltipDirectiveApp.$mount(mountPoint);
+
+    const isValidBindingTextValue = (value) => typeof value === 'string' && value?.trim();
+    const isValidBindingPlacementValue = (value) => value === undefined || TOOLTIP_DIRECTIONS.includes(value);
 
     Vue.directive('dt-tooltip', {
       bind (anchor, binding) {

--- a/directives/tooltip/tooltip.test.js
+++ b/directives/tooltip/tooltip.test.js
@@ -1,22 +1,20 @@
 import { createLocalVue, mount } from '@vue/test-utils';
-import { DtTooltipDirective } from '@/directives';
+import { DtTooltipDirective } from './tooltip.js';
+import { getUniqueString } from '@/common/utils.js';
 
 import {
   TOOLTIP_DIRECTIONS,
 } from '@/components/tooltip/tooltip_constants';
 
-const MOCK_TRANSITION_STUB = () => ({
-  render: function (h) {
-    return this.$options._renderChildren;
-  },
-});
 const MOCK_TOOLTIP_TEXT = 'Tooltip text content';
 const MOCK_ANCHOR_TEXT = 'Button placeholder';
 
 const WrapperComponent = {
+  name: 'wrapper-component',
   template: `
-    <button v-dt-tooltip:[placement]="MOCK_TOOLTIP_TEXT">{{MOCK_ANCHOR_TEXT}}</button>
+    <button :key="id" v-dt-tooltip:[placement]="MOCK_TOOLTIP_TEXT">{{MOCK_ANCHOR_TEXT}}</button>
   `,
+
   props: {
     placement: {
       type: String,
@@ -26,6 +24,7 @@ const WrapperComponent = {
 
   data () {
     return {
+      id: getUniqueString(),
       MOCK_ANCHOR_TEXT,
       MOCK_TOOLTIP_TEXT,
     };
@@ -44,17 +43,17 @@ describe('DtTooltipDirective Tests', () => {
 
   const updateWrapper = () => {
     wrapper = mount(WrapperComponent, {
-      localVue: testContext.localVue,
       propsData: { ...baseProps, ...mockProps },
-      stubs: {
-        // this gets around transition async problems. See https://v1.test-utils.vuejs.org/guides/common-tips.html
-        transition: MOCK_TRANSITION_STUB(),
-      },
+      localVue: testContext.localVue,
       attachTo: document.body,
     });
 
     anchor = wrapper.find('button');
   };
+
+  afterEach(() => {
+    wrapper.destroy();
+  });
 
   beforeAll(() => {
     testContext.localVue = createLocalVue();
@@ -63,11 +62,6 @@ describe('DtTooltipDirective Tests', () => {
     // Need to mock them to avoid error
     global.requestAnimationFrame = vi.fn();
     global.cancelAnimationFrame = vi.fn();
-  });
-
-  afterEach(() => {
-    wrapper.destroy();
-    document.body.outerHTML = '';
   });
 
   afterAll(() => {
@@ -79,8 +73,8 @@ describe('DtTooltipDirective Tests', () => {
   describe('Presentation Tests', () => {
     describe('when tooltip is open', () => {
       beforeEach(async () => {
-        updateWrapper();
-        await anchor.trigger('focusin');
+        await updateWrapper();
+        await anchor.trigger('mouseenter');
       });
 
       it('should render the component', () => {
@@ -96,7 +90,7 @@ describe('DtTooltipDirective Tests', () => {
       });
 
       it('should render the message', () => {
-        expect(document.querySelector('[data-qa="dt-tooltip"]').textContent.trim()).toBe(MOCK_TOOLTIP_TEXT);
+        expect(document.body.querySelector('[data-qa="dt-tooltip"]').textContent.trim()).toBe(MOCK_TOOLTIP_TEXT);
       });
     });
     describe('When a placement is provided', () => {
@@ -104,8 +98,8 @@ describe('DtTooltipDirective Tests', () => {
         describe(`When direction is ${placement}`, () => {
           beforeEach(async () => {
             mockProps = { placement };
-            updateWrapper();
-            await anchor.trigger('focusin');
+            await updateWrapper();
+            await anchor.trigger('mouseenter');
           });
 
           it('should have correct arrow direction class', () => {

--- a/directives/tooltip/tooltip.test.js
+++ b/directives/tooltip/tooltip.test.js
@@ -52,6 +52,7 @@ describe('DtTooltipDirective Tests', () => {
   };
 
   afterEach(() => {
+    mockProps = {};
     wrapper.destroy();
   });
 


### PR DESCRIPTION
# Fix (Tooltip Directive): Default delay

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

- Moved the external anchor event listener bindings to the tooltip component instead of the directive. This way, the directives and external anchor events are handled directly by the tooltip component so we avoid duplicating code. Also, we can remove the need to handle the events manually.

## :bulb: Context

Tooltips through tooltip directive were not using the default delay.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root