### PR TITLE
feat: add description list component

### DIFF
--- a/components/description_list/description_list.mdx
+++ b/components/description_list/description_list.mdx
@@ -1,0 +1,58 @@
+import { Canvas, Story, Subtitle, Controls, Meta } from '@storybook/blocks';
+import * as DtDescriptionListStories from './description_list.stories.js';
+
+<Meta of={DtDescriptionListStories}/>
+
+# DtDescriptionList
+
+<Subtitle>
+  Description lists are a way to group and clarify associated ideas.
+  They are notably useful when outlining and explaining terms, like those in a glossary.
+</Subtitle>
+
+## Base Style
+
+<Canvas of={DtDescriptionListStories.Default} />
+
+## Column Direction
+
+<Canvas of={DtDescriptionListStories.ColumnDirection} />
+
+## Long Text
+
+<Canvas of={DtDescriptionListStories.LongText} />
+
+## Slots, Props & Events
+
+<Controls />
+
+## Usage
+
+### Import
+
+```jsx
+import { DtDescriptionList } from '@dialpad/dialtone-vue';
+```
+
+### Default
+
+```jsx
+<dt-description-list
+  :items="[{
+    term: 'Customer Intent',
+    description: 'Hello, I'm looking to return my TV',
+  }]"
+/>
+```
+
+### Column Direction
+
+```jsx
+<dt-description-list
+  :items="[{
+    term: 'Customer Intent',
+    description: 'Hello, I'm looking to return my TV',
+  }]"
+  :direction="column"
+/>
+```

