### PR TITLE
feat: add initial date formatting functions

### DIFF
--- a/common/dates.js
+++ b/common/dates.js
@@ -1,0 +1,127 @@
+import {
+  format,
+  formatDuration,
+  intervalToDuration,
+  formatDistance,
+  isToday,
+  isYesterday,
+  isThisWeek,
+  isSameYear,
+} from 'date-fns';
+import { capitalizeFirstLetter } from './utils';
+
+// Base functions just wrap core date-fns functions, but this allows us to do checks and set default options.
+
+function _baseFormat (date, formatString) {
+  _checkLocaleSet();
+  return format(date, formatString, {
+    locale: global.locale,
+  });
+}
+
+function _baseFormatDuration (duration, formatString) {
+  _checkLocaleSet();
+  return formatDuration(duration, {
+    locale: global.locale,
+    format: formatString,
+  });
+}
+
+function _baseFormatDistance (date, baseDate) {
+  _checkLocaleSet();
+  return formatDistance(date, baseDate, {
+    locale: global.locale,
+  });
+}
+
+function _isLocaleSet () {
+  return global.locale !== undefined;
+}
+
+function _checkLocaleSet () {
+  if (!_isLocaleSet()) {
+    throw new Error('Locale not set, please call setDateLocale(locale) and pass ' +
+    'in a datefns locale object as the locale param before calling this function');
+  }
+}
+
+/**
+ * Sets the locale for date-fns. This should be called before any date-fns functions are called.
+ * @param {Locale} locale A date-fns locale object
+ */
+export function setDateLocale (locale) {
+  global.locale = locale;
+}
+
+/**
+ * This formats a date to the Dialtone standard medium date format as shown here:
+ * https://dialpad.design/guides/writing-guidelines/#formats-by-length
+ * @param {Date} date A javascript date object
+ * @returns {string} A string in the format of 'September 2, 2022'
+ */
+export function getDateMedium (date) {
+  return _baseFormat(date, 'MMMM d, y');
+}
+
+/**
+ * Converts a call duration in total number of seconds to a human readable string
+ * such as 'less than a minute' or '4 hours 34 minutes'.
+ * @param {number} durationInSeconds The duration of the call in seconds
+ * @returns {string} A human readable string representing the duration of the call
+ */
+export function callDurationToHumanReadable (durationInSeconds) {
+  if (durationInSeconds < 60) {
+    // returns 'less than a minute', we're doing it like this instead of returning a string
+    // so datefns handles i18n.
+    return _baseFormatDistance(0, 29 * 1000);
+  }
+  const duration = intervalToDuration({
+    start: 0,
+    end: durationInSeconds * 1000,
+  });
+  return _baseFormatDuration(duration, ['hours', 'minutes']);
+}
+
+/**
+ * Returns the distance between the passed in date and now in a human readable format, typically used
+ * when showing a history of items in a log such as a feed list.
+ *
+ * datefns does not support 'today' and 'yesterday' without showing time so we use Intl for these cases.
+ *
+ * examples below to explain
+ * the different potential formats:
+ *
+ * If current day:
+ * Today
+ *
+ * If previous day:
+ * Yesterday
+ *
+ * Older than yesterday, but in the same calendar week:
+ * Monday
+ *
+ * Older than the most recent calendar week, but in the same year:
+ * Monday, October 14
+ *
+ * older than a calendar year:
+ * October 14, 2022
+ *
+ *
+ * @param {Date} date The timestamp of the item's date
+ * @returns {string} A human readable string representing the distance between the date and now
+ */
+export function dateRelativeToNow (date) {
+  if (isToday(date)) {
+    const rtl = new Intl.RelativeTimeFormat(global.locale.code, { numeric: 'auto' });
+    return capitalizeFirstLetter(rtl.formatToParts(0, 'day')[0].value, global.locale.code);
+  } else if (isYesterday(date)) {
+    const rtl = new Intl.RelativeTimeFormat(global.locale.code, { numeric: 'auto' });
+    return capitalizeFirstLetter(rtl.formatToParts(-1, 'day')[0].value, global.locale.code);
+  } else if (isThisWeek(date)) {
+    return _baseFormat(date, 'EEEE');
+  } else if (isSameYear(date, Date.now())) {
+    return _baseFormat(date, 'EEEE, MMMM d');
+  } else {
+    return _baseFormat(date, 'MMMM d, y');
+  }
+}

