### PR TITLE
fix: updates necessary for feed-item-row product implementation

### DIFF
--- a/components/emoji_text_wrapper/emoji_text_wrapper.vue
+++ b/components/emoji_text_wrapper/emoji_text_wrapper.vue
@@ -56,7 +56,7 @@ export default {
       return split.map((item) => {
         if (replaceList.includes(item)) {
           return this.$createElement(DtEmoji, {
-            attrs: { class: 'd-mx4 d-d-inline-block' },
+            attrs: { class: 'd-d-inline-block' },
             props: { code: item, size: this.size, ...this.$attrs },
           });
         }

--- a/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -4,7 +4,6 @@
       v-for="reaction in reactions"
       :key="reaction.unicodeOutput"
       :reaction="reaction"
-      class="d-mr4 d-mb4"
     >
       <dt-tooltip
         class="d-d-inline-block"
@@ -39,6 +38,8 @@
         </template>
       </dt-tooltip>
     </span>
+    <!-- @slot Slot for emoji picker component, including the anchor. -->
+    <slot name="picker" />
   </span>
 </template>
 
@@ -97,12 +98,13 @@ export default {
 .dt-emoji-row {
   display: flex;
   flex-wrap: wrap;
+  gap: var(--dt-space-300);
 
   &__reaction {
     padding: var(--dt-space-300) var(--dt-space-400); // 4px 8px
     gap: var(--dt-space-300);
     border-radius: var(--dt-size-radius-500);
-    margin-bottom: 0;
+    border-width: var(--dt-size-border-100);
     transition-delay: 0s;
     transition-duration: var(--td50);
     transition-property: all;
@@ -111,12 +113,17 @@ export default {
     color: var(--dt-color-foreground-secondary);
     background-color: var(--dt-color-surface-moderate-opaque);
 
-    &:hover, &:focus{
+    &.dt-emoji-row__picker {
+      padding: var(--dt-space-200) var(--dt-space-350); // 2px 6px
+    }
+
+    &:hover, &:focus-visible {
       border-color: hsla(var(--dt-color-black-600-hsl)/100%)!important;
     }
 
     &--selected {
       color: var(--dt-color-link-primary);
+      border-width: var(--dt-size-border-150);
       background-color: var(--dt-color-purple-100) !important;
       border-color: var(--dt-color-brand-purple) !important;
       &:hover {
@@ -124,5 +131,6 @@ export default {
       }
     }
   }
+
 }
 </style>

--- a/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -58,14 +58,16 @@
 
     <template #bottom>
       <div
-        class="d-d-flex d-fw-wrap"
+        class="dt-feed-item-row__reactions"
         data-qa="dt-feed-item-row--reactions"
       >
         <!-- @slot Slot for reactions row component -->
         <slot name="reactions" />
       </div>
-      <!-- @slot Slot for threading row component -->
-      <slot name="threading" />
+      <div class="dt-feed-item-row__threading">
+        <!-- @slot Slot for threading row component -->
+        <slot name="threading" />
+      </div>
     </template>
 
     <!-- Action menu -->
@@ -262,8 +264,24 @@ export default {
 </script>
 
 <style lang="less" scoped>
+.dt-feed-item-row :deep(.dt-item-layout--left) {
+  align-self: baseline;
+}
+
 .dt-feed-item-row {
   transition-duration: 2s !important;
+
+  &__reactions {
+    padding-top: var(--dt-space-200);
+    padding-bottom: var(--dt-space-200);
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  &__threading {
+    padding-top: var(--dt-space-200);
+    padding-bottom: var(--dt-space-200);
+  }
 
   &__left-time {
     color: var(--dt-color-foreground-tertiary);

--- a/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -93,6 +93,7 @@ import { DEFAULT_FEED_ROW_STATE, FEED_ROW_STATE_BACKGROUND_COLOR } from './feed_
 import { DtAvatar } from '@/components/avatar';
 import { DtLazyShow } from '@/components/lazy_show';
 import { DtListItem } from '@/components/list_item';
+import Modal from '../../../common/mixins/modal';
 
 export default {
   name: 'DtRecipeFeedItemRow',
@@ -102,6 +103,8 @@ export default {
     DtLazyShow,
     DtListItem,
   },
+
+  mixins: [Modal],
 
   inheritAttrs: false,
 
@@ -206,6 +209,14 @@ export default {
         mouseleave: () => this.setHover(false),
         focusin: () => this.setFocus(true),
         focusout: () => this.setFocus(false),
+        keydown: event => {
+          switch (event.code) {
+            case 'Tab':
+              this.trapFocus(event);
+              break;
+          }
+          this.$emit('keydown', event);
+        },
       };
     },
 
@@ -214,7 +225,7 @@ export default {
         'd-w100p',
         'd-box-border',
         'd-ps-relative',
-        'd-px8',
+        'd-px16',
         { 'd-bgc-secondary-opaque': this.isActive && this.state === DEFAULT_FEED_ROW_STATE },
         FEED_ROW_STATE_BACKGROUND_COLOR[this.state],
         'dt-feed-item-row',
@@ -225,6 +236,10 @@ export default {
   },
 
   methods: {
+    trapFocus (e) {
+      this.focusTrappedTabPress(e);
+    },
+
     setFocus (bool) {
       this.$emit('focus', bool);
     },
@@ -252,7 +267,6 @@ export default {
 
   &__left-time {
     color: var(--dt-color-foreground-tertiary);
-    padding-top: var(--dt-space-350);
     line-height: var(--dt-font-line-height-400);
     font-size: var(--dt-font-size-100);
     font-weight: var(--dt-font-weight-normal);

--- a/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
+++ b/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
@@ -59,7 +59,23 @@
       >
         <dt-recipe-emoji-row
           :reactions="mockReactions"
-        />
+        >
+          <template #picker>
+            <dt-button
+              importance="clear"
+              size="sm"
+              data-qa="feed-item-reaction-button"
+              class="dt-emoji-row__reaction dt-emoji-row__picker"
+            >
+              <span class="d-d-inline-flex">
+                <dt-icon
+                  size="300"
+                  name="satisfied"
+                />
+              </span>
+            </dt-button>
+          </template>
+        </dt-recipe-emoji-row>
       </template>
       <template #menu>
         <!-- TODO replace this with DT menu -->

--- a/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
+++ b/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
@@ -172,7 +172,8 @@ export default {
       }
     }
     &__thread{
-      height: 32px;
+      padding-top: .3rem;
+      padding-bottom: .3rem;
     }
     &__reply{
       color: var(--dt-color-foreground-tertiary);

--- a/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
+++ b/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
@@ -64,6 +64,7 @@
             <dt-button
               importance="clear"
               size="sm"
+              aria-label="Add reaction"
               data-qa="feed-item-reaction-button"
               class="dt-emoji-row__reaction dt-emoji-row__picker"
             >


### PR DESCRIPTION
# fix: updates necessary for feed-item-row product implementation

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` in all of the checkboxes that apply -->

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## :book: Description

- Remove margin from emoji-text-wrapper it is unnecessary and causes lots of spacing issues.
- Add a slot for the emoji picker, since it is not built into the component itself it is very hard to align the anchor correctly without this.
- A few styling changes to better match the designs.
- Trap focus within the feed-item-row. For keyboard navigation purposes the arrow keys will change the selected item and tabbing will tab through the interactive controls within each item. Tabbing to the end should loop around to the first item again rather than going to the next item.

## :bulb: Context

Couple changes that were needed within dialtone-vue when implementing feed-item-row in product

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

- [x] I have reviewed my changes
- [x] I have added all relevant documentation
- [x] I have validated components keyboard navigation

## :crystal_ball: Next Steps

Update in firespotter and release private beta for design review.

Might be some more changes to make later but these are most essential for now.