--- a/components/description_list/description_list.stories.js
+++ b/components/description_list/description_list.stories.js
@@ -1,0 +1,123 @@
+import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import DtDescriptionList from './description_list.vue';
+import DtDescriptionListDefaultTemplate from './description_list_default.story.vue';
+
+export const argTypesData = {
+  // Props
+  items: {
+    control: 'object',
+    table: {
+      defaultValue: {
+        summary: '{ term: string, description: string }[]',
+      },
+    },
+  },
+  descriptionClass: {
+    control: 'text',
+  },
+  termClass: {
+    control: 'text',
+  },
+};
+
+export const argsData = {
+  direction: 'row',
+  gap: '400',
+  items: [
+    {
+      term: 'Customer Intent',
+      description: `Hello, I'm looking to return my TV`,
+    },
+    {
+      term: 'Reason',
+      description: 'Refound',
+    },
+    {
+      term: 'Country',
+      description: 'England',
+    },
+    {
+      term: 'Random',
+      description: 'Value',
+    },
+  ],
+};
+
+const argsDataLongText = {
+  items: [
+    {
+      term: 'Customer Intent',
+      description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+      sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.`,
+    },
+    {
+      term: 'Three word term',
+      description: ` Duis aute irure dolor in reprehenderit in voluptate velit
+      esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`,
+    },
+    {
+      term: 'Country',
+      description: 'England',
+    },
+    {
+      term: 'Random',
+      description: 'Value',
+    },
+  ],
+};
+
+const decorator = () => ({
+  template: `<div
+      style="width: var(--dt-size-925);
+      overflow: hidden;
+      resize: horizontal;
+      height: auto;
+      border: 1px solid var(--dt-color-border-subtle);
+      padding: var(--dt-space-450);
+      borderRadius: var(--dt-size-radius-400);"
+      >
+      <story />
+    </div>`,
+});
+
+// Story Collection
+export default {
+  title: 'Components/Description List',
+  component: DtDescriptionList,
+  args: argsData,
+  argTypes: argTypesData,
+  decorators: [decorator],
+  excludeStories: /.*Data$/,
+};
+
+// Templates
+const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  DtDescriptionListDefaultTemplate,
+);
+
+// Stories
+export const Default = {
+  render: DefaultTemplate,
+  args: {},
+};
+
+export const ColumnDirection = {
+  ...Default,
+  args: {
+    direction: 'column',
+  },
+};
+
+export const LongText = {
+  ...Default,
+  args: { ...Default.args, items: argsDataLongText.items },
+};
+
+export const WithStyles = {
+  ...Default,
+  args: { ...Default.args, termClass: ['d-fw-bold', 'd-fc-disabled'] },
+};

--- a/components/description_list/description_list.stories.js
+++ b/components/description_list/description_list.stories.js
@@ -1,4 +1,5 @@
 import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { DT_STACK_GAP } from '@/components/stack/stack_constants';
 import DtDescriptionList from './description_list.vue';
 import DtDescriptionListDefaultTemplate from './description_list_default.story.vue';
 
@@ -10,6 +11,16 @@ export const argTypesData = {
       defaultValue: {
         summary: '{ term: string, description: string }[]',
       },
+    },
+  },
+  direction: {
+    options: ['row', 'column'],
+    control: { type: 'radio' },
+  },
+  gap: {
+    options: DT_STACK_GAP,
+    control: {
+      type: 'select',
     },
   },
 };

--- a/components/description_list/description_list.stories.js
+++ b/components/description_list/description_list.stories.js
@@ -12,12 +12,6 @@ export const argTypesData = {
       },
     },
   },
-  descriptionClass: {
-    control: 'text',
-  },
-  termClass: {
-    control: 'text',
-  },
 };
 
 export const argsData = {

--- a/components/description_list/description_list.test.js
+++ b/components/description_list/description_list.test.js
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils';
 import DtDescriptionList from './description_list.vue';
 
+let MOCK_LIST = null;
+
 const baseProps = {
   items: [{
     term: 'Customer Intent',
@@ -15,7 +17,6 @@ let mockProps = {};
 
 describe('DtDescriptionList Tests', () => {
   let wrapper;
-  let list;
 
   const updateWrapper = () => {
     wrapper = mount(DtDescriptionList, {
@@ -60,21 +61,21 @@ describe('DtDescriptionList Tests', () => {
 
   describe('Accessibility Tests', () => {
     beforeEach(() => {
-      list = wrapper.find('dl');
+      MOCK_LIST = wrapper.find('dl');
 
       updateWrapper();
     });
 
     it('Should render a <dl> tag', () => {
-      expect(list.exists()).toBe(true);
+      expect(MOCK_LIST.exists()).toBe(true);
     });
 
     it('Should contain two <dt> tags', () => {
-      expect(list.findAll('dt').length).toBe(2);
+      expect(MOCK_LIST.findAll('dt').length).toBe(2);
     });
 
     it('Should contain two <dd> tags', () => {
-      expect(list.findAll('dd').length).toBe(2);
+      expect(MOCK_LIST.findAll('dd').length).toBe(2);
     });
   });
 
@@ -125,23 +126,27 @@ describe('DtDescriptionList Tests', () => {
   describe('Extendability Tests', () => {
     const customClass = 'my-custom-class';
 
-    describe('When an term class is provided', () => {
+    describe('When a term class is provided', () => {
       it('should apply custom class to child', () => {
         mockProps = { termClass: customClass };
 
         updateWrapper();
 
-        expect(wrapper.find('dt').classes().includes(customClass)).toBe(true);
+        const dtElement = wrapper.find('dt');
+
+        expect(dtElement.classes().includes(customClass)).toBe(true);
       });
     });
 
-    describe('When an description class is provided', () => {
+    describe('When a description class is provided', () => {
       it('should apply custom class to child', () => {
         mockProps = { descriptionClass: customClass };
 
         updateWrapper();
 
-        expect(wrapper.find('dd').classes().includes(customClass)).toBe(true);
+        const ddElement = wrapper.find('dd');
+
+        expect(ddElement.classes().includes(customClass)).toBe(true);
       });
     });
   });

--- a/components/description_list/description_list.test.js
+++ b/components/description_list/description_list.test.js
@@ -1,0 +1,148 @@
+import { mount } from '@vue/test-utils';
+import DtDescriptionList from './description_list.vue';
+
+const baseProps = {
+  items: [{
+    term: 'Customer Intent',
+    description: 'Hello, I\'m looking to return my TV',
+  }, {
+    term: 'Reason',
+    description: 'Refound',
+  }],
+};
+
+let mockProps = {};
+
+describe('DtDescriptionList Tests', () => {
+  let wrapper;
+  let list;
+
+  const updateWrapper = () => {
+    wrapper = mount(DtDescriptionList, {
+      propsData: { ...baseProps, ...mockProps },
+    });
+  };
+
+  beforeEach(() => {
+    updateWrapper();
+  });
+
+  afterEach(() => {
+    mockProps = {};
+  });
+
+  describe('Presentation Tests', () => {
+    it('Should render the description list', () => {
+      expect(wrapper).toBeDefined();
+      expect(wrapper.classes().includes('dt-description-list')).toBe(true);
+    });
+
+    describe('When direction prop is set', () => {
+      it('Should have correct class', () => {
+        mockProps = { direction: 'column' };
+
+        updateWrapper();
+
+        expect(wrapper.classes().includes('dt-description-list--column')).toBe(true);
+      });
+    });
+
+    describe('When gap prop is set', () => {
+      it('Should have correct class', () => {
+        mockProps = { gap: '300' };
+
+        updateWrapper();
+
+        expect(wrapper.classes().includes('dt-description-list--gap-300')).toBe(true);
+      });
+    });
+  });
+
+  describe('Accessibility Tests', () => {
+    beforeEach(() => {
+      list = wrapper.find('dl');
+
+      updateWrapper();
+    });
+
+    it('Should render a <dl> tag', () => {
+      expect(list.exists()).toBe(true);
+    });
+
+    it('Should contain two <dt> tags', () => {
+      expect(list.findAll('dt').length).toBe(2);
+    });
+
+    it('Should contain two <dd> tags', () => {
+      expect(list.findAll('dd').length).toBe(2);
+    });
+  });
+
+  describe('Validation Tests', () => {
+    describe('Direction Validator', () => {
+      describe('When provided direction is valid', () => {
+        it('passes custom prop validation', () => {
+          expect(DtDescriptionList.props.direction.validator('column')).toBe(true);
+        });
+      });
+
+      describe('When provided direction is not valid', () => {
+        it('fails custom prop validation', () => {
+          expect(DtDescriptionList.props.direction.validator('INVALID_DIRECTION')).toBe(false);
+        });
+      });
+    });
+
+    describe('Items Validator', () => {
+      describe('When provided items are valid', () => {
+        it('passes custom prop validation', () => {
+          expect(DtDescriptionList.props.items.validator(baseProps.items)).toBe(true);
+        });
+      });
+
+      describe('When provided items are not valid', () => {
+        it('fails custom prop validation', () => {
+          expect(DtDescriptionList.props.items.validator([{ invalid: 'description' }])).toBe(false);
+        });
+      });
+    });
+
+    describe('Gap Validator', () => {
+      describe('When provided gap is valid', () => {
+        it('passes custom prop validation', () => {
+          expect(DtDescriptionList.props.gap.validator('300')).toBe(true);
+        });
+      });
+
+      describe('When provided gap is not valid', () => {
+        it('fails custom prop validation', () => {
+          expect(DtDescriptionList.props.gap.validator('invalid')).toBe(false);
+        });
+      });
+    });
+  });
+
+  describe('Extendability Tests', () => {
+    const customClass = 'my-custom-class';
+
+    describe('When an term class is provided', () => {
+      it('should apply custom class to child', () => {
+        mockProps = { termClass: customClass };
+
+        updateWrapper();
+
+        expect(wrapper.find('dt').classes().includes(customClass)).toBe(true);
+      });
+    });
+
+    describe('When an description class is provided', () => {
+      it('should apply custom class to child', () => {
+        mockProps = { descriptionClass: customClass };
+
+        updateWrapper();
+
+        expect(wrapper.find('dd').classes().includes(customClass)).toBe(true);
+      });
+    });
+  });
+});

--- a/components/description_list/description_list.vue
+++ b/components/description_list/description_list.vue
@@ -1,16 +1,17 @@
-<!-- eslint-disable vue/require-v-for-key -->
 <template>
   <dl :class="['dt-description-list', getDirectionClass, getGapClass]">
     <template
       v-for="item in items"
     >
       <dt
-        :class="['dt-description-list__term', termClass]"
+        :key="`dt-${item.term}`"
+        :class="dtClass"
       >
         {{ item.term }}
       </dt>
       <dd
-        :class="['dt-description-list__description', descriptionClass]"
+        :key="`dd-${item.term}`"
+        :class="ddClass"
       >
         {{ item.description }}
       </dd>
@@ -75,6 +76,14 @@ export default {
   },
 
   computed: {
+    dtClass () {
+      return ['dt-description-list__term', this.termClass];
+    },
+
+    ddClass () {
+      return ['dt-description-list__description', this.descriptionClass];
+    },
+
     getDirectionClass () {
       return `dt-description-list--${this.direction}`;
     },

--- a/components/description_list/description_list.vue
+++ b/components/description_list/description_list.vue
@@ -1,0 +1,116 @@
+<!-- eslint-disable vue/require-v-for-key -->
+<template>
+  <dl :class="['dt-description-list', getDirectionClass, getGapClass]">
+    <template
+      v-for="item in items"
+    >
+      <dt
+        :class="['dt-description-list__term', termClass]"
+      >
+        {{ item.term }}
+      </dt>
+      <dd
+        :class="['dt-description-list__description', descriptionClass]"
+      >
+        {{ item.description }}
+      </dd>
+    </template>
+  </dl>
+</template>
+
+<script>
+import { DT_STACK_GAP } from '../stack/stack_constants';
+import { DT_DESCRIPTION_LIST_DIRECTION } from './description_list_constants';
+import { itemsValidator } from './description_list_validators';
+
+export default {
+  name: 'DtDescriptionList',
+
+  props: {
+    /**
+     * The direction for the list
+     * @values row, column
+     */
+    direction: {
+      type: String,
+      default: 'row',
+      validator: direction => DT_DESCRIPTION_LIST_DIRECTION.includes(direction),
+    },
+
+    /**
+     * A list of items that represent the term and the description
+     */
+    items: {
+      type: Array,
+      default: () => [],
+      validator: items => itemsValidator(items),
+      required: true,
+    },
+
+    /**
+     * Set the space between the elements
+     * @values 0, 100, 200, 300, 400, 500, 600
+     */
+    gap: {
+      type: String,
+      default: '400',
+      validator: (gap) => DT_STACK_GAP.includes(gap),
+    },
+
+    /**
+     * Used to customize the term element
+     */
+    termClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+
+    /**
+     * Used to customize the description element
+     */
+    descriptionClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+  },
+
+  computed: {
+    getDirectionClass () {
+      return `dt-description-list--${this.direction}`;
+    },
+
+    getGapClass () {
+      return DT_STACK_GAP.includes(this.gap) ? `dt-description-list--gap-${this.gap}` : null;
+    },
+  },
+};
+</script>
+
+<style lang="less">
+.dt-description-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: var(--dt-space-400);
+  flex-direction: row;
+  line-height: var(--lh2);
+  font-size: var(--dt-font-size-100);
+  &--column {
+    flex-direction: column;
+  }
+  &__term {
+    color: var(--dt-color-foreground-tertiary);
+    flex: 0 1 40%;
+  }
+  &__description {
+    color: var(--dt-color-foreground-primary);
+    flex: 1 1 50%;
+    margin-left: 0;
+  }
+}
+each(range(0, 600, 100), {
+  .dt-description-list--gap-@{value} {
+    gap: ~"var(--dt-space-@{value})";
+  }
+});
+</style>

--- a/components/description_list/description_list.vue
+++ b/components/description_list/description_list.vue
@@ -123,9 +123,4 @@ export default {
     margin-left: 0;
   }
 }
-each(range(0, 600, 100), {
-  .dt-description-list--gap-@{value} {
-    gap: ~"var(--dt-space-@{value})";
-  }
-});
 </style>

--- a/components/description_list/description_list.vue
+++ b/components/description_list/description_list.vue
@@ -80,7 +80,7 @@ export default {
     },
 
     getGapClass () {
-      return DT_STACK_GAP.includes(this.gap) ? `dt-description-list--gap-${this.gap}` : null;
+      return `dt-description-list--gap-${this.gap}`;
     },
   },
 };
@@ -91,10 +91,16 @@ export default {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
-  gap: var(--dt-space-400);
   flex-direction: row;
-  line-height: var(--lh2);
+  line-height: var(--dt-font-line-height-300);
   font-size: var(--dt-font-size-100);
+  --description-list-gap: var(--dt-space-400);
+  gap: var(--description-list-gap);
+  each(range(0, 600, 100), {
+    &--gap-@{value} {
+     --description-list-gap: ~"var(--dt-space-@{value})";
+    }
+  });
   &--column {
     flex-direction: column;
   }

--- a/components/description_list/description_list_constants.js
+++ b/components/description_list/description_list_constants.js
@@ -1,0 +1,1 @@
+export const DT_DESCRIPTION_LIST_DIRECTION = ['row', 'column'];

--- a/components/description_list/description_list_default.story.vue
+++ b/components/description_list/description_list_default.story.vue
@@ -1,0 +1,18 @@
+<template>
+  <dt-description-list
+    :gap="gap"
+    :items="items"
+    :direction="direction"
+    :term-class="termClass"
+    :description-class="descriptionClass"
+  />
+</template>
+
+<script>
+import DtDescriptionList from './description_list.vue';
+
+export default {
+  name: 'DtDescriptionListDefault',
+  components: { DtDescriptionList },
+};
+</script>

--- a/components/description_list/description_list_validators.js
+++ b/components/description_list/description_list_validators.js
@@ -1,0 +1,37 @@
+const hasValidTerm = item => {
+  if (!item.term) {
+    return false;
+  }
+
+  return typeof item.term === 'string';
+};
+
+const hasValidDescription = item => {
+  if (!item.description) {
+    return false;
+  }
+
+  return typeof item.description === 'string';
+};
+
+export const itemsValidator = items => {
+  if (!Array.isArray(items)) {
+    return false;
+  }
+
+  return items.every(item => {
+    if (typeof item !== 'object') {
+      return false;
+    }
+
+    if (!hasValidTerm(item)) {
+      return false;
+    }
+
+    if (!hasValidDescription(item)) {
+      return false;
+    }
+
+    return true;
+  });
+};

--- a/components/description_list/index.js
+++ b/components/description_list/index.js
@@ -1,0 +1,2 @@
+export { default as DtDescriptionList } from './description_list.vue';
+export { DT_DESCRIPTION_LIST_DIRECTION } from './description_list_constants';

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ export * from './components/card';
 export * from './components/codeblock';
 export * from './components/combobox';
 export * from './components/collapsible';
+export * from './components/description_list';
 export * from './components/dropdown';
 export * from './components/image_viewer';
 export * from './components/input';


### PR DESCRIPTION
# feat: add description list component

Jira ticket: https://dialpad.atlassian.net/browse/DLT-1209
Link to preview: https://vue.dialpad.design/deploy-previews/pr-1289/?path=/story/components-description-list--default

Based on this figma, but it still needs design definition: https://www.figma.com/file/HXPNFvkGbcsfU6KpoW0ZPl/Screen-Pops?type=design&node-id=740-186846&mode=design&t=jxVBVwxW69KpzzZc-0

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

<!--- Describe the changes -->
Adds the new component description list to Dialtone Vue.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added tests
- [x] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [x] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [x] I have checked that my change did not significantly increase bundle size
- [x] I am exporting any new components or constants in the index.js in the component directory
- [x] I am exporting any new components or constants in the index.js in the root

## :crystal_ball: Next Steps
Move the CSS to Dialtone

## :camera: Screenshots / GIFs

<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->
<img width="319" alt="image" src="https://github.com/dialpad/dialtone-vue/assets/24460973/a7656b37-8533-49f1-aaec-a8ca06d5c22e">

## :link: Sources

<!--- Add any links to external reference material -->