--- a/common/dates.js
+++ b/common/dates.js
@@ -69,7 +69,7 @@ export function getDateMedium (date) {
  * @param {number} durationInSeconds The duration of the call in seconds
  * @returns {string} A human readable string representing the duration of the call
  */
-export function callDurationToHumanReadable (durationInSeconds) {
+export function durationInHHMM (durationInSeconds) {
   if (durationInSeconds < 60) {
     // returns 'less than a minute', we're doing it like this instead of returning a string
     // so datefns handles i18n.
@@ -121,7 +121,7 @@ function _getRelativeDaysText (days) {
  * @param {Date} date The timestamp of the item's date
  * @returns {string} A human readable string representing the distance between the date and now
  */
-export function dateRelativeToNow (date) {
+export function relativeDate (date) {
   if (isToday(date)) {
     return _getRelativeDaysText(0);
   } else if (isYesterday(date)) {

--- a/common/dates.js
+++ b/common/dates.js
@@ -6,7 +6,7 @@ import {
   isToday,
   isYesterday,
   isThisWeek,
-  isSameYear,
+  isThisYear,
 } from 'date-fns';
 import { capitalizeFirstLetter } from './utils';
 
@@ -83,6 +83,17 @@ export function callDurationToHumanReadable (durationInSeconds) {
 }
 
 /**
+ * gets the human readable name of the day relative to the current time. For example, if you pass in -1 it will
+ * say "Yesterday" if you pass in 0 it will say "Today", if you pass in 1 it will say "Tomorrow".
+ * @param {number} days The number of days relative to the current time
+ * @returns {string} A human readable string representing the distance between the date and now
+ */
+function _getRelativeDaysText (days) {
+  const rtl = new Intl.RelativeTimeFormat(global.locale.code, { numeric: 'auto' });
+  return capitalizeFirstLetter(rtl.formatToParts(days, 'day')[0].value, global.locale.code);
+}
+
+/**
  * Returns the distance between the passed in date and now in a human readable format, typically used
  * when showing a history of items in a log such as a feed list.
  *
@@ -112,14 +123,12 @@ export function callDurationToHumanReadable (durationInSeconds) {
  */
 export function dateRelativeToNow (date) {
   if (isToday(date)) {
-    const rtl = new Intl.RelativeTimeFormat(global.locale.code, { numeric: 'auto' });
-    return capitalizeFirstLetter(rtl.formatToParts(0, 'day')[0].value, global.locale.code);
+    return _getRelativeDaysText(0);
   } else if (isYesterday(date)) {
-    const rtl = new Intl.RelativeTimeFormat(global.locale.code, { numeric: 'auto' });
-    return capitalizeFirstLetter(rtl.formatToParts(-1, 'day')[0].value, global.locale.code);
+    return _getRelativeDaysText(-1);
   } else if (isThisWeek(date)) {
     return _baseFormat(date, 'EEEE');
-  } else if (isSameYear(date, Date.now())) {
+  } else if (isThisYear(date)) {
     return _baseFormat(date, 'EEEE, MMMM d');
   } else {
     return _baseFormat(date, 'MMMM d, y');

--- a/common/dates.test.js
+++ b/common/dates.test.js
@@ -3,8 +3,8 @@ import { es, enUS } from 'date-fns/locale';
 import {
   setDateLocale,
   getDateMedium,
-  callDurationToHumanReadable,
-  dateRelativeToNow,
+  durationInHHMM,
+  relativeDate,
 } from './dates';
 
 const testInputDate = new Date(2022, 8, 2);
@@ -41,14 +41,14 @@ describe('Date function tests', () => {
       [new Date(2023, 9, 14, 10, 0, 0), null, 'Saturday, October 14'],
       [new Date(2022, 9, 14, 10, 0, 0), null, 'October 14, 2022'],
       [new Date(2022, 11, 31, 23, 59, 59), new Date(2023, 0, 1, 0, 0, 0), 'Yesterday'],
-    ])('When %s is passed in to dateRelativeToNow, it returns %s', (inputDate, currentTime, expected) => {
+    ])('When %s is passed in to relativeDate, it returns %s', (inputDate, currentTime, expected) => {
       if (currentTime === null) {
         // Set current time to Oct 24 2023 10:30:00 AM by default.
         currentTime = new Date(2023, 9, 24, 10, 30, 0);
       }
       vi.setSystemTime(currentTime);
 
-      expect(dateRelativeToNow(inputDate)).toBe(expected);
+      expect(relativeDate(inputDate)).toBe(expected);
     });
 
     it.each([
@@ -58,8 +58,8 @@ describe('Date function tests', () => {
       [60, '1 minute'],
       [55 * 60, '55 minutes'],
       [(4 * 60 * 60) + (34 * 60), '4 hours 34 minutes'],
-    ])('When %d is passed in to callPillDurationToHumanReadable, it returns %s', (inputSeconds, expected) => {
-      expect(callDurationToHumanReadable(inputSeconds)).toBe(expected);
+    ])('When %d is passed in to durationInHHMM, it returns %s', (inputSeconds, expected) => {
+      expect(durationInHHMM(inputSeconds)).toBe(expected);
     });
   });
 
@@ -73,28 +73,28 @@ describe('Date function tests', () => {
       setDateLocale(es);
     });
 
+    it('getDateMedium returns the expected date', () => {
+      expect(getDateMedium(testInputDate)).toBe('septiembre 2, 2022');
+    });
+
     it.each([
       [new Date(2023, 9, 24, 10, 0, 0), null, 'Hoy'],
       [new Date(2023, 9, 14, 10, 0, 0), null, 'sábado, octubre 14'],
-    ])('When %s is passed in to dateRelativeToNow, it returns %s', (inputDate, currentTime, expected) => {
+    ])('When %s is passed in to relativeDate, it returns %s', (inputDate, currentTime, expected) => {
       if (currentTime === null) {
         // Set current time to Oct 24 2023 10:30:00 AM by default.
         currentTime = new Date(2023, 9, 24, 10, 30, 0);
       }
       vi.setSystemTime(currentTime);
 
-      expect(dateRelativeToNow(inputDate)).toBe(expected);
+      expect(relativeDate(inputDate)).toBe(expected);
     });
 
     it.each([
       [59, 'menos de un minuto'],
       [(4 * 60 * 60) + (34 * 60), '4 horas 34 minutos'],
-    ])('When %d is passed in to callPillSecondsToDistance, it returns %s', (inputSeconds, expected) => {
-      expect(callDurationToHumanReadable(inputSeconds)).toBe(expected);
-    });
-
-    it('getDateMedium returns the expected date', () => {
-      expect(getDateMedium(testInputDate)).toBe('septiembre 2, 2022');
+    ])('When %d is passed in to durationInHHMM, it returns %s', (inputSeconds, expected) => {
+      expect(durationInHHMM(inputSeconds)).toBe(expected);
     });
   });
 });

--- a/common/dates.test.js
+++ b/common/dates.test.js
@@ -1,0 +1,100 @@
+import { beforeEach, vi } from 'vitest';
+import { es, enUS } from 'date-fns/locale';
+import {
+  setDateLocale,
+  getDateMedium,
+  callDurationToHumanReadable,
+  dateRelativeToNow,
+} from './dates';
+
+const testInputDate = new Date(2022, 8, 2);
+
+describe('Date function tests', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('When locale is not set', () => {
+    it('getDateMedium throws an error', () => {
+      global.locale = undefined;
+      expect(() => getDateMedium(testInputDate)).toThrow();
+    });
+  });
+
+  describe('When locale is set to enUS', () => {
+    beforeEach(() => {
+      setDateLocale(enUS);
+    });
+
+    it('getDateMedium returns the expected date', () => {
+      expect(getDateMedium(testInputDate)).toBe('September 2, 2022');
+    });
+
+    it.each([
+      [new Date(2023, 9, 24, 10, 0, 0), null, 'Today'],
+      [new Date(2023, 9, 23, 10, 0, 0), null, 'Yesterday'],
+      [new Date(2023, 9, 22, 10, 0, 0), null, 'Sunday'],
+      [new Date(2023, 9, 14, 10, 0, 0), null, 'Saturday, October 14'],
+      [new Date(2022, 9, 14, 10, 0, 0), null, 'October 14, 2022'],
+      [new Date(2022, 11, 31, 23, 59, 59), new Date(2023, 0, 1, 0, 0, 0), 'Yesterday'],
+    ])('When %s is passed in to dateRelativeToNow, it returns %s', (inputDate, currentTime, expected) => {
+      if (currentTime === null) {
+        // Set current time to Oct 24 2023 10:30:00 AM by default.
+        currentTime = new Date(2023, 9, 24, 10, 30, 0);
+      }
+      vi.setSystemTime(currentTime);
+
+      expect(dateRelativeToNow(inputDate)).toBe(expected);
+    });
+
+    it.each([
+      [59, 'less than a minute'],
+      [29, 'less than a minute'],
+      [0, 'less than a minute'],
+      [60, '1 minute'],
+      [55 * 60, '55 minutes'],
+      [(4 * 60 * 60) + (34 * 60), '4 hours 34 minutes'],
+    ])('When %d is passed in to callPillDurationToHumanReadable, it returns %s', (inputSeconds, expected) => {
+      expect(callDurationToHumanReadable(inputSeconds)).toBe(expected);
+    });
+  });
+
+  /**
+   * Most functions can just be tested using just the enUS locale, but we should test a few language based
+   * formats here just to make sure that i18n is working as expected.
+   */
+
+  describe('When locale is set to es', () => {
+    beforeEach(() => {
+      setDateLocale(es);
+    });
+
+    it.each([
+      [new Date(2023, 9, 24, 10, 0, 0), null, 'Hoy'],
+      [new Date(2023, 9, 14, 10, 0, 0), null, 'sábado, octubre 14'],
+    ])('When %s is passed in to dateRelativeToNow, it returns %s', (inputDate, currentTime, expected) => {
+      if (currentTime === null) {
+        // Set current time to Oct 24 2023 10:30:00 AM by default.
+        currentTime = new Date(2023, 9, 24, 10, 30, 0);
+      }
+      vi.setSystemTime(currentTime);
+
+      expect(dateRelativeToNow(inputDate)).toBe(expected);
+    });
+
+    it.each([
+      [59, 'menos de un minuto'],
+      [(4 * 60 * 60) + (34 * 60), '4 horas 34 minutos'],
+    ])('When %d is passed in to callPillSecondsToDistance, it returns %s', (inputSeconds, expected) => {
+      expect(callDurationToHumanReadable(inputSeconds)).toBe(expected);
+    });
+
+    it('getDateMedium returns the expected date', () => {
+      expect(getDateMedium(testInputDate)).toBe('septiembre 2, 2022');
+    });
+  });
+});

--- a/common/utils.js
+++ b/common/utils.js
@@ -358,6 +358,16 @@ export function safeConcatStrings (elements) {
   return elements.filter(str => !!str).join(' ');
 }
 
+/**
+ * Locale safe function to capitalize the first letter of a string.
+ * @param {string} str the string to capitalize the first letter of
+ * @param {string} locale a string representing the locale to be used. Defaults to 'en-US'
+ * @returns The passed in string with the first letter capitalized
+ */
+export function capitalizeFirstLetter (str, locale = 'en-US') {
+  return str.replace(/^\p{CWU}/u, char => char.toLocaleUpperCase(locale));
+}
+
 export default {
   getUniqueString,
   getRandomElement,
@@ -377,4 +387,5 @@ export default {
   isPhoneNumber,
   isURL,
   safeConcatStrings,
+  capitalizeFirstLetter,
 };

--- a/common/utils.test.js
+++ b/common/utils.test.js
@@ -13,6 +13,7 @@ import {
   isPhoneNumber,
   isURL,
   isEmailAddress,
+  capitalizeFirstLetter,
 } from './utils';
 
 describe('Util Tests', () => {
@@ -473,6 +474,15 @@ describe('Util Tests', () => {
       ])('should return true for "%s"', async (input) => {
         expect(isEmailAddress(input)).toBe(true);
       });
+    });
+  });
+
+  describe('capitalizeFirstLetter', () => {
+    it('should capitalize the first letter of a string', () => {
+      expect(capitalizeFirstLetter('hello')).toBe('Hello');
+    });
+    it('should capitalize the first letter of a string with dutch locale', () => {
+      expect(capitalizeFirstLetter('ĳsselmeer', 'nl')).toBe('Ĳsselmeer');
     });
   });
 });

--- a/common/utils.test.js
+++ b/common/utils.test.js
@@ -484,5 +484,8 @@ describe('Util Tests', () => {
     it('should capitalize the first letter of a string with dutch locale', () => {
       expect(capitalizeFirstLetter('ĳsselmeer', 'nl')).toBe('Ĳsselmeer');
     });
+    it('should not change japanese since it does not have capitals', () => {
+      expect(capitalizeFirstLetter('送り仮名', 'ja')).toBe('送り仮名');
+    });
   });
 });

