### PR TITLE
feat(call-pill): add default toggled state - vue3

### DIFF
--- a/percy.config.cjs
+++ b/percy.config.cjs
@@ -46,6 +46,7 @@ module.exports = {
       'Recipes/Comboboxes/Combobox Multi-Select: With Max Validation',
       'Recipes/Comboboxes/Combobox With Popover: Empty',
       'Recipes/Conversation View/Feed Item Row: Default',
+      'Recipes/Conversation View/Feed Item Pill: Default',
       'Recipes/Leftbar/Callbox: Default',
       'Recipes/Leftbar/Contact Row: Default',
       'Recipes/Leftbar/General Row: Default',

--- a/recipes/conversation_view/feed_pill/feed_item_pill.mdx
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.mdx
@@ -10,12 +10,6 @@ import * as FeedItemPillStories from './feed_item_pill.stories';
   A generic layout for different Feed Items
 </Subtitle>
 
-## Base Style
-
-<Canvas>
-  <Story of={FeedItemPillStories.Default} />
-</Canvas>
-
 ## Variants
 
 Set the initial toggled state
@@ -36,6 +30,12 @@ Can provide a border style via borderColor
 Can disable the toggleable behaviour (Cursor is reset, no changing of icon on hover, clicking does not toggle the expandable)
 <Canvas>
   <Story of={FeedItemPillStories.NoToggleVariant} />
+</Canvas>
+
+## Base Style
+
+<Canvas>
+  <Story of={FeedItemPillStories.Default} />
 </Canvas>
 
 ## Slots, Props & Events

--- a/recipes/conversation_view/feed_pill/feed_item_pill.mdx
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.mdx
@@ -10,32 +10,16 @@ import * as FeedItemPillStories from './feed_item_pill.stories';
   A generic layout for different Feed Items
 </Subtitle>
 
-## Variants
-
-Set the initial toggled state
-<Canvas>
-  <Story of={FeedItemPillStories.DefaultToggledVariant} />
-</Canvas>
-
-Set the initial toggled state, and prevents toggle.
-<Canvas>
-  <Story of={FeedItemPillStories.DefaultToggledVariantNonToggleable} />
-</Canvas>
-
-Can provide a border style via borderColor
-<Canvas>
-  <Story of={FeedItemPillStories.AiBorderGradient} />
-</Canvas>
-
-Can disable the toggleable behaviour (Cursor is reset, no changing of icon on hover, clicking does not toggle the expandable)
-<Canvas>
-  <Story of={FeedItemPillStories.NoToggleVariant} />
-</Canvas>
-
 ## Base Style
 
 <Canvas>
   <Story of={FeedItemPillStories.Default} />
+</Canvas>
+
+## Variants
+
+<Canvas>
+  <Story of={FeedItemPillStories.Variants} />
 </Canvas>
 
 ## Slots, Props & Events

--- a/recipes/conversation_view/feed_pill/feed_item_pill.mdx
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.mdx
@@ -18,12 +18,12 @@ import * as FeedItemPillStories from './feed_item_pill.stories';
 
 ## Variants
 
-Can enable the initial toggled state
+Set the initial toggled state
 <Canvas>
   <Story of={FeedItemPillStories.DefaultToggledVariant} />
 </Canvas>
 
-Can enable the initial toggled state, and prevent to be toggled
+Set the initial toggled state, and prevents toggle.
 <Canvas>
   <Story of={FeedItemPillStories.DefaultToggledVariantNonToggleable} />
 </Canvas>

--- a/recipes/conversation_view/feed_pill/feed_item_pill.mdx
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.mdx
@@ -18,6 +18,16 @@ import * as FeedItemPillStories from './feed_item_pill.stories';
 
 ## Variants
 
+Can enable the initial toggled state
+<Canvas>
+  <Story of={FeedItemPillStories.DefaultToggledVariant} />
+</Canvas>
+
+Can enable the initial toggled state, and prevent to be toggled
+<Canvas>
+  <Story of={FeedItemPillStories.DefaultToggledVariantNonToggleable} />
+</Canvas>
+
 Can provide a border style via borderColor
 <Canvas>
   <Story of={FeedItemPillStories.AiBorderGradient} />

--- a/recipes/conversation_view/feed_pill/feed_item_pill.stories.js
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.stories.js
@@ -73,18 +73,15 @@ const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
 export const Default = {
   render: DefaultTemplate,
   parameters: {
-    options: { showPanel: false },
     a11y: { disable: true },
-    percy: {
-      args: { seed: 'seed' },
-    },
   },
 };
 
 export const Variants = {
   render: VariantsTemplate,
   parameters: {
-    ...Default.parameters,
+    options: { showPanel: false },
+    a11y: { disable: true },
     controls: { disable: true },
   },
 };

--- a/recipes/conversation_view/feed_pill/feed_item_pill.stories.js
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.stories.js
@@ -63,9 +63,8 @@ const DefaultTemplate = (args) => createTemplateFromVueFile(
   DtRecipeFeedItemPillDefaultTemplate,
 );
 
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+const VariantsTemplate = (args) => createTemplateFromVueFile(
   args,
-  argTypes,
   DtRecipeFeedItemPillVariantsTemplate,
 );
 

--- a/recipes/conversation_view/feed_pill/feed_item_pill.stories.js
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.stories.js
@@ -72,6 +72,31 @@ export const Default = {
   },
 };
 
