### PR TITLE
fix: add disabled prop to tooltip

### DIFF
--- a/components/tooltip/tooltip.stories.js
+++ b/components/tooltip/tooltip.stories.js
@@ -63,6 +63,10 @@ export const argTypesData = {
       },
     },
   },
+
+  disabled: {
+    type: 'boolean',
+  },
   show: {
     options: [null, true, false],
     type: 'select',

--- a/components/tooltip/tooltip.stories.js
+++ b/components/tooltip/tooltip.stories.js
@@ -64,7 +64,7 @@ export const argTypesData = {
     },
   },
 
-  disabled: {
+  enabled: {
     type: 'boolean',
   },
   show: {

--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -193,6 +193,7 @@ export default {
     /**
      * Controls whether hover/focus causes the tooltip to appear.
      * Cannot be combined with the show prop. show value will be ignored.
+     * by default this is true, if you override with false, the tooltip will never show up.
      */
     enabled: {
       type: Boolean,
@@ -342,6 +343,10 @@ export default {
   },
 
   mounted () {
+    if (!this.enabled && this.show != null) {
+      console.warn('Tooltip: You cannot use both the enabled and show props at the same time.');
+      console.warn('The show prop will be ignored.');
+    }
     this.externalAnchor && this.addExternalAnchorEventListeners();
     this.tip = createTippy(this.anchor, this.initOptions());
 

--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -21,7 +21,7 @@
     <dt-lazy-show
       :id="id"
       ref="content"
-      :show="isShown && enabled && (!!message.trim() || !!$slots.default)"
+      :show="isVisible"
       role="tooltip"
       aria-hidden="false"
       data-qa="dt-tooltip"
@@ -275,6 +275,11 @@ export default {
   },
 
   computed: {
+    // whether the tooltip is visible or not.
+    isVisible () {
+      return this.isShown && this.enabled && (!!this.message.trim() || !!this.$slots.default);
+    },
+
     tooltipListeners () {
       return {
         ...this.$listeners,

--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -21,7 +21,7 @@
     <dt-lazy-show
       :id="id"
       ref="content"
-      :show="isShown && !disabled && (!!message.trim() || !!$slots.default)"
+      :show="isShown && enabled && (!!message.trim() || !!$slots.default)"
       role="tooltip"
       aria-hidden="false"
       data-qa="dt-tooltip"
@@ -194,9 +194,9 @@ export default {
      * Controls whether hover/focus causes the tooltip to appear.
      * Cannot be combined with the show prop. show value will be ignored.
      */
-    disabled: {
+    enabled: {
       type: Boolean,
-      default: false,
+      default: true,
     },
 
     /**
@@ -349,13 +349,6 @@ export default {
     // show prop was initially set to true.
     if (this.isShown) {
       this.tip.show();
-    }
-  },
-
-  beforeCreate () {
-    if (this.$props.disabled != null && this.$props.show != null) {
-      console.warn('Tooltip: You cannot use both the disabled and show props at the same time.');
-      console.warn('The show prop will be ignored.');
     }
   },
 

--- a/components/tooltip/tooltip.vue
+++ b/components/tooltip/tooltip.vue
@@ -21,7 +21,7 @@
     <dt-lazy-show
       :id="id"
       ref="content"
-      :show="isShown && (!!message.trim() || !!$slots.default)"
+      :show="isShown && !disabled && (!!message.trim() || !!$slots.default)"
       role="tooltip"
       aria-hidden="false"
       data-qa="dt-tooltip"
@@ -191,6 +191,15 @@ export default {
     },
 
     /**
+     * Controls whether hover/focus causes the tooltip to appear.
+     * Cannot be combined with the show prop. show value will be ignored.
+     */
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
      * Controls whether the tooltip is shown. Leaving this null will have the tooltip trigger on mouseover by default.
      * If you set this value, the default mouseover behavior will be disabled and you can control it as you need.
      * Supports .sync modifier
@@ -340,6 +349,13 @@ export default {
     // show prop was initially set to true.
     if (this.isShown) {
       this.tip.show();
+    }
+  },
+
+  beforeCreate () {
+    if (this.$props.disabled != null && this.$props.show != null) {
+      console.warn('Tooltip: You cannot use both the disabled and show props at the same time.');
+      console.warn('The show prop will be ignored.');
     }
   },
 

--- a/components/tooltip/tooltip_default.story.vue
+++ b/components/tooltip/tooltip_default.story.vue
@@ -19,7 +19,7 @@
         :content-class="contentClass"
         :transition="transition"
         :show="showTooltip"
-        :disabled="disabled"
+        :enabled="enabled"
         :delay="delay"
         :external-anchor="externalAnchor"
         v-bind="$attrs"

--- a/components/tooltip/tooltip_default.story.vue
+++ b/components/tooltip/tooltip_default.story.vue
@@ -19,6 +19,7 @@
         :content-class="contentClass"
         :transition="transition"
         :show="showTooltip"
+        :disabled="disabled"
         :delay="delay"
         :external-anchor="externalAnchor"
         v-bind="$attrs"


### PR DESCRIPTION
# fix: add disabled prop to tooltip

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

this disabled prop will completely ignore whats set on show prop and make sure the tooltip doesnt appear. The general purpose of this disabled prop should be to preserve the hover actions on show prop but to be able to disable tooltip in certain conditions.