--- a/index.js
+++ b/index.js
@@ -84,3 +84,5 @@ export {
   filterFormattedMessages,
   getValidationState,
 } from './common/utils';
+
+export * from './common/dates';


### PR DESCRIPTION
# feat: add initial date formatting functions

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Added some initial date formatting functions:

- getDateMedium which returns the date in medium format from our [Writing Guidelines](https://dialpad.design/guides/writing-guidelines/#formats-by-length)
- callDurationToHumanReadable ([currently in DP 2.0](https://github.com/dialpad/web-clients/pull/613/files)) 
- dateRelativeToNow ([currently in DP 2.0](https://github.com/dialpad/web-clients/blob/main/packages/conversation-feed-ui/src/use-relative-date-format.ts))

The story was just to initially add this getDateMedium function, but I decided to include the functions that DP 2.0 wanted to transfer to dialtone as well so they have something that's actually useful to work with. All public functions here are fully i18n compatible and the locale must be set via `setDateLocale` before using any of these functions.

I've documented these functions well in the code so please see the comments for further details about how they work.

Documentation will be coming in a separate PR since I'd like to publish it on dialtone.

## :bulb: Context

Requested by DP 2.0 team. They are having to put a lot of logic for date formatting into DP 2.0 when really this should be handled on the Dialtone side.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [ ] I have added all relevant documentation (not yet)
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps

- Write public documentation
- Add more date functions
- See if we can extract or use date functions from our current date picker.

## :link: Sources

- https://dialpad.design/guides/writing-guidelines/#formats-by-length
- https://github.com/dialpad/web-clients/pull/613/files
- https://github.com/dialpad/web-clients/blob/main/packages/conversation-feed-ui/src/use-relative-date-format.ts
- https://date-fns.org/