+export const DefaultToggledVariant = {
+  render: DefaultTemplate,
+  parameters: { a11y: { disable: true } },
+  args: {
+    iconName: 'video',
+    title: 'This meeting has ended',
+    wrapperClass: 'd-w628',
+    ariaLabel: 'Click to expand',
+    toggleable: true,
+    defaultToggled: true,
+  },
+};
+
+export const DefaultToggledVariantNonToggleable = {
+  render: DefaultTemplate,
+  parameters: { a11y: { disable: true } },
+  args: {
+    iconName: 'video',
+    title: 'This meeting has ended',
+    wrapperClass: 'd-w628',
+    toggleable: false,
+    defaultToggled: true,
+  },
+};
+
 export const AiBorderGradient = {
   render: DefaultTemplate,
   parameters: { options: { showPanel: false }, controls: { disable: true }, a11y: { disable: true } },

--- a/recipes/conversation_view/feed_pill/feed_item_pill.stories.js
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.stories.js
@@ -1,13 +1,15 @@
 import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import DtRecipeFeedItemPill from './feed_item_pill.vue';
 import DtRecipeFeedItemPillDefaultTemplate from './feed_item_pill_default.story.vue';
+import DtRecipeFeedItemPillVariantsTemplate from './feed_item_pill_variants.story.vue';
 
 // Default Prop Values
 const args = {
-  iconName: 'phone',
+  iconName: 'video',
   title: 'This meeting has ended',
   ariaLabel: 'Click to expand',
   wrapperClass: 'd-w628',
+  buttonClass: 'd-bar24',
 };
 
 const argTypes = {
@@ -61,42 +63,28 @@ const DefaultTemplate = (args) => createTemplateFromVueFile(
   DtRecipeFeedItemPillDefaultTemplate,
 );
 
+const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  DtRecipeFeedItemPillVariantsTemplate,
+);
+
 // Stories
 export const Default = {
   render: DefaultTemplate,
-  parameters: { options: { showPanel: false }, a11y: { disable: true }, controls: { disable: true } },
-};
-
-export const DefaultToggledVariant = {
-  render: DefaultTemplate,
-  parameters: Default.parameters,
-  args: {
-    defaultToggled: true,
+  parameters: {
+    options: { showPanel: false },
+    a11y: { disable: true },
+    percy: {
+      args: { seed: 'seed' },
+    },
   },
 };
 
-export const DefaultToggledVariantNonToggleable = {
-  render: DefaultTemplate,
-  parameters: Default.parameters,
-  args: {
-    toggleable: false,
-    defaultToggled: true,
-  },
-};
-
-export const AiBorderGradient = {
-  render: DefaultTemplate,
-  parameters: Default.parameters,
-  args: {
-    borderColor: 'ai',
-  },
-};
-
-export const NoToggleVariant = {
-  render: DefaultTemplate,
-  parameters: Default.parameters,
-  args: {
-    toggleable: false,
-    borderColor: 'critical',
+export const Variants = {
+  render: VariantsTemplate,
+  parameters: {
+    ...Default.parameters,
+    controls: { disable: true },
   },
 };

--- a/recipes/conversation_view/feed_pill/feed_item_pill.stories.js
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.stories.js
@@ -3,10 +3,14 @@ import DtRecipeFeedItemPill from './feed_item_pill.vue';
 import DtRecipeFeedItemPillDefaultTemplate from './feed_item_pill_default.story.vue';
 
 // Default Prop Values
-export const argsData = {
+const args = {
+  iconName: 'phone',
+  title: 'This meeting has ended',
+  ariaLabel: 'Click to expand',
+  wrapperClass: 'd-w628',
 };
 
-export const argTypesData = {
+const argTypes = {
   // Slots
   subtitle: {
     control: 'text',
@@ -46,8 +50,8 @@ export const argTypesData = {
 export default {
   title: 'Recipes/Conversation View/Feed Item Pill',
   component: DtRecipeFeedItemPill,
-  args: argsData,
-  argTypes: argTypesData,
+  args,
+  argTypes,
   excludeStories: /.*Data$/,
 };
 
@@ -60,38 +64,21 @@ const DefaultTemplate = (args) => createTemplateFromVueFile(
 // Stories
 export const Default = {
   render: DefaultTemplate,
-  parameters: { a11y: { disable: true } },
-  args: {
-    iconName: 'video',
-    title: 'This meeting has ended',
-    ariaLabel: 'Click to expand',
-    buttonClass: '',
-    toggleable: true,
-    wrapperClass: 'd-w628',
-    borderColor: 'default',
-  },
+  parameters: { options: { showPanel: false }, a11y: { disable: true }, controls: { disable: true } },
 };
 
 export const DefaultToggledVariant = {
   render: DefaultTemplate,
-  parameters: { a11y: { disable: true } },
+  parameters: Default.parameters,
   args: {
-    iconName: 'video',
-    title: 'This meeting has ended',
-    wrapperClass: 'd-w628',
-    ariaLabel: 'Click to expand',
-    toggleable: true,
     defaultToggled: true,
   },
 };
 
 export const DefaultToggledVariantNonToggleable = {
   render: DefaultTemplate,
-  parameters: { a11y: { disable: true } },
+  parameters: Default.parameters,
   args: {
-    iconName: 'video',
-    title: 'This meeting has ended',
-    wrapperClass: 'd-w628',
     toggleable: false,
     defaultToggled: true,
   },
@@ -99,27 +86,16 @@ export const DefaultToggledVariantNonToggleable = {
 
 export const AiBorderGradient = {
   render: DefaultTemplate,
-  parameters: { options: { showPanel: false }, controls: { disable: true }, a11y: { disable: true } },
+  parameters: Default.parameters,
   args: {
-    iconName: 'video',
-    title: 'This meeting has ended',
-    wrapperClass: 'd-w628',
-    buttonClass: '',
-    ariaLabel: 'Click to expand',
-    toggleable: true,
     borderColor: 'ai',
   },
 };
 
 export const NoToggleVariant = {
   render: DefaultTemplate,
-  parameters: { options: { showPanel: false }, controls: { disable: true }, a11y: { disable: true } },
+  parameters: Default.parameters,
   args: {
-    iconName: 'video',
-    title: 'This meeting has ended',
-    wrapperClass: 'd-w628',
-    expanded: false,
-    ariaLabel: 'Click to expand',
     toggleable: false,
     borderColor: 'critical',
   },

--- a/recipes/conversation_view/feed_pill/feed_item_pill.test.js
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.test.js
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils';
 import DtRecipeFeedItemPill from './feed_item_pill.vue';
-import { beforeEach } from 'vitest';
+import { beforeEach, describe } from 'vitest';
 
 describe('DtRecipeFeedItemPill Tests', function () {
   let wrapper, feedItemPill, icon;
@@ -14,6 +14,7 @@ describe('DtRecipeFeedItemPill Tests', function () {
     ariaLabel: MOCK_ARIA_LABEL,
     buttonClass: '',
     toggleable: true,
+    defaultToggled: false,
   };
   const baseAttrs = {};
   const baseSlots = {
@@ -111,6 +112,32 @@ describe('DtRecipeFeedItemPill Tests', function () {
       it('should show a different icon', () => {
         expect(icon.exists()).toBe(true);
         expect(icon.attributes('data-name')).toBe('Chevron Right');
+      });
+    });
+
+    describe('Default toggled state close', function () {
+      beforeAll(() => {
+        mockProps = {
+          defaultToggled: false,
+        };
+      });
+
+      it('content slot should not exist', () => {
+        expect(wrapper.exists()).toBe(true);
+        expect(wrapper.find('[data-qa="content-element"]').exists()).toBe(false);
+      });
+    });
+
+    describe('Default toggled state open', function () {
+      beforeAll(() => {
+        mockProps = {
+          defaultToggled: true,
+        };
+      });
+
+      it('content slot should exist', () => {
+        expect(wrapper.exists()).toBe(true);
+        expect(wrapper.find('[data-qa="content-element"]').exists()).toBe(true);
       });
     });
   });

--- a/recipes/conversation_view/feed_pill/feed_item_pill.test.js
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.test.js
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils';
 import DtRecipeFeedItemPill from './feed_item_pill.vue';
-import { FEED_ITEM_PILL_DATA_QA } from './feed_item_pill_constants';
 
 describe('DtRecipeFeedItemPill Tests', function () {
   let wrapper, feedItemPill, icon;
@@ -8,7 +7,8 @@ describe('DtRecipeFeedItemPill Tests', function () {
   const MOCK_ARIA_LABEL = 'Click to expand';
   const MOCK_ICON_NAME = 'Video';
   const DATA_QA = {
-    ...FEED_ITEM_PILL_DATA_QA,
+    PILL: 'dt-recipe-feed-item-pill',
+    PILL_ICON: 'dt-recipe-feed-item-pill__icon',
     CONTENT_ELEMENT: 'content-element',
   };
 

--- a/recipes/conversation_view/feed_pill/feed_item_pill.test.js
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.test.js
@@ -1,24 +1,25 @@
 import { mount } from '@vue/test-utils';
 import DtRecipeFeedItemPill from './feed_item_pill.vue';
-import { beforeEach, describe } from 'vitest';
+import { FEED_ITEM_PILL_DATA_QA } from './feed_item_pill_constants';
 
 describe('DtRecipeFeedItemPill Tests', function () {
   let wrapper, feedItemPill, icon;
 
   const MOCK_ARIA_LABEL = 'Click to expand';
   const MOCK_ICON_NAME = 'Video';
+  const DATA_QA = {
+    ...FEED_ITEM_PILL_DATA_QA,
+    CONTENT_ELEMENT: 'content-element',
+  };
 
   const baseProps = {
     iconName: MOCK_ICON_NAME,
     title: 'This meeting has ended',
     ariaLabel: MOCK_ARIA_LABEL,
-    buttonClass: '',
-    toggleable: true,
-    defaultToggled: false,
   };
   const baseAttrs = {};
   const baseSlots = {
-    content: '<div data-qa="content-element"> content </div>',
+    content: `<div data-qa="${DATA_QA.CONTENT_ELEMENT}"> content </div>`,
   };
   const baseProvide = {};
 
@@ -36,8 +37,8 @@ describe('DtRecipeFeedItemPill Tests', function () {
         provide: { ...baseProvide, ...mockProvide },
       },
     });
-    feedItemPill = wrapper.find('[data-qa="dt-feed-item-pill"]');
-    icon = wrapper.find('[data-qa="dt-feed-item-pill-icon"]');
+    feedItemPill = wrapper.find(`[data-qa="${DATA_QA.PILL}"]`);
+    icon = wrapper.find(`[data-qa="${DATA_QA.PILL_ICON}"]`);
   };
 
   beforeEach(function () {
@@ -61,7 +62,7 @@ describe('DtRecipeFeedItemPill Tests', function () {
         expect(feedItemPill.exists()).toBeTruthy();
         expect(icon.exists()).toBe(true);
         expect(icon.attributes('data-name')).toBe(MOCK_ICON_NAME);
-        expect(wrapper.find('[data-qa="content-element"]').exists()).toBe(false);
+        expect(wrapper.find(`[data-qa="${DATA_QA.CONTENT_ELEMENT}"]`).exists()).toBe(false);
       });
     });
   });
@@ -80,7 +81,7 @@ describe('DtRecipeFeedItemPill Tests', function () {
         await feedItemPill.trigger('click');
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.find('[data-qa="content-element"]').exists()).toBe(true);
+        expect(wrapper.find(`[data-qa="${DATA_QA.CONTENT_ELEMENT}"]`).exists()).toBe(true);
       });
 
       describe('toggleable false', function () {
@@ -98,7 +99,7 @@ describe('DtRecipeFeedItemPill Tests', function () {
           expect(feedItemPill.exists()).toBeTruthy();
           expect(icon.exists()).toBe(true);
           expect(icon.attributes('data-name')).toBe(MOCK_ICON_NAME);
-          expect(wrapper.find('[data-qa="content-element"]').exists()).toBe(false);
+          expect(wrapper.find(`[data-qa="${DATA_QA.CONTENT_ELEMENT}"]`).exists()).toBe(false);
         });
       });
     });
@@ -106,7 +107,7 @@ describe('DtRecipeFeedItemPill Tests', function () {
     describe('Hover Feed Item Pill event', function () {
       beforeEach(async () => {
         await feedItemPill.trigger('focusin');
-        icon = wrapper.find('[data-qa="dt-feed-item-pill-icon"]');
+        icon = wrapper.find(`[data-qa="${DATA_QA.PILL_ICON}"]`);
       });
 
       it('should show a different icon', () => {
@@ -116,15 +117,9 @@ describe('DtRecipeFeedItemPill Tests', function () {
     });
 
     describe('Default toggled state close', function () {
-      beforeAll(() => {
-        mockProps = {
-          defaultToggled: false,
-        };
-      });
-
       it('content slot should not exist', () => {
         expect(wrapper.exists()).toBe(true);
-        expect(wrapper.find('[data-qa="content-element"]').exists()).toBe(false);
+        expect(wrapper.find(`[data-qa="${DATA_QA.CONTENT_ELEMENT}"]`).exists()).toBe(false);
       });
     });
 
@@ -137,7 +132,7 @@ describe('DtRecipeFeedItemPill Tests', function () {
 
       it('content slot should exist', () => {
         expect(wrapper.exists()).toBe(true);
-        expect(wrapper.find('[data-qa="content-element"]').exists()).toBe(true);
+        expect(wrapper.find(`[data-qa="${DATA_QA.CONTENT_ELEMENT}"]`).exists()).toBe(true);
       });
     });
   });

--- a/recipes/conversation_view/feed_pill/feed_item_pill.vue
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.vue
@@ -18,7 +18,7 @@
               <template #left>
                 <dt-icon
                   size="300"
-                  class="dt-feed-item-pill--icon d-pr8"
+                  class="dt-feed-item-pill--icon d-pr8 d-box-content"
                   data-qa="dt-feed-item-pill-icon"
                   :name="computedIcon"
                 />
@@ -103,6 +103,11 @@ export default {
       default: () => true,
     },
 
+    defaultToggled: {
+      type: Boolean,
+      default: () => false,
+    },
+
     /**
      * Callbox border color
      * @values default, ai, critical
@@ -117,7 +122,7 @@ export default {
   data () {
     return {
       hover: false,
-      expanded: false,
+      expanded: this.defaultToggled,
     };
   },
 

--- a/recipes/conversation_view/feed_pill/feed_item_pill.vue
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.vue
@@ -14,7 +14,9 @@
             @click="onClick"
           >
             <dt-item-layout class="dt-recipe-feed-item-pill__layout">
-              <span class="dt-recipe-feed-item-pill__title">{{ title }}</span>
+              <slot name="title">
+                <span class="dt-recipe-feed-item-pill__title">{{ title }}</span>
+              </slot>
               <template #left>
                 <dt-icon
                   data-qa="dt-recipe-feed-item-pill__icon"

--- a/recipes/conversation_view/feed_pill/feed_item_pill.vue
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.vue
@@ -1,25 +1,25 @@
 <template>
-  <div :class="['dt-feed-item-pill--border', borderClass, wrapperClass]">
-    <div class="d-p8 d-bgc-secondary">
+  <div :class="['dt-recipe-feed-item-pill--border', borderClass, wrapperClass]">
+    <div class="dt-recipe-feed-item-pill--wrapper">
       <dt-collapsible :open="expanded">
         <template #anchor>
           <button
             :aria-label="ariaLabel"
-            data-qa="dt-feed-item-pill"
-            :class="['d-baw0 d-bgc-moderate d-bar-pill d-w100p d-ta-left d-btn--circle', toggleableClass, buttonClass]"
+            :data-qa="DATA_QA.PILL"
+            :class="['dt-recipe-feed-item-pill--button', toggleableClass, buttonClass]"
             @focusin="hover = true"
             @focusout="hover = false"
             @mouseenter="hover = true"
             @mouseleave="hover = false"
             @click="onClick"
           >
-            <dt-item-layout class="d-w100p d-p8">
+            <dt-item-layout class="dt-recipe-feed-item-pill--layout">
               <span class="d-fw-bold">{{ title }}</span>
               <template #left>
                 <dt-icon
                   size="300"
-                  class="dt-feed-item-pill--icon d-pr8 d-box-content"
-                  data-qa="dt-feed-item-pill-icon"
+                  class="dt-recipe-feed-item-pill--icon"
+                  :data-qa="DATA_QA.PILL_ICON"
                   :name="computedIcon"
                 />
               </template>
@@ -36,7 +36,7 @@
           </button>
         </template>
         <template #content>
-          <div class="d-jc-center d-d-flex">
+          <div class="dt-recipe-feed-item-pill--content d-jc-center d-d-flex">
             <slot name="content" />
           </div>
         </template>
@@ -46,7 +46,7 @@
 </template>
 
 <script>
-import { FEED_ITEM_PILL_BORDER_COLORS } from './feed_item_pill_constants';
+import { FEED_ITEM_PILL_BORDER_COLORS, FEED_ITEM_PILL_DATA_QA } from './feed_item_pill_constants';
 import { DtIcon, DtItemLayout, DtCollapsible } from '@/index';
 
 export default {
@@ -123,6 +123,7 @@ export default {
     return {
       hover: false,
       expanded: this.defaultToggled,
+      DATA_QA: FEED_ITEM_PILL_DATA_QA,
     };
   },
 
@@ -155,8 +156,42 @@ export default {
 </script>
 
 <style lang="less" scoped>
+.dt-recipe-feed-item-pill {
+  &--wrapper {
+    background-color: var(--dt-color-surface-secondary);
+    padding: var(--dt-space-400);
+  }
+
+  &--button {
+    background-color: var(--dt-color-surface-moderate);
+    text-align: left;
+    width: 100%;
+    cursor: pointer;
+    border-width: 0;
+    border-radius: var(--dt-size-radius-pill);
+    --button-padding-x: var(--button-padding-y-md);
+    --button-padding-y: var(--button-padding-y-md);
+    --button-color-text: var(--dt-action-color-foreground-muted-default);
+    --button-border-radius: var(--dt-size-radius-circle);
+  }
+
+  &--layout {
+    padding: var(--dt-space-400);
+    width: 100%;
+  }
+
+  &--icon {
+    animation: fade 0.15s ease-in;
+    margin-right: var(--dt-space-400);
+  }
+
+  &--content {
+    display: flex;
+    justify-content: center;
+  }
+
   // Gradient radius solution taken from https://stackoverflow.com/a/53037637
-  .dt-feed-item-pill--border {
+  &--border {
     border: double 1px transparent;
     border-radius: 4.8rem; // Special value determined by designer here where it works in both expanded and collapsed
     background-origin: border-box;
@@ -164,26 +199,23 @@ export default {
     overflow: hidden;
   }
 
-  .dt-feed-item-pill--border-default {
+  &--border-default {
     background: var(--dt-color-border-default)
   }
 
-  .dt-feed-item-pill--border-ai {
+  &--border-ai {
     background-image:
       linear-gradient(var(--dt-color-surface-primary), var(--dt-color-surface-primary)),
       var(--dt-badge-color-background-ai);
   }
 
-  .dt-feed-item-pill--border-critical {
+  &--border-critical {
     background: var(--dt-color-foreground-critical);
-  }
-
-  .dt-feed-item-pill--icon {
-    animation: fade 0.15s ease-in;
   }
 
   @keyframes fade {
     0%   {transform: scale(0);}
     100% {transform: scale(1);}
   }
+}
 </style>

--- a/recipes/conversation_view/feed_pill/feed_item_pill.vue
+++ b/recipes/conversation_view/feed_pill/feed_item_pill.vue
@@ -1,25 +1,25 @@
 <template>
-  <div :class="['dt-recipe-feed-item-pill--border', borderClass, wrapperClass]">
-    <div class="dt-recipe-feed-item-pill--wrapper">
+  <div :class="['dt-recipe-feed-item-pill__border', borderClass, wrapperClass]">
+    <div class="dt-recipe-feed-item-pill__wrapper">
       <dt-collapsible :open="expanded">
         <template #anchor>
           <button
+            data-qa="dt-recipe-feed-item-pill"
             :aria-label="ariaLabel"
-            :data-qa="DATA_QA.PILL"
-            :class="['dt-recipe-feed-item-pill--button', toggleableClass, buttonClass]"
+            :class="['dt-recipe-feed-item-pill__button', toggleableClass, buttonClass]"
             @focusin="hover = true"
             @focusout="hover = false"
             @mouseenter="hover = true"
             @mouseleave="hover = false"
             @click="onClick"
           >
-            <dt-item-layout class="dt-recipe-feed-item-pill--layout">
-              <span class="d-fw-bold">{{ title }}</span>
+            <dt-item-layout class="dt-recipe-feed-item-pill__layout">
+              <span class="dt-recipe-feed-item-pill__title">{{ title }}</span>
               <template #left>
                 <dt-icon
+                  data-qa="dt-recipe-feed-item-pill__icon"
                   size="300"
-                  class="dt-recipe-feed-item-pill--icon"
-                  :data-qa="DATA_QA.PILL_ICON"
+                  class="dt-recipe-feed-item-pill__icon"
                   :name="computedIcon"
                 />
               </template>
@@ -36,7 +36,7 @@
           </button>
         </template>
         <template #content>
-          <div class="dt-recipe-feed-item-pill--content d-jc-center d-d-flex">
+          <div class="dt-recipe-feed-item-pill__content">
             <slot name="content" />
           </div>
         </template>
@@ -46,7 +46,7 @@
 </template>
 
 <script>
-import { FEED_ITEM_PILL_BORDER_COLORS, FEED_ITEM_PILL_DATA_QA } from './feed_item_pill_constants';
+import { FEED_ITEM_PILL_BORDER_COLORS } from './feed_item_pill_constants';
 import { DtIcon, DtItemLayout, DtCollapsible } from '@/index';
 
 export default {
@@ -123,7 +123,6 @@ export default {
     return {
       hover: false,
       expanded: this.defaultToggled,
-      DATA_QA: FEED_ITEM_PILL_DATA_QA,
     };
   },
 
@@ -157,59 +156,63 @@ export default {
 
 <style lang="less" scoped>
 .dt-recipe-feed-item-pill {
-  &--wrapper {
+  &__wrapper {
     background-color: var(--dt-color-surface-secondary);
     padding: var(--dt-space-400);
   }
 
-  &--button {
+  &__button {
     background-color: var(--dt-color-surface-moderate);
     text-align: left;
     width: 100%;
     cursor: pointer;
     border-width: 0;
-    border-radius: var(--dt-size-radius-pill);
+    border-radius: var(--dt-size-radius-600);
     --button-padding-x: var(--button-padding-y-md);
     --button-padding-y: var(--button-padding-y-md);
     --button-color-text: var(--dt-action-color-foreground-muted-default);
-    --button-border-radius: var(--dt-size-radius-circle);
+    --button-border-radius: var(--dt-size-radius-600);
   }
 
-  &--layout {
+  &__layout {
     padding: var(--dt-space-400);
     width: 100%;
   }
 
-  &--icon {
+  &__icon {
     animation: fade 0.15s ease-in;
     margin-right: var(--dt-space-400);
   }
 
-  &--content {
+  &__content {
     display: flex;
     justify-content: center;
   }
 
+  &__title {
+    font-weight: var(--dt-font-weight-bold);
+  }
+
   // Gradient radius solution taken from https://stackoverflow.com/a/53037637
-  &--border {
+  &__border {
     border: double 1px transparent;
-    border-radius: 4.8rem; // Special value determined by designer here where it works in both expanded and collapsed
+    border-radius: var(--dt-size-radius-600);
     background-origin: border-box;
     background-clip: content-box, border-box;
     overflow: hidden;
   }
 
-  &--border-default {
+  &__border-default {
     background: var(--dt-color-border-default)
   }
 
-  &--border-ai {
+  &__border-ai {
     background-image:
       linear-gradient(var(--dt-color-surface-primary), var(--dt-color-surface-primary)),
       var(--dt-badge-color-background-ai);
   }
 
-  &--border-critical {
+  &__border-critical {
     background: var(--dt-color-foreground-critical);
   }
 

--- a/recipes/conversation_view/feed_pill/feed_item_pill_constants.js
+++ b/recipes/conversation_view/feed_pill/feed_item_pill_constants.js
@@ -1,7 +1,12 @@
 export const FEED_ITEM_PILL_BORDER_COLORS = {
-  default: 'dt-feed-item-pill--border-default',
-  ai: 'dt-feed-item-pill--border-ai',
-  critical: 'dt-feed-item-pill--border-critical',
+  default: 'dt-recipe-feed-item-pill--border-default',
+  ai: 'dt-recipe-feed-item-pill--border-ai',
+  critical: 'dt-recipe-feed-item-pill--border-critical',
+};
+
+export const FEED_ITEM_PILL_DATA_QA = {
+  PILL: 'dt-recipe-feed-item-pill',
+  PILL_ICON: 'dt-recipe-feed-item-pill-icon',
 };
 
 export default {

--- a/recipes/conversation_view/feed_pill/feed_item_pill_constants.js
+++ b/recipes/conversation_view/feed_pill/feed_item_pill_constants.js
@@ -1,12 +1,7 @@
 export const FEED_ITEM_PILL_BORDER_COLORS = {
-  default: 'dt-recipe-feed-item-pill--border-default',
-  ai: 'dt-recipe-feed-item-pill--border-ai',
-  critical: 'dt-recipe-feed-item-pill--border-critical',
-};
-
-export const FEED_ITEM_PILL_DATA_QA = {
-  PILL: 'dt-recipe-feed-item-pill',
-  PILL_ICON: 'dt-recipe-feed-item-pill-icon',
+  default: 'dt-recipe-feed-item-pill__border-default',
+  ai: 'dt-recipe-feed-item-pill__border-ai',
+  critical: 'dt-recipe-feed-item-pill__border-critical',
 };
 
 export default {

--- a/recipes/conversation_view/feed_pill/feed_item_pill_default.story.vue
+++ b/recipes/conversation_view/feed_pill/feed_item_pill_default.story.vue
@@ -1,13 +1,13 @@
 <template>
   <dt-recipe-feed-item-pill
-    :icon-name="iconName"
-    :title="title"
-    :wrapper-class="wrapperClass"
-    :button-class="buttonClass"
-    :border-color="borderColor"
-    :aria-label="ariaLabel"
-    :toggleable="toggleable"
-    :default-toggled="defaultToggled"
+    :icon-name="$attrs.iconName"
+    :title="$attrs.title"
+    :wrapper-class="$attrs.wrapperClass"
+    :button-class="$attrs.buttonClass"
+    :border-color="$attrs.borderColor"
+    :aria-label="$attrs.ariaLabel"
+    :toggleable="$attrs.toggleable"
+    :default-toggled="$attrs.defaultToggled"
   >
     <template #subtitle>
       Last 43 minutes - Ended at 5:04pm

--- a/recipes/conversation_view/feed_pill/feed_item_pill_default.story.vue
+++ b/recipes/conversation_view/feed_pill/feed_item_pill_default.story.vue
@@ -1,12 +1,13 @@
 <template>
   <dt-recipe-feed-item-pill
-    :icon-name="$attrs.iconName"
-    :title="$attrs.title"
-    :wrapper-class="$attrs.wrapperClass"
-    :button-class="$attrs.buttonClass"
-    :border-color="$attrs.borderColor"
-    :aria-label="$attrs.ariaLabel"
-    :toggleable="$attrs.toggleable"
+    :icon-name="iconName"
+    :title="title"
+    :wrapper-class="wrapperClass"
+    :button-class="buttonClass"
+    :border-color="borderColor"
+    :aria-label="ariaLabel"
+    :toggleable="toggleable"
+    :default-toggled="defaultToggled"
   >
     <template #subtitle>
       Last 43 minutes - Ended at 5:04pm

--- a/recipes/conversation_view/feed_pill/feed_item_pill_variants.story.vue
+++ b/recipes/conversation_view/feed_pill/feed_item_pill_variants.story.vue
@@ -1,0 +1,271 @@
+<template>
+  <div>
+    <div>
+      <h2>Call pill</h2>
+      <h3 class="d-mt8 d-mb4">
+        With summary
+      </h3>
+      <dt-recipe-feed-item-pill
+        default-toggled
+        title="Ben called you"
+        icon-name="phone-outgoing"
+        wrapper-class="d-w628"
+      >
+        <template #subtitle>
+          Lasted 8 min • Ended at 11:56 AM
+        </template>
+        <template #right>
+          <div class="d-pr16">
+            <dt-button
+              aria-label="Open external link"
+              kind="muted"
+              importance="clear"
+              :circle="true"
+              @click.stop=""
+            >
+              <template #icon>
+                <dt-icon
+                  name="external-link"
+                  size="300"
+                />
+              </template>
+            </dt-button>
+          </div>
+        </template>
+        <template #content>
+          <div class="d-p16">
+            <p>
+              The agent from Dialpad called to follow up on a support ticket
+              that Jeff was handling for them regarding Dialpad CTI. They apologized
+              for calling outside of the requested time and expressed that they had
+              asked the team to look into the issue and would email them after the call.
+            </p>
+            <p class="d-fs-100 d-mt12">
+              <strong>Actions items</strong>
+            </p>
+            <p class="d-d-flex">
+              <strong class="d-mr4">1. </strong>
+              The agent needs to inform the team to check on Vijay's request or ticket regarding Dialpad CTI.
+            </p>
+          </div>
+        </template>
+      </dt-recipe-feed-item-pill>
+
+      <h3 class="d-mt16 d-mb4">
+        Missed
+      </h3>
+      <dt-recipe-feed-item-pill
+        title="Missed call from Ben"
+        border-color="critical"
+        icon-name="phone-missed"
+        wrapper-class="d-w628"
+        :toggleable="false"
+      >
+        <template #right>
+          <div class="d-pr16">
+            <dt-button
+              aria-label="Call Ben"
+              kind="muted"
+              importance="clear"
+              :circle="true"
+              @click.stop=""
+            >
+              <template #icon>
+                <dt-icon
+                  name="phone"
+                  size="300"
+                />
+              </template>
+            </dt-button>
+          </div>
+        </template>
+      </dt-recipe-feed-item-pill>
+
+      <h3 class="d-mt16 d-mb4">
+        Voicemail
+      </h3>
+      <dt-recipe-feed-item-pill
+        icon-name="voicemail"
+        title="Voicemail"
+        wrapper-class="d-w628"
+        :toggleable="false"
+      >
+        <template #subtitle>
+          From (800)504-9978
+        </template>
+        <template #right>
+          <div class="d-pr16">
+            <dt-button
+              aria-label="Open external link"
+              kind="muted"
+              importance="clear"
+              :circle="true"
+              @click.stop=""
+            >
+              <template #icon>
+                <dt-icon
+                  name="external-link"
+                  size="300"
+                />
+              </template>
+            </dt-button>
+          </div>
+        </template>
+      </dt-recipe-feed-item-pill>
+
+      <h3 class="d-mt16 d-mb4">
+        Generating AI summary
+      </h3>
+      <dt-recipe-feed-item-pill
+        border-color="ai"
+        title="Ben called you"
+        icon-name="phone-incoming"
+        wrapper-class="d-w628"
+        :toggleable="false"
+      >
+        <template #right>
+          <div class="d-pr16">
+            <dt-button
+              aria-label="Open external link"
+              kind="muted"
+              importance="clear"
+              :circle="true"
+              @click.stop=""
+            >
+              <template #icon>
+                <dt-icon
+                  name="external-link"
+                  size="300"
+                />
+              </template>
+            </dt-button>
+          </div>
+        </template>
+      </dt-recipe-feed-item-pill>
+    </div>
+    <div>
+      <h2 class="d-mt16">
+        Meeting pill
+      </h2>
+
+      <h3 class="d-mt8 d-mb4">
+        With summary
+      </h3>
+      <dt-recipe-feed-item-pill
+        title="Ben started a meeting"
+        icon-name="video"
+        button-class="d-bar24"
+        wrapper-class="d-w628"
+        :default-toggled="true"
+      >
+        <template #subtitle>
+          Started 10 minutes ago
+        </template>
+        <template #bottom>
+          <span class="d-fc-tertiary d-fs-100">8 people joined</span>
+        </template>
+        <template #right>
+          <div class="d-pr16">
+            <dt-button
+              aria-label="Open external link"
+              kind="muted"
+              importance="clear"
+              :circle="true"
+              @click.stop=""
+            >
+              <template #icon>
+                <dt-icon
+                  name="external-link"
+                  size="300"
+                />
+              </template>
+            </dt-button>
+          </div>
+        </template>
+        <template #content>
+          <div class="d-p16">
+            <p>
+              The agent from Dialpad called to follow up on a support ticket
+              that Jeff was handling for them regarding Dialpad CTI. They apologized
+              for calling outside of the requested time and expressed that they had
+              asked the team to look into the issue and would email them after the call.
+            </p>
+            <p class="d-fs-100 d-mt12">
+              <strong>Actions items</strong>
+            </p>
+            <p class="d-d-flex">
+              <strong class="d-mr4">1. </strong>
+              The agent needs to inform the team to check on Vijay's request or ticket regarding Dialpad CTI.
+            </p>
+          </div>
+        </template>
+      </dt-recipe-feed-item-pill>
+
+      <h3 class="d-mt16 d-mb4">
+        Generating AI summary
+      </h3>
+      <dt-recipe-feed-item-pill
+        title="Ben started a meeting"
+        icon-name="video"
+        border-color="ai"
+        button-class="d-bar24"
+        wrapper-class="d-w628"
+        :toggleable="false"
+      >
+        <template #subtitle>
+          Started 10 minutes ago
+        </template>
+        <template #bottom>
+          <span class="d-fc-tertiary d-fs-100">8 people joined</span>
+        </template>
+        <template #right>
+          <div class="d-pr16">
+            <dt-button
+              aria-label="Open external link"
+              kind="muted"
+              importance="clear"
+              :circle="true"
+              @click.stop=""
+            >
+              <template #icon>
+                <dt-icon
+                  name="external-link"
+                  size="300"
+                />
+              </template>
+            </dt-button>
+          </div>
+        </template>
+      </dt-recipe-feed-item-pill>
+    </div>
+  </div>
+</template>
+
+<script>
+import DtRecipeFeedItemPill from './feed_item_pill.vue';
+import { DtIcon } from '@/components/icon';
+import { DtButton } from '@/components/button';
+
+const DEFAULT_PROPS = {
+  iconName: 'phone',
+  title: 'This meeting has ended',
+  ariaLabel: 'Click to expand',
+  wrapperClass: 'd-w628',
+};
+
+export default {
+  name: 'DtRecipeFeedItemPillVariants',
+
+  components: {
+    DtRecipeFeedItemPill,
+    DtButton,
+    DtIcon,
+  },
+
+  computed: {
+    DEFAULT_PROPS () {
+      return DEFAULT_PROPS;
+    },
+  },
+};
+</script>

--- a/recipes/conversation_view/feed_pill/feed_item_pill_variants.story.vue
+++ b/recipes/conversation_view/feed_pill/feed_item_pill_variants.story.vue
@@ -3,13 +3,14 @@
     <div>
       <h2>Call pill</h2>
       <h3 class="d-mt8 d-mb4">
-        With summary
+        With call recap
       </h3>
       <dt-recipe-feed-item-pill
         default-toggled
         title="Ben called you"
         icon-name="phone-outgoing"
         wrapper-class="d-w628"
+        border-color="ai"
       >
         <template #subtitle>
           Lasted 8 min • Ended at 11:56 AM
@@ -149,13 +150,14 @@
       </h2>
 
       <h3 class="d-mt8 d-mb4">
-        With summary
+        With call recap
       </h3>
       <dt-recipe-feed-item-pill
         title="Ben started a meeting"
         icon-name="video"
         button-class="d-bar24"
         wrapper-class="d-w628"
+        border-color="ai"
         :default-toggled="true"
       >
         <template #subtitle>

--- a/recipes/conversation_view/feed_pill/feed_item_pill_variants.story.vue
+++ b/recipes/conversation_view/feed_pill/feed_item_pill_variants.story.vue
@@ -246,13 +246,6 @@ import DtRecipeFeedItemPill from './feed_item_pill.vue';
 import { DtIcon } from '@/components/icon';
 import { DtButton } from '@/components/button';
 
-const DEFAULT_PROPS = {
-  iconName: 'phone',
-  title: 'This meeting has ended',
-  ariaLabel: 'Click to expand',
-  wrapperClass: 'd-w628',
-};
-
 export default {
   name: 'DtRecipeFeedItemPillVariants',
 
@@ -260,12 +253,6 @@ export default {
     DtRecipeFeedItemPill,
     DtButton,
     DtIcon,
-  },
-
-  computed: {
-    DEFAULT_PROPS () {
-      return DEFAULT_PROPS;
-    },
   },
 };
 </script>


### PR DESCRIPTION
# PR Title

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Feat

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Add a default behavior to control the default state of the collapsible component

## :bulb: Context

For some of our implementation, there is a need to render the call pill with the default state of the collapsible component being open

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

https://github.com/dialpad/dialtone-vue/assets/5950950/93a0298c-faaa-4205-9b2c-38220467d77c


