### PR TITLE
docs(tooltip): add sticky popper variation

### DIFF
--- a/components/tooltip/tooltip.mdx
+++ b/components/tooltip/tooltip.mdx
@@ -41,6 +41,14 @@ A tooltip has two slots:
     <Story of={TooltipStories.Flip} />
 </Canvas>
 
+## Dinamically change the position when the content changes
+
+This is achieved by setting the property `sticky` to "popper"
+
+<Canvas>
+    <Story of={TooltipStories.ChangeOnClick} />
+</Canvas>
+
 ## Props & Slots
 
 <Controls />

--- a/components/tooltip/tooltip.stories.js
+++ b/components/tooltip/tooltip.stories.js
@@ -3,6 +3,7 @@ import DtTooltip from './tooltip.vue';
 import DtTooltipFlipTemplate from './tooltip_flip.story.vue';
 import DtTooltipDefault from './tooltip_default.story.vue';
 import DtTooltipVariantsTemplate from './tooltip_variants.vue';
+import DtTooltipChangeOnClick from './tooltip_change_on_click.story.vue';
 import { action } from '@storybook/addon-actions';
 
 import { TOOLTIP_DIRECTIONS, TOOLTIP_STICKY_VALUES } from './tooltip_constants';
@@ -123,6 +124,8 @@ const TooltipDefaultTemplate = (args, { argTypes }) =>
   createTemplateFromVueFile(args, argTypes, DtTooltipDefault);
 const TooltipVariantsTemplate = (args, { argTypes }) =>
   createTemplateFromVueFile(args, argTypes, DtTooltipVariantsTemplate);
+const TooltipChangeOnClick = (args, { argTypes }) =>
+  createTemplateFromVueFile(args, argTypes, DtTooltipChangeOnClick);
 
 export const Default = {
   render: TooltipDefaultTemplate,
@@ -148,5 +151,13 @@ export const Flip = {
   parameters: {
     options: { showPanel: false },
     controls: { disable: true },
+  },
+};
+
+export const ChangeOnClick = {
+  render: TooltipChangeOnClick,
+  args: {
+    anchor: 'Click to see the tooltip content change',
+    sticky: 'popper',
   },
 };

--- a/components/tooltip/tooltip_change_on_click.story.vue
+++ b/components/tooltip/tooltip_change_on_click.story.vue
@@ -1,0 +1,78 @@
+<!-- eslint-disable vue/no-deprecated-v-bind-sync -->
+<template>
+  <div
+    :class="[
+      'd-fl-center d-fd-column d-pt64',
+      {
+        'd-bgc-purple-600 d-pb64': $attrs.inverted,
+      },
+    ]"
+  >
+    <div class="d-pt16">
+      <dt-tooltip
+        :id="$attrs.id"
+        :placement="$attrs.placement"
+        :inverted="$attrs.inverted"
+        :message="$attrs.message"
+        :fallback-placements="$attrs.fallbackPlacements"
+        :offset="$attrs.offset"
+        :sticky="$attrs.sticky"
+        :content-class="$attrs.contentClass"
+        :content-appear="$attrs.contentAppear"
+        :transition="$attrs.transition"
+        :show.sync="$attrs.show"
+        :enabled="$attrs.enabled"
+        :delay="$attrs.delay"
+        :external-anchor="$attrs.externalAnchor"
+        v-bind="$attrs"
+        @shown="$attrs.onShown"
+      >
+        <template #anchor>
+          <dt-button
+            importance="outlined"
+            :kind="buttonKind"
+            @click="handleClick"
+          >
+            {{ $attrs.anchor }}
+          </dt-button>
+        </template>
+        {{ isButtonActive ? 'Remove from starred' : 'Add to starred' }}
+      </dt-tooltip>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+import DtTooltip from './tooltip.vue';
+import { DtButton } from '../button';
+const buttonActive = ref(false);
+export default {
+  name: 'TooltipDefault',
+  components: {
+    DtTooltip,
+    DtButton,
+  },
+
+  inheritAttrs: false,
+  computed: {
+    buttonKind () {
+      return this.$attrs.inverted ? 'inverted' : 'default';
+    },
+
+    showTooltip () {
+      return this.$attrs.globalShow ?? this.$attrs.show;
+    },
+
+    isButtonActive () {
+      return buttonActive.value;
+    },
+  },
+
+  methods: {
+    handleClick () {
+      buttonActive.value = !buttonActive.value;
+    },
+  },
+};
+</script>

--- a/percy.config.cjs
+++ b/percy.config.cjs
@@ -38,6 +38,7 @@ module.exports = {
       'Components/Toggle: Default',
       'Components/Tooltip: Default',
       'Components/Tooltip: Flip',
+      'Components/Tooltip: Change On Click',
       'Components/Validation Messages: Default',
       'Recipes/Buttons/Callbar Button: Default',
       'Recipes/Buttons/Callbar Button: Callbar',
@@ -54,7 +55,7 @@ module.exports = {
       'Recipes/List Items/Contact Info: Default',
       'Recipes/Notices/Top Banner Info: Default',
       'Utilities/Lazy Show',
-      'Visual Testing/'
+      'Visual Testing/',
     ],
   },
   snapshot: {


### PR DESCRIPTION
# docs(tooltip): add sticky popper variation

Jira ticket: https://dialpad.atlassian.net/browse/DLT-1292

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [ ] Fix
- [ ] Feature
- [ ] Refactoring
- [x] Documentation

## :book: Description
The user had an issue when clicking the "star" button, where the tooltip would not dynamically update its position when the content changed. This was already supported but it was not clear in the documentation. The way to allow this is adding the property `sticky: "popper"`, as per [tippy documentation](https://atomiks.github.io/tippyjs/v6/all-props/#sticky).
<!--- Describe the changes -->


<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [ ] I have added tests
- [x] I have added all relevant documentation
- [ ] I have validated components with a screen reader
- [ ] I have validated components keyboard navigation
- [x] I have considered the performance impact of my change
- [ ] I have checked that my change did not significantly increase bundle size
- [ ] I am exporting any new components or constants in the index.js in the component directory
- [ ] I am exporting any new components or constants in the index.js in the root


<!--- Describe any future changes that need to be made after merging the PR -->

## :camera: Screenshots / GIFs

![tooltip-changes](https://github.com/dialpad/dialtone-vue/assets/24460973/c8496954-c223-4d3d-b82c-64ad7e2f902a)


<!--- Mandatory for any UI work -->
<!--- Link any screenshots / GIFs below -->


<!--- Add any links to external reference material -->
