### PR TITLE
fix: enter event stop propagation on suggestion list

### DIFF
--- a/components/rich_text_editor/extensions/suggestion/SuggestionList.vue
+++ b/components/rich_text_editor/extensions/suggestion/SuggestionList.vue
@@ -82,6 +82,7 @@ export default {
 
       if (event.key === 'Enter') {
         this.enterHandler();
+        event.stopPropagation();
         return true;
       }
 


### PR DESCRIPTION
# fix: enter event stop propagation on suggestion list

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

Enter key is submitting the message when a suggestion is picked. hence use event stop propagation at this child component.