### PR TITLE
docs: fixed story for buttongroup component aligment

### DIFF
--- a/components/button_group/button_group.mdx
+++ b/components/button_group/button_group.mdx
@@ -34,7 +34,7 @@ import { DtButtonGroup, DtButton } from '@dialpad/dialtone-vue';
 
 ```html
 <template>
-  <dt-button-group>
+  <dt-button-group class="d-gg8">
     <dt-button importance="primary">
       Confirm
     </dt-button>

--- a/components/button_group/button_group_default.story.vue
+++ b/components/button_group/button_group_default.story.vue
@@ -1,14 +1,26 @@
 <template>
   <dt-button-group
     :alignment="alignment"
+    class="d-gg8"
   >
     <html-fragment
       v-if="defaultSlot"
       :html="defaultSlot"
     />
+    <template v-if="alignment === 'end'">
+      <dt-button
+        importance="outlined"
+      >
+        Cancel
+      </dt-button>
+      <dt-button
+        importance="primary"
+      >
+        Confirm
+      </dt-button>
+    </template>
     <template v-else>
       <dt-button
-        class="d-mr6"
         importance="primary"
       >
         Confirm

--- a/components/button_group/button_group_default.story.vue
+++ b/components/button_group/button_group_default.story.vue
@@ -7,7 +7,7 @@
       v-if="defaultSlot"
       :html="defaultSlot"
     />
-    <template v-if="alignment === 'end'">
+    <template v-else-if="alignment === 'end'">
       <dt-button
         importance="outlined"
       >


### PR DESCRIPTION
# docs: fixed story for button-group component alignment

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [ ] Feature
- [ ] Refactoring
- [x] Documentation

## :book: Description

Related to ticket: [DLT-1362](https://dialpad.atlassian.net/browse/DLT-1362)
Updated story for button-group component where aligned to `end` primary button goes on the right side of the group. This impacts only the story, not the component.

## :bulb: Context

Improve the button-group component's documentation, making it clearer to understand how it works when aligned to 'end.' This ensures that users can use the component without any confusion.

## :pencil: Checklist

- [x] I have reviewed my changes
- [ ] I have added tests
- [ ] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [ ] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root

## :camera: Screenshots / GIFs

Before:
<img width="514" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/144369133/e55a834e-1f2a-4c1f-a3b1-24be03aa0bc7">

After:
<img width="493" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/144369133/aed3e2d2-c3aa-4a95-bd06-b3d44c50b9ce">

## :link: Sources

<!--- Add any links to external reference material -->


[DLT-1362]: https://dialpad.atlassian.net/browse/DLT-1362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